### PR TITLE
sort unusedaltlabels.log lines

### DIFF
--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -561,21 +561,25 @@ int main(int argc, char *argv[])
 
 	// write log file for alt labels not in use
 	cout << et.et() << "Writing unused alt labels log." << endl;
-	ofstream unusedfile(args.logfilepath+"/unusedaltlabels.log");
-	timestamp = time(0);
-	unusedfile << "Log file created at: " << ctime(&timestamp);
 	unsigned int total_unused_alt_labels = 0;
+	list<string> unused_alt_labels;
 	for (HighwaySystem *h : highway_systems)
 		for (Route &r : h->route_list)
 			if (r.unused_alt_labels.size())
 			{	total_unused_alt_labels += r.unused_alt_labels.size();
-				unusedfile << r.root << '(' << r.unused_alt_labels.size() << "):";
+				string ual_entry = r.root + '(' + to_string(r.unused_alt_labels.size()) + "):";
 				list<string> ual_list(r.unused_alt_labels.begin(), r.unused_alt_labels.end());
 				ual_list.sort();
-				for (string label : ual_list) unusedfile << ' ' << label;
-				unusedfile << '\n';
+				for (string label : ual_list) ual_entry += ' ' + label;
 				r.unused_alt_labels.clear();
+				unused_alt_labels.push_back(ual_entry);
 			}
+	unused_alt_labels.sort();
+	ofstream unusedfile(args.logfilepath+"/unusedaltlabels.log");
+	timestamp = time(0);
+	unusedfile << "Log file created at: " << ctime(&timestamp);
+	for (string &ual_entry : unused_alt_labels) unusedfile << ual_entry << '\n';
+	unused_alt_labels.clear();
 	unusedfile << "Total: " << total_unused_alt_labels << '\n';
 	unusedfile.close();
 

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2584,18 +2584,23 @@ inusefile.close()
 
 # write log file for alt labels not in use
 print(et.et() + "Writing unused alt labels log.")
-unusedfile = open(args.logfilepath+'/unusedaltlabels.log','w',encoding='UTF-8')
-unusedfile.write("Log file created at: " + str(datetime.datetime.now()) + "\n")
 total_unused_alt_labels = 0
+unused_alt_labels = []
 for h in highway_systems:
     for r in h.route_list:
         if len(r.unused_alt_labels) > 0:
             total_unused_alt_labels += len(r.unused_alt_labels)
-            unusedfile.write(r.root + "(" + str(len(r.unused_alt_labels)) + "):")
+            ual_entry = r.root + "(" + str(len(r.unused_alt_labels)) + "):"
             for label in sorted(r.unused_alt_labels):
-                unusedfile.write(" " + label)
-            unusedfile.write("\n")
+                ual_entry += " " + label
             r.unused_alt_labels = None
+            unused_alt_labels.append(ual_entry)
+unused_alt_labels.sort()
+unusedfile = open(args.logfilepath+'/unusedaltlabels.log','w',encoding='UTF-8')
+unusedfile.write("Log file created at: " + str(datetime.datetime.now()) + "\n")
+for ual_entry in unused_alt_labels:
+    unusedfile.write(ual_entry + "\n")
+unused_alt_labels = None
 unusedfile.write("Total: " + str(total_unused_alt_labels) + "\n")
 unusedfile.close()
 


### PR DESCRIPTION
For #271. Not a file per region as @michihdeu originally suggested, but instead keeping the original single file, only sorted by region.