### PR TITLE
revised str(DatacheckEntry) based on CSV line

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1171,7 +1171,17 @@ class DatacheckEntry:
         return True
 
     def __str__(self):
-        return self.route.root + ";" + str(self.labels) + ";" + self.code + ";" + self.info
+        entry = str(self.route.root)+";"
+        if len(self.labels) == 0:
+            entry += ";;;"
+        elif len(self.labels) == 1:
+            entry += self.labels[0]+";;;"
+        elif len(self.labels) == 2:
+            entry += self.labels[0]+";"+self.labels[1]+";;"
+        else:
+            entry += self.labels[0]+";"+self.labels[1]+";"+self.labels[2]+";"
+        entry += self.code+";"+self.info
+        return entry
 
 class HighwayGraphVertexInfo:
     """This class encapsulates information needed for a highway graph
@@ -3298,16 +3308,7 @@ logfile.write("Root;Waypoint1;Waypoint2;Waypoint3;Error;Info\n")
 if len(datacheckerrors) > 0:
     for d in datacheckerrors:
         if not d.fp:
-            logfile.write(str(d.route.root)+";")
-            if len(d.labels) == 0:
-                logfile.write(";;;")
-            elif len(d.labels) == 1:
-                logfile.write(d.labels[0]+";;;")
-            elif len(d.labels) == 2:
-                logfile.write(d.labels[0]+";"+d.labels[1]+";;")
-            else:
-                logfile.write(d.labels[0]+";"+d.labels[1]+";"+d.labels[2]+";")
-            logfile.write(d.code+";"+d.info+"\n")
+            logfile.write(str(d)+"\n")
 else:
     logfile.write("No datacheck errors found.")
 logfile.close()


### PR DESCRIPTION
str(DatacheckEntry) is only used when [sorting datacheck entries](https://github.com/TravelMapping/DataProcessing/commit/73107c87e04f2979a6cc9bb03dfd18704deb3b85) before marking false positives.

Before that, it was only used [in nearmatchfps.log](https://github.com/TravelMapping/DataProcessing/commit/12f00bd9ef3378394dff9de74b8e7de10c345932), but was [eliminated as redundant and distracting](https://github.com/TravelMapping/DataProcessing/issues/133).

Sorting asciibetically by the CSV line as we see it is more intuitive than sorting by a "Python list" style string we don't actually see in the log.
This would bring siteupdate.py more in line with the in-dev siteupdate.cpp, and have their datacheck.log files sorted in the same order, for more usable DIFFs.

@jteresco, is there any reason to keep the old "Python list" style str(DatacheckEntry) around?