### PR TITLE
HighwayGraphCollapsedEdgeInfo initial setup

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1256,17 +1256,17 @@ class HighwayGraphEdgeInfo:
         # checks for the very unusual cases where an edge ends up
         # in the system as itself and its "reverse"
         duplicate = False
-        for e in graph.vertices[s.waypoint1.unique_name].incident_edges:
+        for e in self.vertex1.incident_edges:
             if e.vertex1 == self.vertex2 and e.vertex2 == self.vertex1:
                 duplicate = True
 
-        for e in graph.vertices[s.waypoint2.unique_name].incident_edges:
+        for e in self.vertex2.incident_edges:
             if e.vertex1 == self.vertex2 and e.vertex2 == self.vertex1:
                 duplicate = True
 
         if not duplicate:
-            graph.vertices[s.waypoint1.unique_name].incident_edges.append(self)
-            graph.vertices[s.waypoint2.unique_name].incident_edges.append(self)
+            self.vertex1.incident_edges.append(self)
+            self.vertex2.incident_edges.append(self)
 
     # compute an edge label, optionally resticted by systems
     def label(self,systems=None):

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1194,47 +1194,48 @@ class HighwayGraphVertexInfo:
     vertex.
     """
 
-    def __init__(self,waypoint_list,datacheckerrors):
-        self.lat = waypoint_list[0].lat
-        self.lng = waypoint_list[0].lng
-        self.unique_name = waypoint_list[0].unique_name
+    def __init__(self,wpt,unique_name,datacheckerrors):
+        self.lat = wpt.lat
+        self.lng = wpt.lng
+        self.unique_name = unique_name
         # will consider hidden iff all colocated waypoints are hidden
         self.is_hidden = True
-        # note: if saving the first waypoint, no longer need first
-        # three fields and can replace with methods
-        self.first_waypoint = waypoint_list[0]
+        # note: if saving the first waypoint, no longer need
+        # lat & lng and can replace with methods
+        self.first_waypoint = wpt
         self.regions = set()
         self.systems = set()
-        for w in waypoint_list:
+        self.incident_edges = []
+        self.incident_collapsed_edges = []
+        if wpt.colocated is None:
+            if not wpt.is_hidden:
+                self.is_hidden = False
+            self.regions.add(wpt.route.region)
+            self.systems.add(wpt.route.system)
+            return
+        for w in wpt.colocated:
             if not w.is_hidden:
                 self.is_hidden = False
             self.regions.add(w.route.region)
             self.systems.add(w.route.system)
-        self.incident_edges = []
-        self.incident_collapsed_edges = []
         # VISIBLE_HIDDEN_COLOC datacheck
-        if self.visible_hidden_coloc(waypoint_list):
-            # determine which route, label, and info to use for this entry asciibetically
-            vis_list = []
-            hid_list = []
-            for w in waypoint_list:
-                if w.is_hidden:
-                    hid_list.append(w)
-                else:
-                    vis_list.append(w)
-            datacheckerrors.append(DatacheckEntry(vis_list[0].route,[vis_list[0].label],"VISIBLE_HIDDEN_COLOC",
-                                                  hid_list[0].route.root+"@"+hid_list[0].label))
+        for p in range(1, len(wpt.colocated)):
+            if wpt.colocated[p].is_hidden != wpt.colocated[0].is_hidden:
+                # determine which route, label, and info to use for this entry asciibetically
+                vis_list = []
+                hid_list = []
+                for w in wpt.colocated:
+                    if w.is_hidden:
+                        hid_list.append(w)
+                    else:
+                        vis_list.append(w)
+                datacheckerrors.append(DatacheckEntry(vis_list[0].route,[vis_list[0].label],"VISIBLE_HIDDEN_COLOC",
+                                                      hid_list[0].route.root+"@"+hid_list[0].label))
+                break;
 
     # printable string
     def __str__(self):
         return self.unique_name
-
-    @staticmethod
-    def visible_hidden_coloc(waypoint_list):
-        for w in range(1,len(waypoint_list)):
-            if waypoint_list[w].is_hidden != waypoint_list[0].is_hidden:
-                return True
-        return False
 
 class HighwayGraphEdgeInfo:
     """This class encapsulates information needed for a 'standard'
