### PR TITLE
master graph vertex & edge count speedup

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -143,49 +143,7 @@ class HighwayGraph
 			}
 		}
 		std::cout << '!' << std::endl;
-
-		// print summary info
-		std::cout << et.et() << "   Simple graph has " << vertices.size() << " vertices, " << simple_edge_count() << " edges." << std::endl;
-		std::cout << et.et() << "Collapsed graph has " << num_collapsed_vertices() << " vertices, " << collapsed_edge_count() << " edges." << std::endl;
-		std::cout << et.et() << " Traveled graph has " << num_traveled_vertices() << " vertices, " << traveled_edge_count() << " edges." << std::endl;
 	} // end ctor
-
-	unsigned int num_collapsed_vertices()
-	{	unsigned int count = 0;
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
-		  if (wv.second->visibility == 2) count ++;
-		return count;
-	}
-
-	unsigned int num_traveled_vertices()
-	{	unsigned int count = 0;
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
-		  if (wv.second->visibility >= 1) count ++;
-		return count;
-	}
-
-	unsigned int simple_edge_count()
-	{	unsigned int edges = 0;
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
-		  edges += wv.second->incident_s_edges.size();
-		return edges/2;
-	}
-
-	unsigned int collapsed_edge_count()
-	{	unsigned int edges = 0;
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
-		  if (wv.second->visibility == 2)
-		    edges += wv.second->incident_c_edges.size();
-		return edges/2;
-	}
-
-	unsigned int traveled_edge_count()
-	{	unsigned int edges = 0;
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
-		  if (wv.second->visibility >= 1)
-		    edges += wv.second->incident_t_edges.size();
-		return edges/2;
-	}
 
 	void clear()
 	{	for (std::pair<const Waypoint*, HGVertex*> wv : vertices) delete wv.second;
@@ -371,19 +329,40 @@ class HighwayGraph
 	{	std::ofstream simplefile(path+"tm-master-simple.tmg");
 		std::ofstream collapfile(path+"tm-master-collapsed.tmg");
 		std::ofstream travelfile(path+"tm-master-traveled.tmg");
-		unsigned int num_collapsed_edges = collapsed_edge_count();
-		unsigned int num_traveled_edges = traveled_edge_count();
-		simplefile << "TMG 1.0 simple\n";
-		collapfile << "TMG 1.0 collapsed\n";
-		travelfile << "TMG 2.0 traveled\n";
-		simplefile << vertices.size() << ' ' << simple_edge_count() << '\n';
-		collapfile << num_collapsed_vertices() << ' ' << num_collapsed_edges << '\n';
-		travelfile << num_traveled_vertices() << ' ' << num_traveled_edges << ' ' << traveler_lists.size() << '\n';
-
-		// write vertices
 		unsigned int sv = 0;
 		unsigned int cv = 0;
 		unsigned int tv = 0;
+		unsigned int se = 0;
+		unsigned int ce = 0;
+		unsigned int te = 0;
+
+		// count vertices & edges
+		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
+		{	se += wv.second->incident_s_edges.size();
+			if (wv.second->visibility >= 1)
+			{	tv++;
+				te += wv.second->incident_t_edges.size();
+				if (wv.second->visibility == 2)
+				{	cv++;
+					ce += wv.second->incident_c_edges.size();
+				}
+			}
+		}
+		se /= 2;
+		ce /= 2;
+		te /= 2;
+
+		// write graph headers
+		simplefile << "TMG 1.0 simple\n";
+		collapfile << "TMG 1.0 collapsed\n";
+		travelfile << "TMG 2.0 traveled\n";
+		simplefile << vertices.size() << ' ' << se << '\n';
+		collapfile << cv << ' ' << ce << '\n';
+		travelfile << tv << ' ' << te << ' ' << traveler_lists.size() << '\n';
+
+		// write vertices
+		cv = 0;
+		tv = 0;
 		for (std::pair<Waypoint* const, HGVertex*> wv : vertices)
 		{	char fstr[57];
 			sprintf(fstr, " %.15g %.15g", wv.second->lat, wv.second->lng);
@@ -439,14 +418,19 @@ class HighwayGraph
 		travelfile.close();
 
 		graph_vector[0].vertices = vertices.size();
-		graph_vector[1].vertices = num_collapsed_vertices();
-		graph_vector[2].vertices = num_traveled_vertices();
-		graph_vector[0].edges = simple_edge_count();
-		graph_vector[1].edges = num_collapsed_edges;
-		graph_vector[2].edges = num_traveled_edges;
+		graph_vector[1].vertices = cv;
+		graph_vector[2].vertices = tv;
+		graph_vector[0].edges = se;
+		graph_vector[1].edges = ce;
+		graph_vector[2].edges = te;
 		graph_vector[0].travelers = 0;
 		graph_vector[1].travelers = 0;
 		graph_vector[2].travelers = traveler_lists.size();
+
+		// print summary info
+		std::cout << "   Simple graph has " << vertices.size() << " vertices, " << se << " edges." << std::endl;
+		std::cout << "Collapsed graph has " << cv << " vertices, " << ce << " edges." << std::endl;
+		std::cout << " Traveled graph has " << tv << " vertices, " << te << " edges." << std::endl;//*/
 	}
 
 	// write a subset of the data,

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1730,48 +1730,6 @@ class HighwayGraph:
                         HGEdge(vertex=v, fmt_mask=1)
                         HGEdge(vertex=v, fmt_mask=2)
 
-        # print summary info
-        print("!\n" + et.et() + "   Simple graph has " + str(len(self.vertices)) +
-              " vertices, " + str(self.simple_edge_count()) + " edges.")
-        print(et.et() + "Collapsed graph has " + str(self.num_collapsed_vertices()) +
-              " vertices, " + str(self.collapsed_edge_count()) + " edges.")
-        print(et.et() + " Traveled graph has " + str(self.num_traveled_vertices()) +
-              " vertices, " + str(self.traveled_edge_count()) + " edges.")
-
-    def num_collapsed_vertices(self):
-        count = 0
-        for v in self.vertices.values():
-            if v.visibility == 2:
-                count += 1
-        return count
-
-    def num_traveled_vertices(self):
-        count = 0
-        for v in self.vertices.values():
-            if v.visibility >= 1:
-                count += 1
-        return count
-
-    def simple_edge_count(self):
-        edges = 0
-        for v in self.vertices.values():
-            edges += len(v.incident_s_edges)
-        return edges//2
-
-    def collapsed_edge_count(self):
-        edges = 0
-        for v in self.vertices.values():
-            if v.visibility == 2:
-                edges += len(v.incident_c_edges)
-        return edges//2
-
-    def traveled_edge_count(self):
-        edges = 0
-        for v in self.vertices.values():
-            if v.visibility >= 1:
-                edges += len(v.incident_t_edges)
-        return edges//2
-
     def matching_vertices(self, regions, systems, placeradius, rg_vset_hash, qt):
         # return a tuple containing
         # 1st, a set of vertices from the graph, optionally
@@ -1893,14 +1851,32 @@ class HighwayGraph:
         simplefile = open(path+"tm-master-simple.tmg","w",encoding='utf-8')
         collapfile = open(path+"tm-master-collapsed.tmg","w",encoding='utf-8')
         travelfile = open(path+"tm-master-traveled.tmg","w",encoding='utf-8')
-        num_collapsed_edges = self.collapsed_edge_count()
-        num_traveled_edges = self.traveled_edge_count()
+        cv = 0
+        tv = 0
+        se = 0
+        ce = 0
+        te = 0
+
+        # count vertices & edges
+        for v in self.vertices.values():
+            se += len(v.incident_s_edges)
+            if v.visibility >= 1:
+                tv += 1
+                te += len(v.incident_t_edges)
+                if v.visibility == 2:
+                    cv += 1
+                    ce += len(v.incident_c_edges)
+        se //= 2;
+        ce //= 2;
+        te //= 2;
+
+        # write graph headers
         simplefile.write("TMG 1.0 simple\n")
         collapfile.write("TMG 1.0 collapsed\n")
         travelfile.write("TMG 2.0 traveled\n")
-        simplefile.write(str(len(self.vertices)) + ' ' + str(self.simple_edge_count()) + '\n')
-        collapfile.write(str(self.num_collapsed_vertices()) + ' ' + str(num_collapsed_edges) + '\n')
-        travelfile.write(str(self.num_traveled_vertices()) + ' ' + str(num_traveled_edges) + ' ' + str(len(traveler_lists)) + '\n')
+        simplefile.write(str(len(self.vertices)) + ' ' + str(se) + '\n')
+        collapfile.write(str(cv) + ' ' + str(ce) + '\n')
+        travelfile.write(str(tv) + ' ' + str(te) + ' ' + str(len(traveler_lists)) + '\n')
 
         # write vertices
         sv = 0
@@ -1948,9 +1924,16 @@ class HighwayGraph:
         simplefile.close()
         collapfile.close()
         travelfile.close()
-        graph_list.append(GraphListEntry('tm-master-simple.tmg', 'All Travel Mapping Data', sv, self.simple_edge_count(), 0, 'simple', 'master'))
-        graph_list.append(GraphListEntry('tm-master-collapsed.tmg', 'All Travel Mapping Data', cv, self.collapsed_edge_count(), 0, 'collapsed', 'master'))
-        graph_list.append(GraphListEntry('tm-master-traveled.tmg', 'All Travel Mapping Data', tv, self.traveled_edge_count(), len(traveler_lists), 'traveled', 'master'))
+        graph_list.append(GraphListEntry('tm-master-simple.tmg', 'All Travel Mapping Data', sv, se, 0, 'simple', 'master'))
+        graph_list.append(GraphListEntry('tm-master-collapsed.tmg', 'All Travel Mapping Data', cv, ce, 0, 'collapsed', 'master'))
+        graph_list.append(GraphListEntry('tm-master-traveled.tmg', 'All Travel Mapping Data', tv, te, len(traveler_lists), 'traveled', 'master'))
+        # print summary info
+        print("   Simple graph has " + str(len(self.vertices)) +
+              " vertices, " + str(se) + " edges.")
+        print("Collapsed graph has " + str(cv) +
+              " vertices, " + str(ce) + " edges.")
+        print(" Traveled graph has " + str(tv) +
+              " vertices, " + str(te) + " edges.")
 
     # write a subset of the data,
     # in simple, collapsed and traveled formats,
@@ -3027,7 +3010,7 @@ if len(el.error_list) > 0:
 print(et.et() + "Setting up for graphs of highway data.", flush=True)
 graph_data = HighwayGraph(all_waypoints, highway_systems, datacheckerrors, et)
 
-print(et.et() + "Writing graph waypoint simplification log.", flush=True)
+print(et.et() + "!\nWriting graph waypoint simplification log.", flush=True)
 logfile = open(args.logfilepath + '/waypointsimplification.log', 'w')
 for line in graph_data.waypoint_naming_log:
     logfile.write(line + '\n')


### PR DESCRIPTION
Closes #200.
* Combined & tidied up some redundant calls to several functions that collectively did a bunch of redundant iterating through the HighwayGraph vertices.
  - **Python:** 25.6 -> 23.9 s, a 7.1% speedup
  - **C++:** 7.8 -> 6.8 s, a 14.7% speedup
* Moved the summary info printout of # of vertices & edges for each graph from before to after writing master graphs, to save either still computing it twice or needlessly passing a handful of extra variables to `write_master_graphs_tmg`. If we count this toward our master graph time savings:
  - **Python:** 26.5 -> 23.9 s, a 10.9% speedup
  - **C++:** 8.5 -> 6.8 s, a 25% speedup.