### PR TITLE
Strip `+` from .list labels

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2891,7 +2891,7 @@ else:
                         'These graphs contain all routes currently plotted in the Travel Mapping project.'])
 
     # graphs restricted by place/area - from areagraphs.csv file
-    print(et.et() + "\nCreating area data graphs.", flush=True)
+    print("\n" + et.et() + "Creating area data graphs.", flush=True)
     with open(args.highwaydatapath+"/graphs/areagraphs.csv", "rt",encoding='utf-8') as file:
         lines = file.readlines()
     lines.pop(0);  # ignore header line

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1042,8 +1042,8 @@ class TravelerList:
                 checking_index = 0;
                 for w in r.point_list:
                     lower_label = w.label.lower().strip("+*")
-                    list_label_1 = fields[2].lower().strip("*")
-                    list_label_2 = fields[3].lower().strip("*")
+                    list_label_1 = fields[2].lower().strip("+*")
+                    list_label_2 = fields[3].lower().strip("+*")
                     if list_label_1 == lower_label or list_label_2 == lower_label:
                         canonical_waypoints.append(w)
                         canonical_waypoint_indices.append(checking_index)


### PR DESCRIPTION
http://travelmapping.net/logs/unusedaltlabels.log :
`tn.i069futmem(1): 0`

http://travelmapping.net/logs/pointsinuse.log :
`tn.i069futmem(18): 1E(40) 1F(40) 2 2(40) 2A(40) 30(240) 31(240) 32(240) 5B 6 I-240 MS/TN US51`

https://github.com/TravelMapping/UserData/blob/e8b472392b3b376b27978e314df72ff0fe19bc39/list_files/lowenbrau.list#L1411 :
`TN I-69FutMem +0 6`

http://travelmapping.net/logs/users/lowenbrau.log :
`Waypoint label(s) not found in line: TN I-69FutMem +0 6`