### PR TITLE
Sort colocated waypoint lists; close various minor issues

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -672,7 +672,6 @@ class Route:
     def __init__(self,line,system,el):
         """initialize object from a .csv file line, but do not
         yet read in waypoint file"""
-        self.line = line
         fields = line.split(";")
         if len(fields) != 8:
             el.add_error("Could not parse csv line: [" + line +
@@ -800,7 +799,6 @@ class ConnectedRoute:
 
     def __init__(self,line,system,el):
         """initialize the object from the _con.csv line given"""
-        self.line = line
         fields = line.split(";")
         if len(fields) != 5:
             el.add_error("Could not parse _con.csv line: [" + line +

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -77,8 +77,8 @@ class WaypointQuadtree:
         #print("QTDEBUG: " + str(self) + " insert " + str(w))
         if self.points is not None:
             if self.waypoint_at_same_point(w) is None:
+                #print("QTDEBUG: " + str(self) + " at " + str(self.unique_locations) + " unique locations")
                 self.unique_locations += 1
-                #print("QTDEBUG: " + str(self) + " has " + str(self.unique_locations) + " unique locations")
             self.points.append(w)
             if self.unique_locations > 50:  # 50 unique points max per quadtree node
                 self.refine()

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3202,9 +3202,8 @@ for d in datacheckerrors:
             toremove.append(fp)
             break
         if d.match_except_info(fp):
-            fpfile.write("DCERROR: " + str(d) + "\n")
-            fpfile.write("FPENTRY: " + fp[0] + ';' + fp[1] + ';' + fp[2] + ';' + fp[3] + ';' + fp[4] + ';' + fp[5] + '\n')
-            fpfile.write("REPLACEWITH: " + fp[0] + ';' + fp[1] + ';' + fp[2] + ';' + fp[3] + ';' + fp[4] + ';' + d.info + '\n')
+            fpfile.write("FP_ENTRY: " + fp[0] + ';' + fp[1] + ';' + fp[2] + ';' + fp[3] + ';' + fp[4] + ';' + fp[5] + '\n')
+            fpfile.write("CHANGETO: " + fp[0] + ';' + fp[1] + ';' + fp[2] + ';' + fp[3] + ';' + fp[4] + ';' + d.info + '\n')
 
 fpfile.close()
 # now remove the ones we matched from the list

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2053,14 +2053,9 @@ else:
 
 # report any duplicate list names as errors
 if len(duplicate_list_names) > 0:
-    print("Found " + str(len(duplicate_list_names)) + " DUPLICATE_LIST_NAME cases.")
-    num_found = 0
-    for h in highway_systems:
-        for r in h.route_list:
-            if r.region + ' ' + r.list_entry_name() in duplicate_list_names:
-                el.add_error("Duplicate list name: " + r.region + ' ' + r.list_entry_name())
-                num_found += 1
-    print("Added " + str(num_found) + " DUPLICATE_LIST_NAME error entries.")
+    print("Found " + str(len(duplicate_list_names)) + " DUPLICATE_LIST_NAME case(s).")
+    for d in duplicate_list_names:
+        el.add_error("Duplicate list name: " + d)
 else:
     print("No duplicate list names found.")
 

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -927,7 +927,7 @@ class TravelerList:
     start_waypoint end_waypoint
     """
 
-    def __init__(self,travelername,systems,route_hash,path="../../../UserData/list_files"):
+    def __init__(self,travelername,route_hash,path="../../../UserData/list_files"):
         self.list_entries = []
         self.clinched_segments = set()
         self.traveler_name = travelername[:-5]
@@ -2280,7 +2280,7 @@ print(et.et() + "Processing traveler list files:",end="",flush=True)
 for t in traveler_ids:
     if t.endswith('.list'):
         print(" " + t,end="",flush=True)
-        traveler_lists.append(TravelerList(t,highway_systems,route_hash,args.userlistfilepath))
+        traveler_lists.append(TravelerList(t,route_hash,args.userlistfilepath))
 print(" processed " + str(len(traveler_lists)) + " traveler list files.")
 
 # Read updates.csv file, just keep in the fields array for now since we're

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -830,7 +830,7 @@ class ConnectedRoute:
             rootOrder += 1
         if len(self.roots) < 1:
             el.add_error("No roots in _con.csv line [" + line + "]")
-        # will be computed for routes in active systems later
+        # will be computed for routes in active & preview systems later
         self.mileage = 0.0
 
     def csv_line(self):

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -601,8 +601,7 @@ class HighwaySegment:
         self.segment_name = None
 
     def __str__(self):
-        return self.waypoint1.label + " to " + self.waypoint2.label + \
-            " via " + self.route.root
+        return self.route.region + " " + self.route.route + " " + self.waypoint1.label + " " + self.waypoint2.label
 
     def add_clinched_by(self,traveler):
         if traveler not in self.clinched_by:

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -601,7 +601,7 @@ class HighwaySegment:
         self.segment_name = None
 
     def __str__(self):
-        return self.route.region + " " + self.route.route + " " + self.waypoint1.label + " " + self.waypoint2.label
+        return self.route.readable_name() + " " + self.waypoint1.label + " " + self.waypoint2.label
 
     def add_clinched_by(self,traveler):
         if traveler not in self.clinched_by:

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1155,8 +1155,6 @@ class HighwayGraphVertexInfo:
                     hid_list.append(w)
                 else:
                     vis_list.append(w)
-            vis_list.sort(key=lambda waypoint: waypoint.route.root + "@" + waypoint.label)
-            hid_list.sort(key=lambda waypoint: waypoint.route.root + "@" + waypoint.label)
             datacheckerrors.append(DatacheckEntry(vis_list[0].route,[vis_list[0].label],"VISIBLE_HIDDEN_COLOC",
                                                   hid_list[0].route.root+"@"+hid_list[0].label))
 
@@ -1589,8 +1587,9 @@ class HighwayGraph:
                     vinfo.is_hidden = False
                     continue
                 if len(vinfo.incident_collapsed_edges) > 2:
-                    dc_waypoint = sorted(vinfo.first_waypoint.colocated, key=lambda waypoint: waypoint.route.root + "@" + waypoint.label)[0]
-                    datacheckerrors.append(DatacheckEntry(dc_waypoint.route,[dc_waypoint.label],"HIDDEN_JUNCTION",str(len(vinfo.incident_collapsed_edges))))
+                    datacheckerrors.append(DatacheckEntry(vinfo.first_waypoint.colocated[0].route,
+                                           [vinfo.first_waypoint.colocated[0].label],
+                                           "HIDDEN_JUNCTION",str(len(vinfo.incident_collapsed_edges))))
                     vinfo.is_hidden = False
                     continue
                 # construct from vertex_info this time
@@ -2157,6 +2156,11 @@ for t in thread_list:
 
 print(et.et() + "Sorting waypoints in Quadtree.")
 all_waypoints.sort()
+
+print(et.et() + "Sorting colocated point lists.")
+for w in all_waypoints.point_list():
+    if w.colocated is not None:
+        w.colocated.sort(key=lambda waypoint: waypoint.route.root + "@" + waypoint.label)
 
 print(et.et() + "Finding unprocessed wpt files.", flush=True)
 unprocessedfile = open(args.logfilepath+'/unprocessedwpts.log','w',encoding='utf-8')

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2025,12 +2025,12 @@ for h in highway_systems:
             
 con_roots = set()
 for h in highway_systems:
-    for r in h.con_route_list:
-        for cr in r.roots:
-            if cr.root in con_roots:
-                el.add_error("Duplicate root in con_route lists: " + cr.root)
+    for cr in h.con_route_list:
+        for r in cr.roots:
+            if r.root in con_roots:
+                el.add_error("Duplicate root in con_route lists: " + r.root)
             else:
-                con_roots.add(cr.root)
+                con_roots.add(r.root)
 
 # Make sure every route was listed as a part of some connected route
 if len(roots) == len(con_roots):


### PR DESCRIPTION
* Canonical Waypoint Names are deterministic now. I've not yet looked into how DIFFable graph files are.
* Deterministic **waypointsimplification.log**.
* **concurrencies.log:**
Deterministic concurrency detection portion. I've not yet addressed the per-traveler augments.
* ~**highwaydatastats.log:**
I didn't set out to make this deterministic, but 10 single-threaded trials & 10 multi-threaded trials have no DIFFs other than the initial `Travel Mapping highway mileage as of ...` line. OK! :)~

This allows me to simplify the code for my earlier modifications to the VISIBLE_HIDDEN_COLOC and HIDDEN_JUNCTION datachecks.

Takes 1.6-1.7 seconds on my machine. Will be a little faster on Noreaster.
I think DIFFs are worthwhile. :)