### PR TITLE
OUT_OF_BOUNDS datacheck; datacheck.log header row

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2240,7 +2240,8 @@ lines.pop(0)  # ignore header line
 datacheckfps = []
 datacheck_always_error = [ 'DUPLICATE_LABEL', 'HIDDEN_TERMINUS',
                            'LABEL_INVALID_CHAR', 'LABEL_SLASHES',
-                           'LONG_UNDERSCORE', 'NONTERMINAL_UNDERSCORE' ]
+                           'LONG_UNDERSCORE', 'NONTERMINAL_UNDERSCORE',
+                           'OUT_OF_BOUNDS' ]
 for line in lines:
     fields = line.rstrip('\n').split(';')
     if len(fields) != 6:
@@ -2295,6 +2296,14 @@ for h in highway_systems:
                     datacheckerrors.append(DatacheckEntry(r,labels,"DUPLICATE_LABEL"))
                 else:
                     all_route_labels.add(lower_label)
+
+            # out-of-bounds coords
+            if w.lat > 90 or w.lat < -90 or w.lng > 180 or w.lng < -180:
+                labels = []
+                labels.append(w.label)
+                datacheckerrors.append(DatacheckEntry(r,labels,'OUT_OF_BOUNDS',
+                                                      "("+str(w.lat)+","+str(w.lng)+")"))
+
             # duplicate coordinates
             latlng = w.lat, w.lng
             if latlng in coords_used:
@@ -3204,6 +3213,7 @@ logfile = open(args.logfilepath + '/datacheck.log', 'w')
 logfile.write("Log file created at: " + str(datetime.datetime.now()) + "\n")
 logfile.write("Datacheck errors that have been flagged as false positives are not included.\n")
 logfile.write("These entries should be in a format ready to paste into datacheckfps.csv.\n")
+logfile.write("Root;Waypoint1;Waypoint2;Waypoint3;Error;Info\n")
 if len(datacheckerrors) > 0:
     for d in datacheckerrors:
         if not d.fp:


### PR DESCRIPTION
**OUT_OF_BOUNDS datacheck**
Checks for latitude > 90 or < -90 or longitude > 180 or < -180
[Google coped](http://tm.teresco.org/hb/index.php?units=miles&u=&r=mt.sr320) with these cases OK, but [Leaflet doesn't like them](http://tml.teresco.org/hb/index.php?units=miles&u=&r=mt.sr320).
[forum thread with discussion](http://tm.teresco.org/forum/index.php?topic=2453)
[forum thread without discussion](http://tm.teresco.org/forum/index.php?topic=2452)

Of course, it would be possible to detect these cases and correct them while loading the waypoint objects from disk. For example, this is what I'm planning for a future commit to [yakra/tmtools](https://github.com/yakra/tmtools/):
```C++
// Yes, this is C++, not Python. Sorry...

void waypoint::InitCoords()
{	// parse URL
	size_t latBeg = URL.find("lat=")+4;	if (latBeg == 3) latBeg = URL.size();
	size_t lonBeg = URL.find("lon=")+4;	if (lonBeg == 3) lonBeg = URL.size();
	Lat = strtod(&URL[latBeg], 0);
	Lon = strtod(&URL[lonBeg], 0);
	// check for out-of-bounds coords
	if (Lat > 90)
	{	std::cout << "Warning: latitude > 90 in " << hwy->Root << " @ " << label[0] << "\n";
		std::cout << to_string(Lat) << " converted to ";
		while (Lat > 360)	Lat -= 360;
		if (Lat > 90)		Lat = 180-Lat;
		if (Lat < -90)		Lat = -180-Lat;
		std::cout << to_string(Lat) << '\n';
	}
	if (Lat < -90)
	{	std::cout << "Warning: latitude < -90 in " << hwy->Root << " @ " << label[0] << "\n";
		std::cout << to_string(Lat) << " converted to ";
		while (Lat < -360)	Lat += 360;
		if (Lat < -90)		Lat = -180-Lat;
		if (Lat > 90)		Lat = 180-Lat;
		std::cout << to_string(Lat) << '\n';
	}
	if (Lon > 180)
	{	std::cout << "Warning: longitude > 180 in " << hwy->Root << " @ " << label[0] << "\n";
		std::cout << to_string(Lon) << " converted to ";
		while (Lat > 180)	Lat -= 360;
		std::cout << to_string(Lon) << '\n';
	}
	if (Lon < -180)
	{	std::cout << "Warning: longitude < -180 in " << hwy->Root << " @ " << label[0] << "\n";
		std::cout << to_string(Lon) << " converted to ";
		while (Lat < -180)	Lat += 360;
		std::cout << to_string(Lon) << '\n';
	}
	// ...and some other gisplunge-specific code that's not relevant here
}
```
...I already had the datacheck pretty much done before starting on working this out.
For how exactly this would be done in Python, I've not looked that deeply into the code yet.
There's always the possibility than an out-of-bounds coordinate is just completely rubbish, and the "fixed" coordinate from the above function still isn't the intended location. Fixing these just seems like it'd be *Good Practice*.

---

Along for the ride: this closes #84.