### PR TITLE
concurrency augment speed & parallelism

### DIFF
--- a/siteupdate/cplusplus/threads/ConcAugThread.cpp
+++ b/siteupdate/cplusplus/threads/ConcAugThread.cpp
@@ -1,5 +1,5 @@
 void ConcAugThread(unsigned int id, std::list<TravelerList*> *travlists, std::list<TravelerList*>::iterator *it,
-		   std::mutex *tl_mtx, std::mutex *log_mtx, std::ofstream *concurrencyfile)
+		   std::mutex *tl_mtx, std::mutex *log_mtx, std::list<std::string>* augment_list)
 {	//printf("Starting ConcAugThread %02i\n", id); fflush(stdout);
 	while (*it != travlists->end())
 	{	tl_mtx->lock();
@@ -16,10 +16,7 @@ void ConcAugThread(unsigned int id, std::list<TravelerList*> *travlists, std::li
 		for (HighwaySegment *s : t->clinched_segments)
 		  if (s->concurrent)
 		    for (HighwaySegment *hs : *(s->concurrent))
-		      if (hs->route->system->active_or_preview() && hs->add_clinched_by(t))
-		      {	log_mtx->lock();
-			*concurrencyfile << "Concurrency augment for traveler " << t->traveler_name << ": [" << hs->str() << "] based on [" << s->str() << "]\n";
-			log_mtx->unlock();
-		      }
+		      if (hs != s && hs->route->system->active_or_preview() && hs->add_clinched_by(t))
+			augment_list->push_back("Concurrency augment for traveler " + t->traveler_name + ": [" + hs->str() + "] based on [" + s->str() + ']');
 	}
 }

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2897,7 +2897,7 @@ for t in traveler_lists:
     for s in t.clinched_segments:
         if s.concurrent is not None:
             for hs in s.concurrent:
-                if hs.route.system.active_or_preview() and hs.add_clinched_by(t):
+                if hs != s and hs.route.system.active_or_preview() and hs.add_clinched_by(t):
                     concurrencyfile.write("Concurrency augment for traveler " + t.traveler_name + ": [" + str(hs) + "] based on [" + str(s) + "]\n")
 print("!")
 concurrencyfile.close()


### PR DESCRIPTION
Closes https://github.com/yakra/DataProcessing/issues/117.

As we saw in #284, doing too much stuff while a mutex is locked can be a big hit to performance.
Similar to @jteresco's [suggestion](https://github.com/TravelMapping/DataProcessing/issues/281#issuecomment-592768745) in #281, we build `numthreads` lists of log entry lines, eliminate the mutex completely, and output them all single-threaded (taking ~0.2-0.3s) when done. A big win for parallelism.

Checking whether `hs != s` can speed us up a little in both languages.

**Python:**
* 9.2% faster on lab1
* 9.8% faster on lab1.5

**C++:**
![ConcAugGood](https://user-images.githubusercontent.com/13720877/79593088-f0bcfd80-80a8-11ea-938d-a985f87256c4.gif)