@@ -1505,8 +1506,7 @@ class HighwayGraph:
     """This class implements the capability to create graph
     data structures representing the highway data.
 
-    On construction, build a list (as keys of a dict) of unique
-    waypoint names that can be used as vertex labels in unique_waypoints,
+    On construction, build a set of unique vertex names
     and determine edges, at most one per concurrent segment.
     Create two sets of edges - one for the full graph
     and one for the graph with hidden waypoints compressed into
@@ -1514,15 +1514,10 @@ class HighwayGraph:
     """
 
     def __init__(self, all_waypoints, highway_systems, datacheckerrors):
-        # first, build a list of the unique waypoints and create
-        # unique names that will be our vertex labels, these will
-        # be in a dict where the keys are the unique vertex labels
-        # and the values are lists of Waypoint objects (either a
-        # colocation list or a singleton list for a place occupied
-        # by a single Waypoint)
-        self.unique_waypoints = dict()
+        # first, find unique waypoints and create vertex labels
+        vertex_names = set()
+        self.vertices = {}
         all_waypoint_list = all_waypoints.point_list()
-        self.highway_systems = highway_systems
 
         # add a unique name field to each waypoint, initialized to
         # None, which should get filled in later for any waypoint that
@@ -1535,17 +1530,18 @@ class HighwayGraph:
         # to this list
         self.waypoint_naming_log = []
 
-        # loop again, for each Waypoint, create a unique name and an
-        # entry in the unique_waypoints list, unless it's a point not
-        # in or colocated with any active or preview system
+        # loop for each Waypoint, create a unique name and vertex
+        # unless it's a point not in or colocated with any active
+        # or preview system, or is colocated and not at the front
+        # of its colocation list
         for w in all_waypoint_list:
             # skip if this point is occupied by only waypoints in
             # devel systems
             if not w.is_or_colocated_with_active_or_preview():
                 continue
 
-            # skip if named previously as someone else's colocated point
-            if w.unique_name is not None:
+            # skip if colocated and not at front of list
+            if w.colocated is not None and w != w.colocated[0]:
                 continue
 
             # come up with a unique name that brings in its meaning
@@ -1554,45 +1550,34 @@ class HighwayGraph:
             point_name = w.canonical_waypoint_name(self.waypoint_naming_log)
 
             # if that's taken, append the region code
-            if point_name in self.unique_waypoints:
+            if point_name in vertex_names:
                 point_name += "|" + w.route.region
                 self.waypoint_naming_log.append("Appended region: " + point_name)
 
             # if that's taken, see if the simple name
             # is available
-            if point_name in self.unique_waypoints:
+            if point_name in vertex_names:
                 simple_name = w.simple_waypoint_name()
-                if simple_name not in self.unique_waypoints:
+                if simple_name not in vertex_names:
                     self.waypoint_naming_log.append("Revert to simple: " + simple_name + " from (taken) " + point_name)
                     point_name = simple_name
 
             # if we have not yet succeeded, add !'s until we do
-            while point_name in self.unique_waypoints:
+            while point_name in vertex_names:
                 point_name += "!"
                 self.waypoint_naming_log.append("Appended !: " + point_name)
 
-            # we're good, add the list of waypoints, either as a
-            # singleton list or the colocated list a values for the
-            # key of the unique name we just computed
+            # we're good; now construct a vertex
             if w.colocated is None:
-                self.unique_waypoints[point_name] = [ w ]
-                w.unique_name = point_name
+                self.vertices[w] = HighwayGraphVertexInfo(w, point_name, datacheckerrors)
             else:
-                self.unique_waypoints[point_name] = w.colocated
-                # mark each of these Waypoint objects also with this name
-                for wpt in w.colocated:
-                    wpt.unique_name = point_name
+                self.vertices[w] = HighwayGraphVertexInfo(w.colocated[0], point_name, datacheckerrors)
 
-        # Full graph info now complete.  Next, build a graph structure
-        # that is more convenient to use.
-
-        # One copy of the vertices
-        self.vertices = {}
-        for pointlist in self.unique_waypoints.values():
-            self.vertices[pointlist[0]] = HighwayGraphVertexInfo(pointlist,datacheckerrors)
+        # now that vertices are in place with names, set of unique names is no longer needed
+        vertex_names = None
 
         # add edges, which end up in two separate vertex adjacency lists,
