### PR TITLE
route mutexes

### DIFF
--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -1,5 +1,3 @@
-std::mutex Route::liu_mtx;
-std::mutex Route::ual_mtx;
 std::mutex Route::awf_mtx;
 
 Route::Route(std::string &line, HighwaySystem *sys, ErrorList &el, std::unordered_map<std::string, Region*> &region_hash)

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -52,9 +52,8 @@ class Route
 	std::unordered_set<std::string> labels_in_use;
 	std::unordered_set<std::string> unused_alt_labels;
 	static std::mutex awf_mtx;	// for locking the all_wpt_files set when erasing processed WPTs
-	static std::mutex liu_mtx;	// for locking the labels_in_use set when inserting labels during TravelerList processing
-	static std::mutex ual_mtx;	// for locking the unused_alt_labels set when removing in-use alt_labels
-					// with one for each route, rather than static, no discernable speed difference. Saving a wee bit of RAM.
+	std::mutex liu_mtx;	// for locking the labels_in_use set when inserting labels during TravelerList processing
+	std::mutex ual_mtx;	// for locking the unused_alt_labels set when removing in-use alt_labels
 	std::vector<HighwaySegment*> segment_list;
 	double mileage;
 	int rootOrder;

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
 	unordered_set<Route*> con_roots;
 
 	for (HighwaySystem *h : highway_systems)
-	{	for (Route r : h->route_list)
+	{	for (Route& r : h->route_list)
 		{	if (roots.find(r.root) == roots.end()) roots.insert(r.root);
 			else el.add_error("Duplicate root in route lists: " + r.root);
 			string list_name = r.readable_name();
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
 			if (list_names.find(list_name) == list_names.end()) list_names.insert(list_name);
 			else duplicate_list_names.insert(list_name);
 		}
-		for (ConnectedRoute cr : h->con_route_list)
+		for (ConnectedRoute& cr : h->con_route_list)
 		  for (size_t r = 0; r < cr.roots.size(); r++)
 		    // FIXME branch based on result of list_names.insert
 		    if (con_roots.find(cr.roots[r]) == con_roots.end()) con_roots.insert(cr.roots[r]);
@@ -292,8 +292,8 @@ int main(int argc, char *argv[])
 		// only be a few in reasonable cases)
 		unsigned int num_found = 0;
 		for (HighwaySystem *h : highway_systems)
-		  for (Route r : h->route_list)
-		    for (string lr : roots)
+		  for (Route& r : h->route_list)
+		    for (const string& lr : roots)
 		      if (lr == r.root)
 		      {	el.add_error("route " + lr + " not matched by any connected route root.");
 			num_found++;


### PR DESCRIPTION
Closes https://github.com/yakra/DataProcessing/issues/124.

Mutex for each route, rather than one mutex for all routes. Improves parallelism as thread count increases.

---
The graphs have the same info; the lines are overlaid in a different order.
![List-lab1](https://user-images.githubusercontent.com/13720877/79997396-88df2c00-8487-11ea-953f-1736088784ee.png)
![List-lab1_5](https://user-images.githubusercontent.com/13720877/79997397-8977c280-8487-11ea-95d9-53175ef44c77.png)