### PR TITLE
rstrip null zero from .list lines

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1008,7 +1008,7 @@ class TravelerList:
         self.log_entries = []
 
         for line in lines:
-            line = line.strip()
+            line = line.strip().rstrip('\x00')
             # ignore empty or "comment" lines
             if len(line) == 0 or line.startswith("#"):
                 continue


### PR DESCRIPTION
This allows traveler **lowenbrau** to be properly credited for ON405.
As noted in https://github.com/TravelMapping/DataProcessing/issues/41#issuecomment-450941199:
> **Re .list files:**
> https://github.com/TravelMapping/UserData/blob/9ab420d7cc23d79b6d24f224c7186c88ee6ef777/list_files/lowenbrau.list
>
> The final line, `ON ON405 ON/USA PorRd`, is followed by 1486 null `\0`s, before a final CRLF.
>
> We can see that this line is not parsed:
http://travelmapping.net/logs/users/lowenbrau.log
http://travelmapping.net/hb/index.php?units=miles&u=lowenbrau&r=on.on405

This yields the same Python-to-Python diff as the Python-to-C++ diff pasted at https://github.com/TravelMapping/DataProcessing/issues/41#issuecomment-453611692