-        for h in self.highway_systems:
+        for h in highway_systems:
             if h.devel():
                 continue
             for r in h.route_list:

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1571,12 +1571,12 @@ class HighwayGraph:
             # key of the unique name we just computed
             if w.colocated is None:
                 self.unique_waypoints[point_name] = [ w ]
+                w.unique_name = point_name
             else:
                 self.unique_waypoints[point_name] = w.colocated
-
-            # mark each of these Waypoint objects also with this name
-            for wpt in self.unique_waypoints[point_name]:
-                wpt.unique_name = point_name
+                # mark each of these Waypoint objects also with this name
+                for wpt in w.colocated:
+                    wpt.unique_name = point_name
 
         # now create graph edges from highway segments start by
         # marking all as unvisited and giving a segment name of None,

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1300,7 +1300,7 @@ class HighwayGraphCollapsedEdgeInfo:
     edge that can incorporate intermediate points.
     """
 
-    def __init__(self,graph,HGEdge=None,vertex_info=None):
+    def __init__(self,HGEdge=None,vertex_info=None):
         if HGEdge is None and vertex_info is None:
             print("ERROR: improper use of HighwayGraphCollapsedEdgeInfo constructor\n")
             return
@@ -1572,7 +1572,7 @@ class HighwayGraph:
                         # and again for a graph where hidden waypoints
                         # are merged into the edge structures
                         if e.vertex1 is not None:
-                            HighwayGraphCollapsedEdgeInfo(self, HGEdge=e)
+                            HighwayGraphCollapsedEdgeInfo(HGEdge=e)
                         else:
                             e = None
 
@@ -1593,7 +1593,7 @@ class HighwayGraph:
                     vinfo.is_hidden = False
                     continue
                 # construct from vertex_info this time
-                HighwayGraphCollapsedEdgeInfo(self, vertex_info=vinfo)
+                HighwayGraphCollapsedEdgeInfo(vertex_info=vinfo)
 
         # print summary info
         print("Edge compressed graph has " + str(self.num_visible_vertices()) +

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -664,7 +664,6 @@ class HighwaySegment:
         self.route = route
         self.concurrent = None
         self.clinched_by = []
-        self.segment_name = None
 
     def __str__(self):
         return self.route.readable_name() + " " + self.waypoint1.label + " " + self.waypoint2.label
@@ -684,19 +683,20 @@ class HighwaySegment:
         """return segment length in miles"""
         return self.waypoint1.distance_to(self.waypoint2)
 
-    def set_segment_name(self):
-        """compute and set a segment name based on names of all
+    def segment_name(self):
+        """compute a segment name based on names of all
         concurrent routes, used for graph edge labels"""
-        self.segment_name = ""
+        segment_name = ""
         if self.concurrent is None:
             if self.route.system.active_or_preview():
-                self.segment_name += self.route.list_entry_name()
+                segment_name += self.route.list_entry_name()
         else:
             for cs in self.concurrent:
                 if cs.route.system.active_or_preview():
-                    if self.segment_name != "":
-                        self.segment_name += ","
-                    self.segment_name += cs.route.list_entry_name()
+                    if segment_name != "":
+                        segment_name += ","
+                    segment_name += cs.route.list_entry_name()
+        return segment_name
 
 class Route:
     """This class encapsulates the contents of one .csv file line
@@ -1238,7 +1238,7 @@ class HighwayGraphEdgeInfo:
     def __init__(self,s,graph):
         # temp debug
         self.written = False
-        self.segment_name = s.segment_name
+        self.segment_name = s.segment_name()
         self.vertex1 = graph.vertices[s.waypoint1.unique_name]
         self.vertex2 = graph.vertices[s.waypoint2.unique_name]
         # assumption: each edge/segment lives within a unique region
@@ -1303,7 +1303,7 @@ class HighwayGraphCollapsedEdgeInfo:
 
         # initial construction is based on a HighwaySegment
         if segment is not None:
-            self.segment_name = segment.segment_name
+            self.segment_name = segment.segment_name()
             self.vertex1 = graph.vertices[segment.waypoint1.unique_name]
             self.vertex2 = graph.vertices[segment.waypoint2.unique_name]
             # assumption: each edge/segment lives within a unique region
@@ -1501,9 +1501,8 @@ class HighwayGraph:
 
     On construction, build a list (as keys of a dict) of unique
     waypoint names that can be used as vertex labels in unique_waypoints,
-    and a determine edges, at most one per concurrent segment, by
-    setting segment names only on certain HighwaySegments in the overall
-    data set.  Create two sets of edges - one for the full graph
+    and determine edges, at most one per concurrent segment.
+    Create two sets of edges - one for the full graph
     and one for the graph with hidden waypoints compressed into
     multi-point edges.
     """
