### PR TITLE
improved speed & parallelism when reading WPTs

### DIFF
--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -63,9 +63,7 @@ void Route::read_wpt
 			  if (al[c] >= 'a' && al[c] <= 'z') al[c] -= 32;
 			unused_alt_labels.insert(al);
 		}
-		all_waypoints->mtx.lock();
 		all_waypoints->insert(w, 1);
-		all_waypoints->mtx.unlock();
 
 		// single-point Datachecks, and HighwaySegment
 		w->out_of_bounds(datacheckerrors, fstr);

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -63,20 +63,8 @@ void Route::read_wpt
 			  if (al[c] >= 'a' && al[c] <= 'z') al[c] -= 32;
 			unused_alt_labels.insert(al);
 		}
-		// look for colocated points
 		all_waypoints->mtx.lock();
-		Waypoint *other_w = all_waypoints->waypoint_at_same_point(w);
-		if (other_w)
-		{	// see if this is the first point colocated with other_w
-			if (!other_w->colocated)
-			{	other_w->colocated = new std::list<Waypoint*>;
-						     // deleted on termination of program
-				other_w->colocated->push_front(other_w);
-			}
-			other_w->colocated->push_front(w);
-			w->colocated = other_w->colocated;
-		}
-		all_waypoints->insert(w);
+		all_waypoints->insert(w, 1);
 		all_waypoints->mtx.unlock();
 
 		// single-point Datachecks, and HighwaySegment

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -35,14 +35,15 @@ void WaypointQuadtree::insert(Waypoint *w)
 {	// insert Waypoint *w into this quadtree node
 	//std::cout << "QTDEBUG: " << str() << " insert " << w->str() << std::endl;
 	if (!refined())
-	{	if (!waypoint_at_same_point(w))
+	     {
+		if (!w->colocated || w == w->colocated->back())
 		{	//std::cout << "QTDEBUG: " << str() << " at " << unique_locations << " unique locations" << std::endl;
 			unique_locations++;
 		}
 		points.push_front(w);
 		if (unique_locations > 50)  // 50 unique points max per quadtree node
 			refine();
-	}
+	     }
 	else	if (w->lat < mid_lat)
 			if (w->lng < mid_lng)
 				sw_child->insert(w);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -7,7 +7,7 @@ class WaypointQuadtree
 	WaypointQuadtree *nw_child, *ne_child, *sw_child, *se_child;
 	std::forward_list<Waypoint*> points;
 	unsigned int unique_locations;
-	static std::mutex mtx;
+	std::recursive_mutex mtx;
 
 	bool refined();
 	WaypointQuadtree(double, double, double, double);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -12,7 +12,7 @@ class WaypointQuadtree
 	bool refined();
 	WaypointQuadtree(double, double, double, double);
 	void refine();
-	void insert(Waypoint*);
+	void insert(Waypoint*, bool);
 	Waypoint *waypoint_at_same_point(Waypoint*);
 	std::forward_list<Waypoint*> near_miss_waypoints(Waypoint*, double);
 	std::string str();

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
 	// create NMP lists
 	cout << et.et() << "Searching for near-miss points." << endl;
       #ifdef threading_enabled
-	// set up for threaded processing of highway systems
+	// set up for threaded NMP search
 	hs_it = highway_systems.begin();
 
 	for (unsigned int t = 0; t < args.numthreads; t++)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -77,7 +77,7 @@ class WaypointQuadtree:
         """insert Waypoint w into this quadtree node"""
         #print("QTDEBUG: " + str(self) + " insert " + str(w))
         if self.points is not None:
-            if self.waypoint_at_same_point(w) is None:
+            if w.colocated is None or w == w.colocated[0]:
                 #print("QTDEBUG: " + str(self) + " at " + str(self.unique_locations) + " unique locations")
                 self.unique_locations += 1
             self.points.append(w)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -71,12 +71,25 @@ class WaypointQuadtree:
         points = self.points
         self.points = None
         for p in points:
-            self.insert(p)
+            self.insert(p, False)
 
-    def insert(self,w):
+    def insert(self,w,init):
         """insert Waypoint w into this quadtree node"""
         #print("QTDEBUG: " + str(self) + " insert " + str(w))
         if self.points is not None:
+            # look for colocated points during initial insertion
+            if init:
+                other_w = None
+                for p in self.points:
+                    if p.same_coords(w):
+                        other_w = p
+                        break
+                if other_w is not None:
+                    # see if this is the first point colocated with other_w
+                    if other_w.colocated is None:
+                        other_w.colocated = [ other_w ]
+                    other_w.colocated.append(w)
+                    w.colocated = other_w.colocated
             if w.colocated is None or w == w.colocated[0]:
                 #print("QTDEBUG: " + str(self) + " at " + str(self.unique_locations) + " unique locations")
                 self.unique_locations += 1
@@ -86,14 +99,14 @@ class WaypointQuadtree:
         else:
             if w.lat < self.mid_lat:
                 if w.lng < self.mid_lng:
-                    self.sw_child.insert(w)
+                    self.sw_child.insert(w, init)
                 else:
-                    self.se_child.insert(w)
+                    self.se_child.insert(w, init)
             else:
                 if w.lng < self.mid_lng:
-                    self.nw_child.insert(w)
+                    self.nw_child.insert(w, init)
                 else:
-                    self.ne_child.insert(w)
+                    self.ne_child.insert(w, init)
 
     def waypoint_at_same_point(self,w):
         """find an existing waypoint at the same coordinates as w"""
@@ -928,16 +941,8 @@ class Route:
                     # populate unused alt labels
                     for label in w.alt_labels:
                         self.unused_alt_labels.add(label.upper().strip("+"))
-                    # look for colocated points
-                    all_waypoints_lock.acquire()
-                    other_w = all_waypoints.waypoint_at_same_point(w)
-                    if other_w is not None:
-                        # see if this is the first point colocated with other_w
-                        if other_w.colocated is None:
-                            other_w.colocated = [ other_w ]
-                        other_w.colocated.append(w)
-                        w.colocated = other_w.colocated
 
+                    all_waypoints_lock.acquire()
                     # look for near-miss points (before we add this one in)
                     #print("DEBUG: START search for nmps for waypoint " + str(w) + " in quadtree of size " + str(all_waypoints.size()))
                     #if not all_waypoints.is_valid():
@@ -959,7 +964,7 @@ class Route:
                             else:
                                 other_w.near_miss_points.append(w)
     
-                    all_waypoints.insert(w)
+                    all_waypoints.insert(w, True)
                     all_waypoints_lock.release()
                     # add HighwaySegment, if not first point
                     if previous_point is not None:


### PR DESCRIPTION
Closes https://github.com/yakra/DataProcessing/issues/111. This picks up where #280 left off, improving multi-threaded performance `Reading waypoints for all routes` by moving unique location counting & colocation detection *(parts of these improvements also found their way into siteupdate.py, removing some redundant iteration down thru quadtree nodes)* to where it's not necessary to keep the quadtree locked, and then finally reworking WaypointQuadtree::mtx to lock individual nodes, allowing different branches of the quadtree to be refined in parallel.

Graphs were produced by grepping the beginning and ending timestamps for a given task in siteupdate.log files (3000 in total!) produced by the different binaries, averaging the times of 10 different runs each.

* The blue line shows time `reading waypoints for all routes` before #280, back when NMP detection was still included in this task.
* The 3 red-orange lines represent the changes in #280, when NMP detection was carved out to be done separately. The solid line, the sum of the two dotted/dashed lines, is the time spent performing both tasks, and thus our basis of comparison against the blue line.
* The remaining (yellow, green, purple) lines are for reading WPTs only, sans NMPs, and should be compared to the upper dashed line, "readWPT".

---
![lab2](https://user-images.githubusercontent.com/13720877/77212362-305ded00-6add-11ea-940a-b5a833a76b8b.gif)
IMO our sanest & nicest-looking graph overall. Lab2's 20MB L3 cache helps it scale up to a higher number of threads, making it just barely faster at this task than the faster-clocked lab1.

---
![lab3](https://user-images.githubusercontent.com/13720877/77212363-305ded00-6add-11ea-9750-a59bc52f7c38.gif)
Here we see our bottleneck(s) as a big factor in 30d84fd, and the effects of removing it.
I would *assume* that if our only bottleneck were the mutex, with nothing else at play, our time would make an asymptotic approach to the time required to do the effectively single-threaded bits, and then stay relatively flat. What we see is efficiency peaking early, and things quickly getting worse. My suspicion = memory; lab3 has 15MB L3 cache, and 1333 MHz RAM vice lab2's 1600. When we have to start going (earlier) to slower main memory for our data, it's all over.
By contrast, 10f9c92 calms things down quite a bit. Once NMPs are out of the equation, we're working with a smaller data set at once, and can keep more of what we're using in cache.

---
![lab1](https://user-images.githubusercontent.com/13720877/77212360-2f2cc000-6add-11ea-9a9f-5f75bf56efa7.gif)
Raw clock speed gives lab1 an initial edge, but it starts to feel the slowdown a bit earlier. 8MB L3 cache here.

---
![lab1_5](https://user-images.githubusercontent.com/13720877/77212361-2fc55680-6add-11ea-8e00-8afcf3827908.gif)
Wow. Worst of both worlds on lab1.5: 8MB L3 cache + 1333 MHz RAM clock = ouch!
What we ***don't*** see here: While expectedly slower at this particular task, lab1.5 runs siteupdate faster overall than lab1 (speed records are 42.5s & 48.5s respectively). This despite a Xeon E3-1230 CPU (vice an E3-1230 v2) with slightly slower clock speed and 1333 MHz RAM instead of 1600. I've not yet checked out what tasks account for the time savings.
Potential factors: Different OS. Different chipset?

---
![bt](https://user-images.githubusercontent.com/13720877/77212306-099fb680-6add-11ea-86c5-79e0b39d9c76.gif)
[And now last, but not to be the least,](https://www.youtube.com/watch?v=ppttxQoc74Q&t=1m32s) BiggaTomato, my daily driver desktop. The 30d84fd line looks a bit funky here, but it doesn't appear to be an artifact of low sample size; the data checks out. Weird.

---
If you'd like, I'll give an extra run thru the stats, logs and graphs and make sure everything checks out compared to what's in the master branch now.