### PR TITLE
ev_combine

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -35,17 +35,13 @@ HGEdge::HGEdge(HighwaySegment *s, HighwayGraph *graph)
 	// and a 'multi-edge' would not be able to span regions as there
 	// would be a required visible waypoint at the border
 	segment = s;
-	s->route->region->edges.insert(this);
 	// a list of route name/system pairs
 	if (!s->concurrent)
-	{	route_names_and_systems.emplace_back(s->route->list_entry_name(), s->route->system);
-		s->route->system->edges.insert(this);
-	}
-	else	for (HighwaySegment *cs : *(s->concurrent))
-		{	if (cs->route->system->devel()) continue;
-			route_names_and_systems.emplace_back(cs->route->list_entry_name(), cs->route->system);
-			cs->route->system->edges.insert(this);
-		}
+		route_names_and_systems.emplace_back(s->route->list_entry_name(), s->route->system);
+	else for (HighwaySegment *cs : *(s->concurrent))
+	     {	if (cs->route->system->devel()) continue;
+		route_names_and_systems.emplace_back(cs->route->list_entry_name(), cs->route->system);
+	     }
 }
 
 HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask)
@@ -205,13 +201,7 @@ std::string HGEdge::label(std::list<HighwaySystem*> *systems)
 {	std::string the_label;
 	for (std::pair<std::string, HighwaySystem*> &ns : route_names_and_systems)
 	{	// test whether system in systems
-		bool sys_in_sys = 0;
-		if (systems) for (HighwaySystem *h : *systems)
-		  if (h == ns.second)
-		  {	sys_in_sys = 1;
-			break;
-		  }
-		if (!systems || sys_in_sys)
+		if (!systems || list_contains(systems, ns.second))
 		  if (the_label.empty())
 			the_label = ns.first;
 		  else	the_label += "," + ns.first;

--- a/siteupdate/cplusplus/classes/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem.cpp
@@ -28,7 +28,6 @@ class HighwaySystem
 	std::list<ConnectedRoute> con_route_list;
 	std::unordered_map<Region*, double> mileage_by_region;
 	std::unordered_set<HGVertex*> vertices;
-	std::unordered_set<HGEdge*> edges;
 
 	HighwaySystem(std::string &line, ErrorList &el, std::string path, std::string &systemsfile,
 		      std::list<std::pair<std::string,std::string>> &countries,

--- a/siteupdate/cplusplus/classes/Region.cpp
+++ b/siteupdate/cplusplus/classes/Region.cpp
@@ -41,7 +41,6 @@ class Region
 	double overall_mileage;
 	std::mutex *ao_mi_mtx, *ap_mi_mtx, *ov_mi_mtx;
 	std::unordered_set<HGVertex*> vertices;
-	std::unordered_set<HGEdge*> edges;
 
 	Region (std::string &line,
 		std::list<std::pair<std::string, std::string>> &countries,

--- a/siteupdate/cplusplus/functions/list_contains.cpp
+++ b/siteupdate/cplusplus/functions/list_contains.cpp
@@ -1,0 +1,7 @@
+template <class item>
+inline bool list_contains(const std::list<item> *haystack, const item &needle)
+{	for (const item &i : *haystack)
+	  if (i == needle)
+	    return 1;
+	return 0;
+}

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -50,6 +50,7 @@ class HGEdge;
 #include "functions/double_quotes.cpp"
 #include "functions/crawl_hwy_data.cpp"
 #include "functions/operators.cpp"
+#include "functions/list_contains.cpp"
 #include "classes/Arguments.cpp"
 #include "classes/WaypointQuadtree/WaypointQuadtree.h"
 #include "classes/Route/Route.h"


### PR DESCRIPTION
Tidied up subgraph-generation code by matching all vertices and simple, collapsed & traveled edges in a single function, yielding a very small speedup. Closes #233.

**Python:** Saves ~4s on BiggaTomato. We're down 23 lines of code.
**C++:** Saves only ~1s, with more substantial code-cleanup benefits here; we're down 76 total lines across several files. In the process, we save some RAM by getting rid of the underwhelming per-Region & per-HighwaySystem edge sets from #187, no worse for wear performance-wise.