### PR TITLE
delete waypoint_naming_log when done

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2791,6 +2791,7 @@ logfile = open(args.logfilepath + '/waypointsimplification.log', 'w')
 for line in graph_data.waypoint_naming_log:
     logfile.write(line + '\n')
 logfile.close()
+graph_data.waypoint_naming_log = None
 
 # create list of graph information for the DB
 graph_list = []


### PR DESCRIPTION
Gain a small amount of RAM headroom near the end of the process.
About 12-40 MB, ballpark.

---

On a related note, I saw this comment in the HighwayGraphVertexInfo constructor:
https://github.com/TravelMapping/DataProcessing/blob/73107c87e04f2979a6cc9bb03dfd18704deb3b85/siteupdate/python-teresco/siteupdate.py#L1127-L1128
I gave it a try, and siteupdate actually seemed to be using *more* RAM -- 6-19, MB ballpark.
If there is any savings, it's slight, and lost in the noise of whatever else the computer is doing.
Leaving this part of the code alone for now.