### PR TITLE
.list processing enhancements

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem.cpp
@@ -1,4 +1,3 @@
-//FIXME try to break strtok. That goes for all strtok project-wide.
 class HighwaySystem
 {	/* This class encapsulates the contents of one .csv file
 	that represents the collection of highways within a system.
@@ -28,6 +27,8 @@ class HighwaySystem
 	std::list<ConnectedRoute> con_route_list;
 	std::unordered_map<Region*, double> mileage_by_region;
 	std::unordered_set<HGVertex*> vertices;
+	std::unordered_set<std::string>listnamesinuse, unusedaltroutenames;
+	std::mutex lniu_mtx, uarn_mtx;
 	bool is_valid;
 
 	HighwaySystem(std::string &line, ErrorList &el, std::string path, std::string &systemsfile,

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -51,7 +51,9 @@ class Route
 	std::vector<Waypoint*> point_list;
 	std::unordered_set<std::string> labels_in_use;
 	std::unordered_set<std::string> unused_alt_labels;
-	static std::unordered_map<std::string, Route*> root_hash, list_hash;
+	std::unordered_set<std::string> duplicate_labels;
+	std::unordered_map<std::string, unsigned int> pri_label_hash, alt_label_hash;
+	static std::unordered_map<std::string, Route*> root_hash, pri_list_hash, alt_list_hash;
 	static std::mutex awf_mtx;	// for locking the all_wpt_files set when erasing processed WPTs
 	std::mutex liu_mtx;	// for locking the labels_in_use set when inserting labels during TravelerList processing
 	std::mutex ual_mtx;	// for locking the unused_alt_labels set when removing in-use alt_labels
@@ -73,4 +75,5 @@ class Route
 	double clinched_by_traveler(TravelerList *);
 	std::string list_line(int, int);
 	void write_nmp_merged(std::string);
+	inline void store_traveled_segments(TravelerList*, unsigned int, unsigned int);
 };

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -27,17 +27,11 @@ void Route::read_wpt
 	// split file into lines
 	size_t spn = 0;
 	for (char* c = wptdata; *c; c += spn)
-	{	spn = strcspn(c, "\n\r");
-		while (c[spn] == '\n' || c[spn] == '\r')
-		{	c[spn] = 0;
-			spn++;
-		}
+	{	for (spn = strcspn(c, "\n\r"); c[spn] == '\n' || c[spn] == '\r'; spn++) c[spn] = 0;
 		lines.emplace_back(c);
 	}
 
 	lines.push_back(wptdata+wptdatasize+1); // add a dummy "past-the-end" element to make lines[l+1]-2 work
-	// set to be used per-route to find label duplicates
-	std::unordered_set<std::string> all_route_labels;
 	// set to be used for finding duplicate coordinates
 	std::unordered_set<Waypoint*> coords_used;
 	double vis_dist = 0;
@@ -67,7 +61,6 @@ void Route::read_wpt
 
 		// single-point Datachecks, and HighwaySegment
 		w->out_of_bounds(datacheckerrors, fstr);
-		w->duplicate_label(datacheckerrors, all_route_labels);
 		w->duplicate_coords(datacheckerrors, coords_used, fstr);
 		if (point_list.size() > 1)
 		{	w->distance_update(datacheckerrors, fstr, vis_dist, point_list[point_list.size()-2]);

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -1,234 +1,118 @@
-class TravelerList
-{   /* This class encapsulates the contents of one .list file
-    that represents the travels of one individual user.
+TravelerList::TravelerList(std::string travname, ErrorList *el, Arguments *args)
+{	active_systems_traveled = 0;
+	active_systems_clinched = 0;
+	preview_systems_traveled = 0;
+	preview_systems_clinched = 0;
+	unsigned int list_entries = 0;
+	traveler_num = new unsigned int[args->numthreads];
+		       // deleted on termination of program
+	traveler_name = travname.substr(0, travname.size()-5); // strip ".list" from end of travname
+	if (traveler_name.size() > DBFieldLength::traveler)
+	  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");
+	std::ofstream log(args->logfilepath+"/users/"+traveler_name+".log");
+	std::ofstream splist;
+	if (args->splitregionpath != "") splist.open(args->splitregionpath+"/list_files/"+travname);
+	time_t StartTime = time(0);
+	log << "Log file created at: " << ctime(&StartTime);
+	std::vector<char*> lines;
+	std::vector<std::string> endlines;
+	std::ifstream file(args->userlistfilepath+"/"+travname);
+	// we can't getline here because it only allows one delimiter, and we need two; '\r' and '\n'.
+	// at least one .list file contains newlines using only '\r' (0x0D):
+	// https://github.com/TravelMapping/UserData/blob/6309036c44102eb3325d49515b32c5eef3b3cb1e/list_files/whopperman.list
+	file.seekg(0, std::ios::end);
+	unsigned long listdatasize = file.tellg();
+	file.seekg(0, std::ios::beg);
+	char *listdata = new char[listdatasize+1];
+	file.read(listdata, listdatasize);
+	listdata[listdatasize] = 0; // add null terminator
+	file.close();
 
-    A list file consists of lines of 4 values:
-    region route_name start_waypoint end_waypoint
+	// get canonical newline for writing splitregion .list files
+	std::string newline;
+	unsigned long c = 0;
+	while (listdata[c] != '\r' && listdata[c] != '\n' && c < listdatasize) c++;
+	if (listdata[c] == '\r')
+		if (listdata[c+1] == '\n')	newline = "\r\n";
+		else				newline = "\r";
+	else	if (listdata[c] == '\n')	newline = "\n";
+	// Use CRLF as failsafe if .list file contains no newlines.
+		else				newline = "\r\n";
 
-    which indicates that the user has traveled the highway names
-    route_name in the given region between the waypoints named
-    start_waypoint end_waypoint
-    */
-	public:
-	std::mutex ap_mi_mtx, ao_mi_mtx, sr_mi_mtx;
-	std::unordered_set<HighwaySegment*> clinched_segments;
-	std::string traveler_name;
-	std::unordered_map<Region*, double> active_preview_mileage_by_region;				// total mileage per region, active+preview only
-	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only
-	std::unordered_map<HighwaySystem*, std::unordered_map<Region*, double>> system_region_mileages;	// mileage per region per system
-	std::unordered_map<HighwaySystem*, std::unordered_map<ConnectedRoute*, double>> con_routes_traveled; // mileage per ConRte per system
-														// TODO is this necessary?
-														// ConRtes by definition exist in one system only
-	std::unordered_map<Route*, double> routes_traveled;						// mileage per traveled route
-	std::unordered_map<HighwaySystem*, unsigned int> con_routes_clinched;				// clinch count per system
-	//std::unordered_map<HighwaySystem*, unsigned int> routes_clinched;				// commented out in original siteupdate.py
-	unsigned int *traveler_num;
-	unsigned int active_systems_traveled;
-	unsigned int active_systems_clinched;
-	unsigned int preview_systems_traveled;
-	unsigned int preview_systems_clinched;
-	static std::mutex alltrav_mtx;	// for locking the traveler_lists list when reading .lists from disk
+	// separate listdata into series of lines & newlines
+	size_t spn = 0;
+	for (char *c = listdata; *c; c += spn)
+	{	endlines.push_back("");
+		for (spn = strcspn(c, "\n\r"); c[spn] == '\n' || c[spn] == '\r'; spn++)
+		{	endlines.back().push_back(c[spn]);
+			c[spn] = 0;
+		}
+		lines.push_back(c);
+	}
+	lines.push_back(listdata+listdatasize+1); // add a dummy "past-the-end" element to make lines[l+1]-2 work
+	// strip UTF-8 byte order mark if present
+	if (!strncmp(lines[0], "\xEF\xBB\xBF", 3)) lines[0] += 3;
 
-	TravelerList(std::string travname, ErrorList *el, Arguments *args, std::mutex *strtok_mtx)
-	{	active_systems_traveled = 0;
-		active_systems_clinched = 0;
-		preview_systems_traveled = 0;
-		preview_systems_clinched = 0;
-		unsigned int list_entries = 0;
-		traveler_num = new unsigned int[args->numthreads];
-			       // deleted on termination of program
-		traveler_name = travname.substr(0, travname.size()-5); // strip ".list" from end of travname
-		if (traveler_name.size() > DBFieldLength::traveler)
-		  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");
-		std::ofstream log(args->logfilepath+"/users/"+traveler_name+".log");
-		std::ofstream splist;
-		if (args->splitregionpath != "") splist.open(args->splitregionpath+"/list_files/"+travname);
-		time_t StartTime = time(0);
-		log << "Log file created at: " << ctime(&StartTime);
-		std::vector<char*> lines;
-		std::vector<std::string> endlines;
-		std::ifstream file(args->userlistfilepath+"/"+travname);
-		// we can't getline here because it only allows one delimiter, and we need two; '\r' and '\n'.
-		// at least one .list file contains newlines using only '\r' (0x0D):
-		// https://github.com/TravelMapping/UserData/blob/6309036c44102eb3325d49515b32c5eef3b3cb1e/list_files/whopperman.list
-		file.seekg(0, std::ios::end);
-		unsigned long listdatasize = file.tellg();
-		file.seekg(0, std::ios::beg);
-		char *listdata = new char[listdatasize+1];
-		file.read(listdata, listdatasize);
-		listdata[listdatasize] = 0; // add null terminator
-		file.close();
-
-		// get canonical newline for writing splitregion .list files
-		std::string newline;
-		unsigned long c = 0;
-		while (listdata[c] != '\r' && listdata[c] != '\n' && c < listdatasize) c++;
-		if (listdata[c] == '\r')
-			if (listdata[c+1] == '\n')	newline = "\r\n";
-			else				newline = "\r";
-		else	if (listdata[c] == '\n')	newline = "\n";
-		// Use CRLF as failsafe if .list file contains no newlines.
-			else				newline = "\r\n";
-
-		// separate listdata into series of lines & newlines
+	for (unsigned int l = 0; l < lines.size()-1; l++)
+	{	std::string orig_line(lines[l]);
+		// strip whitespace
+		while (lines[l][0] == ' ' || lines[l][0] == '\t') lines[l]++;
+		char * endchar = lines[l+1]-2; // -2 skips over the 0 inserted while separating listdata into lines
+		while (*endchar == 0) endchar--;  // skip back more for CRLF cases, and lines followed by blank lines
+		while (*endchar == ' ' || *endchar == '\t')
+		{	*endchar = 0;
+			endchar--;
+		}
+		std::string trim_line(lines[l]);
+		// ignore empty or "comment" lines
+		if (lines[l][0] == 0 || lines[l][0] == '#')
+		{	splist << orig_line << endlines[l];
+			continue;
+		}
+		// process fields in line
+		std::vector<char*> fields;
 		size_t spn = 0;
-		for (char *c = listdata; *c; c += spn)
-		{	endlines.push_back("");
-			spn = strcspn(c, "\r\n");
-			while (c[spn] == '\r' || c[spn] == '\n')
-			{	endlines.back().push_back(c[spn]);
-				c[spn] = 0;
-				spn++;
-			}
-			lines.push_back(c);
+		for (char* c = lines[l]; *c; c += spn)
+		{	for (spn = strcspn(c, " \t"); c[spn] == ' ' || c[spn] == '\t'; spn++) c[spn] = 0;
+			if (*c == '#') break;
+			else fields.push_back(c);
 		}
-		lines.push_back(listdata+listdatasize+1); // add a dummy "past-the-end" element to make lines[l+1]-2 work
-		// strip UTF-8 byte order mark if present
-		if (!strncmp(lines[0], "\xEF\xBB\xBF", 3)) lines[0] += 3;
-
-		for (unsigned int l = 0; l < lines.size()-1; l++)
-		{	std::string orig_line(lines[l]);
-			// strip whitespace
-			while (lines[l][0] == ' ' || lines[l][0] == '\t') lines[l]++;
-			char * endchar = lines[l+1]-2; // -2 skips over the 0 inserted while separating listdata into lines
-			while (*endchar == 0) endchar--;  // skip back more for CRLF cases, and lines followed by blank lines
-			while (*endchar == ' ' || *endchar == '\t')
-			{	*endchar = 0;
-				endchar--;
-			}
-			std::string trim_line(lines[l]);
-			// ignore empty or "comment" lines
-			if (lines[l][0] == 0 || lines[l][0] == '#')
-			{	splist << orig_line << endlines[l];
-				continue;
-			}
-			// process fields in line
-			std::vector<char*> fields;
-			strtok_mtx->lock();
-			for (char *token = strtok(lines[l], " \t"); token; token = strtok(0, " \t") ) fields.push_back(token);
-			strtok_mtx->unlock();
-			if (fields.size() != 4)
-			  // OK if 5th field exists and starts with #
-			  if (fields.size() < 5 || fields[4][0] != '#')
-			  {	log << "Incorrect format line: " << trim_line << '\n';
-				splist << orig_line << endlines[l];
-				continue;
-			  }
-
-			// find the root that matches in some system and when we do, match labels
-			std::string route_entry = upper(std::string(fields[1])); // leave fields[1] intact for potential AltRouteName note
-			std::string lookup = std::string(upper(fields[0])) + " " + route_entry;
-			try {	Route *r = Route::list_hash.at(lookup);
-				for (std::string& a : r->alt_route_names)
-				  if (route_entry == a)
-				  {	log << "Note: deprecated route name " << fields[1]
-					    << " -> canonical name " << r->list_entry_name() << " in line " << trim_line << '\n';
-					break;
-				  }
-				if (r->system->devel())
-				{	log << "Ignoring line matching highway in system in development: " << trim_line << '\n';
-					splist << orig_line << endlines[l];
-					continue;
-				}
-				// r is a route match, r.root is our root, and we need to find
-				// canonical waypoint labels, ignoring case and leading
-				// "+" or "*" when matching
-				std::vector<unsigned int> point_indices;
-				unsigned int checking_index = 0;
-				while (*fields[2] == '*' || *fields[2] == '+') fields[2]++;
-				while (*fields[3] == '*' || *fields[3] == '+') fields[3]++;
-				upper(fields[2]);
-				upper(fields[3]);
-				for (Waypoint *w : r->point_list)
-				{	std::string upper_label = upper(w->label);
-					while (upper_label.front() == '+' || upper_label.front() == '*') upper_label = upper_label.substr(1);
-					if (fields[2] == upper_label || fields[3] == upper_label)
-					     {	point_indices.push_back(checking_index);
-						r->liu_mtx.lock();
-						r->labels_in_use.insert(upper_label);
-						r->liu_mtx.unlock();
-					     }
-					else {	for (std::string &alt : w->alt_labels)
-						{	if (fields[2] == alt || fields[3] == alt)
-							{	point_indices.push_back(checking_index);
-								r->liu_mtx.lock();
-								r->labels_in_use.insert(alt);
-								r->liu_mtx.unlock();
-								// if we have not yet used this alt label, remove it from the unused set
-								r->ual_mtx.lock();
-								r->unused_alt_labels.erase(alt);
-								r->ual_mtx.unlock();
-							}
-						}
-					     }
-					checking_index++;
-				}
-				if (point_indices.size() != 2)
-				{	bool invalid_char = 0;
-					for (char& c : trim_line)
-					  if (iscntrl(c))
-					  {	c = '?';
-						invalid_char = 1;
-					  }
-					log << "Waypoint label(s) not found in line: " << trim_line;
-					if (invalid_char) log << " [contains invalid character(s)]";
-					log << '\n';
-					splist << orig_line << endlines[l];
-				}
-				else {	list_entries++;
-					// find the segments we just matched and store this traveler with the
-					// segments and the segments with the traveler (might not need both
-					// ultimately)
-					for (unsigned int wp_pos = point_indices[0]; wp_pos < point_indices[1]; wp_pos++)
-					{	HighwaySegment *hs = r->segment_list[wp_pos];
-						hs->add_clinched_by(this);
-						clinched_segments.insert(hs);
-					}
-					#include "splitregion.cpp"
-				     }
-			    }
-			catch (const std::out_of_range& oor)
-			    {	bool invalid_char = 0;
-				for (char& c : trim_line)
-				  if (iscntrl(c))
-				  {	c = '?';
-					invalid_char = 1;
-				  }
-				log << "Unknown region/highway combo in line: " << trim_line;
-				if (invalid_char) log << " [contains invalid character(s)]";
-				log << '\n';
-				splist << orig_line << endlines[l];
-			    }
-		}
-		delete[] listdata;
-		log << "Processed " << list_entries << " good lines marking " << clinched_segments.size() << " segments traveled.\n";
-		log.close();
-		splist.close();
+		if (fields.size() == 4)
+		     {
+			#include "mark_chopped_route_segments.cpp"
+		     }
+		else {	log << "Incorrect format line: " << trim_line << '\n';
+			splist << orig_line << endlines[l];
+		     }
 	}
+	delete[] listdata;
+	log << "Processed " << list_entries << " good lines marking " << clinched_segments.size() << " segments traveled.\n";
+	log.close();
+	splist.close();
+}
 
-	/* Return active mileage across all regions */
-	double active_only_miles()
-	{	double mi = 0;
-		for (std::pair<Region* const, double>& rm : active_only_mileage_by_region) mi += rm.second;
-		return mi;
-	}
+/* Return active mileage across all regions */
+double TravelerList::active_only_miles()
+{	double mi = 0;
+	for (std::pair<Region* const, double>& rm : active_only_mileage_by_region) mi += rm.second;
+	return mi;
+}
 
-	/* Return active+preview mileage across all regions */
-	double active_preview_miles()
-	{	double mi = 0;
-		for (std::pair<Region* const, double>& rm : active_preview_mileage_by_region) mi += rm.second;
-		return mi;
-	}
+/* Return active+preview mileage across all regions */
+double TravelerList::active_preview_miles()
+{	double mi = 0;
+	for (std::pair<Region* const, double>& rm : active_preview_mileage_by_region) mi += rm.second;
+	return mi;
+}
 
-	/* Return mileage across all regions for a specified system */
-	double system_region_miles(HighwaySystem *h)
-	{	double mi = 0;
-		for (std::pair<Region* const, double>& rm : system_region_mileages.at(h)) mi += rm.second;
-		return mi;
-	}
+/* Return mileage across all regions for a specified system */
+double TravelerList::system_region_miles(HighwaySystem *h)
+{	double mi = 0;
+	for (std::pair<Region* const, double>& rm : system_region_mileages.at(h)) mi += rm.second;
+	return mi;
+}
 
-	#include "userlog.cpp"
-};
+#include "userlog.cpp"
 
 std::mutex TravelerList::alltrav_mtx;
 

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -1,0 +1,37 @@
+class TravelerList
+{   /* This class encapsulates the contents of one .list file
+    that represents the travels of one individual user.
+
+    A list file consists of lines of 4 values:
+    region route_name start_waypoint end_waypoint
+
+    which indicates that the user has traveled the highway names
+    route_name in the given region between the waypoints named
+    start_waypoint end_waypoint
+    */
+	public:
+	std::mutex ap_mi_mtx, ao_mi_mtx, sr_mi_mtx;
+	std::unordered_set<HighwaySegment*> clinched_segments;
+	std::string traveler_name;
+	std::unordered_map<Region*, double> active_preview_mileage_by_region;				// total mileage per region, active+preview only
+	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only
+	std::unordered_map<HighwaySystem*, std::unordered_map<Region*, double>> system_region_mileages;	// mileage per region per system
+	std::unordered_map<HighwaySystem*, std::unordered_map<ConnectedRoute*, double>> con_routes_traveled; // mileage per ConRte per system
+														// TODO is this necessary?
+														// ConRtes by definition exist in one system only
+	std::unordered_map<Route*, double> routes_traveled;						// mileage per traveled route
+	std::unordered_map<HighwaySystem*, unsigned int> con_routes_clinched;				// clinch count per system
+	//std::unordered_map<HighwaySystem*, unsigned int> routes_clinched;				// commented out in original siteupdate.py
+	unsigned int *traveler_num;
+	unsigned int active_systems_traveled;
+	unsigned int active_systems_clinched;
+	unsigned int preview_systems_traveled;
+	unsigned int preview_systems_clinched;
+	static std::mutex alltrav_mtx;	// for locking the traveler_lists list when reading .lists from disk
+
+	TravelerList(std::string, ErrorList *, Arguments *);
+	double active_only_miles();
+	double active_preview_miles();
+	double system_region_miles(HighwaySystem *);
+	void userlog(ClinchedDBValues *, const double, const double, std::list<HighwaySystem*>*, std::string path);
+};

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -1,0 +1,111 @@
+// find the route that matches and when we do, match labels
+std::string lookup = upper(fields[0]) + ( ' ' + upper(std::string(fields[1])) ); // leave fields[1] intact for potential AltRouteName note
+// look for region/route combo, first in pri_list_hash
+std::unordered_map<std::string,Route*>::iterator rit = Route::pri_list_hash.find(lookup);
+// and then if not found, in alt_list_hash
+if (rit == Route::pri_list_hash.end())
+{	rit = Route::alt_list_hash.find(lookup);
+	if (rit == Route::alt_list_hash.end())
+	{	bool invalid_char = 0;
+		for (char& c : trim_line)
+		  if (iscntrl(c))
+		  {	c = '?';
+			invalid_char = 1;
+		  }
+		log << "Unknown region/highway combo in line: " << trim_line;
+		if (invalid_char) log << " [contains invalid character(s)]";
+		log << '\n';
+		splist << orig_line << endlines[l];
+		continue;
+	}
+	else	log << "Note: deprecated route name " << fields[1]
+		    << " -> canonical name " << rit->second->list_entry_name() << " in line " << trim_line << '\n';
+}
+Route* r = rit->second;
+if (r->system->devel())
+{	log << "Ignoring line matching highway in system in development: " << trim_line << '\n';
+	splist << orig_line << endlines[l];
+	continue;
+}
+// r is a route match, and we need to find
+// waypoint indices, ignoring case and leading
+// '+' or '*' when matching
+unsigned int index1, index2;
+while (*fields[2] == '*' || *fields[2] == '+') fields[2]++;
+while (*fields[3] == '*' || *fields[3] == '+') fields[3]++;
+upper(fields[2]);
+upper(fields[3]);
+
+// look for point indices for labels, first in pri_label_hash
+std::unordered_map<std::string,unsigned int>::iterator lit1 = r->pri_label_hash.find(fields[2]);
+std::unordered_map<std::string,unsigned int>::iterator lit2 = r->pri_label_hash.find(fields[3]);
+// and then if not found, in alt_label_hash
+if (lit1 == r->pri_label_hash.end()) lit1 = r->alt_label_hash.find(fields[2]);
+if (lit2 == r->pri_label_hash.end()) lit2 = r->alt_label_hash.find(fields[3]);
+
+// if we did not find matches for both labels...
+if (lit1 == r->alt_label_hash.end() || lit2 == r->alt_label_hash.end())
+{	bool invalid_char = 0;
+	for (char& c : trim_line)
+	  if (iscntrl(c))
+	  {	c = '?';
+		invalid_char = 1;
+	  }
+	for (char* c = fields[2]; *c; c++) if (iscntrl(*c)) *c = '?';
+	for (char* c = fields[3]; *c; c++) if (iscntrl(*c)) *c = '?';
+	if (lit1 == lit2)
+		log << "Waypoint labels " << fields[2] << " and " << fields[3] << " not found in line: " << trim_line;
+	else {	log << "Waypoint label ";
+		log << (lit1 == r->alt_label_hash.end() ? fields[2] : fields[3]);
+		log << " not found in line: " << trim_line;
+	     }
+	if (invalid_char) log << " [contains invalid character(s)]";
+	log << '\n';
+	splist << orig_line << endlines[l];
+	continue;
+}
+// are either of the labels used duplicates?
+char duplicate = 0;
+if (r->duplicate_labels.find(fields[2]) != r->duplicate_labels.end())
+{	log << r->region->code << ": duplicate label " << fields[2] << " in " << r->root
+	    << ". Please report this error in the TravelMapping forum"
+	    << ". Unable to parse line: " << trim_line << '\n';
+	duplicate = 1;
+}
+if (r->duplicate_labels.find(fields[3]) != r->duplicate_labels.end())
+{	log << r->region->code << ": duplicate label " << fields[3] << " in " << r->root
+	    << ". Please report this error in the TravelMapping forum"
+	    << ". Unable to parse line: " << trim_line << '\n';
+	duplicate = 1;
+}
+if (duplicate) continue;
+// if both labels reference the same waypoint...
+if (lit1->second == lit2->second)
+	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
+// otherwise both labels are valid; mark in use & proceed
+else {	r->system->lniu_mtx.lock();
+	r->system->listnamesinuse.insert(lookup);
+	r->system->lniu_mtx.unlock();
+	r->system->uarn_mtx.lock();
+	r->system->unusedaltroutenames.erase(lookup);
+	r->system->uarn_mtx.unlock();
+	r->liu_mtx.lock();
+	r->labels_in_use.insert(fields[2]);
+	r->labels_in_use.insert(fields[3]);
+	r->liu_mtx.unlock();
+	r->ual_mtx.lock();
+	r->unused_alt_labels.erase(fields[2]);
+	r->unused_alt_labels.erase(fields[3]);
+	r->ual_mtx.unlock();
+
+	list_entries++;
+	if (lit1->second < lit2->second)
+	     {	index1 = lit1->second;
+		index2 = lit2->second;
+	     }
+	else {	index1 = lit2->second;
+		index2 = lit1->second;
+	     }
+	r->store_traveled_segments(this, index1, index2);
+	#include "splitregion.cpp"
+     }

--- a/siteupdate/cplusplus/classes/TravelerList/splitregion.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/splitregion.cpp
@@ -2,7 +2,7 @@
 if (args->splitregion == upper(fields[0]))
 {	// first, comment out original line
 	splist << "##### " << orig_line << newline;
-	HighwaySegment *orig_hs = r->segment_list[point_indices[0]];
+	HighwaySegment *orig_hs = r->segment_list[index1];
 	HighwaySegment *new_hs = 0;
 	if (!orig_hs->concurrent)
 		std::cout << "ERROR: " << orig_hs->str() << " not concurrent" << std::endl;
@@ -17,7 +17,7 @@ if (args->splitregion == upper(fields[0]))
 		else {	if (count > 1) std::cout << "DEBUG: multiple matches found for " << orig_hs->str() << std::endl;
 			// get lines from associated connected route.
 			// assumption: each chopped route in old full region corresponds 1:1 to a connected route in new chopped regions
-			splist << new_hs->route->con_route->list_lines(point_indices[0], point_indices[1] - point_indices[0], newline, 2) << endlines[l];
+			splist << new_hs->route->con_route->list_lines(index1, index2 - index1, newline, 2) << endlines[l];
 		     }
 	     }
 }

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -1,4 +1,4 @@
-void userlog
+void TravelerList::userlog
 (	ClinchedDBValues *clin_db_val,
 	const double total_active_only_miles,
 	const double total_active_preview_miles,

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -20,11 +20,7 @@ Waypoint::Waypoint(char *line, Route *rte, DatacheckEntryList *datacheckerrors)
 	// parse WPT line
 	size_t spn = 0;
 	for (char* c = line; *c; c += spn)
-	{	spn = strcspn(c, " ");
-		while (c[spn] == ' ')
-		{	c[spn] = 0;
-			spn++;
-		}
+	{	for (spn = strcspn(c, " "); c[spn] == ' '; spn++) c[spn] = 0;
 		alt_labels.emplace_back(c);
 	}
 
@@ -308,19 +304,6 @@ bool Waypoint::label_references_route(Route *r, DatacheckEntryList *datacheckerr
 }
 
 /* Datacheck */
-
-inline void Waypoint::duplicate_label(DatacheckEntryList *datacheckerrors, std::unordered_set<std::string> &all_route_labels)
-{	// duplicate labels
-	// first, check primary label
-	std::string upper_label = upper(label);
-	while (upper_label[0] == '+' || upper_label[0] == '*') upper_label = upper_label.substr(1);
-	if (!all_route_labels.insert(upper_label).second)
-		datacheckerrors->add(route, upper_label, "", "", "DUPLICATE_LABEL", "");
-	// then check alt labels
-	for (std::string &a : alt_labels)
-	    if (!all_route_labels.insert(a).second)
-		datacheckerrors->add(route, a, "", "", "DUPLICATE_LABEL", "");
-}
 
 inline void Waypoint::duplicate_coords(DatacheckEntryList *datacheckerrors, std::unordered_set<Waypoint*> &coords_used, char *fstr)
 {	// duplicate coordinates

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -39,7 +39,6 @@ class Waypoint
 	bool label_references_route(Route *, DatacheckEntryList *);
 
 	// Datacheck
-	inline void duplicate_label(DatacheckEntryList *, std::unordered_set<std::string> &);
 	inline void duplicate_coords(DatacheckEntryList *, std::unordered_set<Waypoint*> &, char *);
 	inline void out_of_bounds(DatacheckEntryList *, char *);
 	inline void distance_update(DatacheckEntryList *, char *, double &, Waypoint *);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -1,4 +1,4 @@
-bool WaypointQuadtree::WaypointQuadtree::refined()
+inline bool WaypointQuadtree::WaypointQuadtree::refined()
 {	return nw_child;
 }
 

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -9,7 +9,7 @@ class WaypointQuadtree
 	unsigned int unique_locations;
 	std::recursive_mutex mtx;
 
-	bool refined();
+	inline bool refined();
 	WaypointQuadtree(double, double, double, double);
 	void refine();
 	void insert(Waypoint*, bool);

--- a/siteupdate/cplusplus/threads/ReadListThread.cpp
+++ b/siteupdate/cplusplus/threads/ReadListThread.cpp
@@ -1,7 +1,6 @@
 void ReadListThread
 (	unsigned int id, std::list<std::string> *traveler_ids, std::list<std::string>::iterator *it,
-	std::list<TravelerList*> *traveler_lists, std::mutex *tl_mtx, std::mutex *strtok_mtx,
-	Arguments *args, ErrorList *el
+	std::list<TravelerList*> *traveler_lists, std::mutex *tl_mtx, Arguments *args, ErrorList *el
 )
 {	//printf("Starting ReadListThread %02i\n", id); fflush(stdout);
 	while (*it != traveler_ids->end())
@@ -16,7 +15,7 @@ void ReadListThread
 		//printf("ReadListThread %02i (*it)++\n", id); fflush(stdout);
 		std::cout << tl << ' ' << std::flush;
 		tl_mtx->unlock();
-		TravelerList *t = new TravelerList(tl, el, args, strtok_mtx);
+		TravelerList *t = new TravelerList(tl, el, args);
 				  // deleted on termination of program
 		TravelerList::alltrav_mtx.lock();
 		traveler_lists->push_back(t);


### PR DESCRIPTION
* C++: bugfix for duplicate AltLabels datacheck
  * closes #325
* hash tables for waypoint labels
  * closes #278
* C++: parallelism processing .list files
  * closes #274
* improved userlog error messages
  * closes #326
  * closes #275
* listnamesinuse.log & unusedaltroutenames.log
  * closes #230
* preparation for #58
  * #308
  * [Route::store_traveled_segments](https://github.com/TravelMapping/DataProcessing/issues/58#issuecomment-629957813)
  * C++: refactor chopped route (4-field) list line parsing into its own file

---
A couple Obligatory C++ Speed Graphs at https://github.com/TravelMapping/DataProcessing/issues/278#issuecomment-629718898 and https://github.com/TravelMapping/DataProcessing/issues/274#issuecomment-631611817.

---
Most recent squashed commit on BiggaTomato is `2ae735779f88e95e8a4386a43ff428b7f4689f65`.
A more complete list will be hidden below.