@@ -1578,35 +1577,6 @@ class HighwayGraph:
                 for wpt in w.colocated:
                     wpt.unique_name = point_name
 
-        # now create graph edges from highway segments start by
-        # marking all as unvisited and giving a segment name of None,
-        # so only those segments that are given a name are used later
-        # in the graph edge listing
-        for h in highway_systems:
-            if h.devel():
-                continue
-            for r in h.route_list:
-                for s in r.segment_list:
-                    s.visited = False
-                    s.segment_name = None
-
-        # now go back and visit again, but concurrent segments just
-        # get named once. also count up unique edges as we go
-        self.unique_edges = 0
-        for h in highway_systems:
-            if h.devel():
-                continue
-            for r in h.route_list:
-                for s in r.segment_list:
-                    if not s.visited:
-                        self.unique_edges += 1
-                        s.set_segment_name()
-                        if s.concurrent is None:
-                            s.visited = True
-                        else:
-                            for cs in s.concurrent:
-                                cs.visited = True
-
         # Full graph info now complete.  Next, build a graph structure
         # that is more convenient to use.
 
@@ -1615,30 +1585,21 @@ class HighwayGraph:
         for label, pointlist in self.unique_waypoints.items():
             self.vertices[label] = HighwayGraphVertexInfo(pointlist,datacheckerrors)
 
-        # add edges, which end up in vertex adjacency lists, first one
-        # copy for the full graph
+        # add edges, which end up in two separate vertex adjacency lists,
         for h in self.highway_systems:
             if h.devel():
                 continue
             for r in h.route_list:
                 for s in r.segment_list:
-                    if s.segment_name is not None:
+                    if s.concurrent is None or s == s.concurrent[0]:
+                        # first one copy for the full simple graph
                         HighwayGraphEdgeInfo(s, self)
+                        # and again for a graph where hidden waypoints
+                        # are merged into the edge structures
+                        HighwayGraphCollapsedEdgeInfo(self, segment=s)
 
         print("Full graph has " + str(len(self.vertices)) +
               " vertices, " + str(self.edge_count()) + " edges.")
-
-        # add edges again, which end up in a separate set of vertex
-        # adjacency lists, this one will be used to create a graph
-        # where the hidden waypoints are merged into the edge
-        # structures
-        for h in self.highway_systems:
-            if h.devel():
-                continue
-            for r in h.route_list:
-                for s in r.segment_list:
-                    if s.segment_name is not None:
-                        HighwayGraphCollapsedEdgeInfo(self, segment=s)
 
         # compress edges adjacent to hidden vertices
         for label, vinfo in self.vertices.items():


### PR DESCRIPTION
This branch also contains the commits in #188 & #190.

With the initial HighwayGraphCollapsedEdgeInfo setup based on a HighwaySegment, we end up recomputing a lot of the info we just obtained for the HighwayGraphEdgeInfo based on the same HighwaySegment. If we base initial construction on the corresponding HighwayGraphEdgeInfo instead, we can avoid duplicating this work.
* segment_name is copied from the HighwayGraphEdgeInfo, rather than recomputed from HighwaySegment.segment_name().
* vertex1 & vertex2 are copied from the HighwayGraphEdgeInfo, avoiding looking them up by Waypoint in the hash table.
* "Reverse" duplicate checks are done away with, as we already know the HighwayGraphEdgeInfo to not be a duplicate.
* If a HighwayGraphEdgeInfo is a duplicate, we skip its corresponding HighwayGraphCollapsedEdgeInfo entirely.

Compared to the version in #190, this reduces initial HighwayGraph setup time from ~41.8s to ~38.5s on BiggaTomato.

---

~**ToDo:** The HighwayGraphCollapsedEdgeInfo constructor receives a HighwayGraph object, but doesn't do anything with it. This can be trimmed.~ **Done:** 268485b0d4758496a331528c72ec5645291e21cf