### PR TITLE
null zero bugfix

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1228,7 +1228,7 @@ class TravelerList:
         self.log_entries = []
 
         for line in lines:
-            line = line.rstrip('\x00').strip()
+            line = line.strip(" \t\r\n\x00")
             # ignore empty or "comment" lines
             if len(line) == 0 or line.startswith("#"):
                 continue


### PR DESCRIPTION
[This change](https://github.com/TravelMapping/DataProcessing/commit/21f3ec9e18ffe5037764799b632c3fc3b7f53abc#diff-3b571d212fe64f9b192528ad4af883b7R1231) from #309 was poorly thought out.
The idea was to have a wee bit more robustness & allow for cases with whitespace before null zeros, and trim the null zeros first.
Problem is, unlike C++'s `std::getline`, Python's `readlines` doesn't automatically strip the endline. So The `\0`s aren't stripped because of the endline, and any whitespace then won't be stripped because of the `\0`s.
A single customized strip should take care of any combination of the three.

Luckily, this only affects lowenbrau.list, and even then [not the latest version](https://github.com/TravelMapping/UserData/commit/9c3ccc03eafe5eba557bbb4a6c14ee1f3b160e51#diff-89940ef01f6590d8184eedac1667df38R1775). Found this because I frequently check out an older head to run speed tests.