### PR TITLE
2 region-splitting bugfixes

### DIFF
--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -51,7 +51,10 @@ TravelerList::TravelerList(std::string travname, ErrorList *el, Arguments *args)
 	}
 	lines.push_back(listdata+listdatasize+1); // add a dummy "past-the-end" element to make lines[l+1]-2 work
 	// strip UTF-8 byte order mark if present
-	if (!strncmp(lines[0], "\xEF\xBB\xBF", 3)) lines[0] += 3;
+	if (!strncmp(lines[0], "\xEF\xBB\xBF", 3))
+	{	lines[0] += 3;
+		splist << "\xEF\xBB\xBF";
+	}
 
 	for (unsigned int l = 0; l < lines.size()-1; l++)
 	{	std::string orig_line(lines[l]);

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -35,14 +35,12 @@ while (*fields[2] == '*' || *fields[2] == '+') fields[2]++;
 while (*fields[3] == '*' || *fields[3] == '+') fields[3]++;
 upper(fields[2]);
 upper(fields[3]);
-
 // look for point indices for labels, first in pri_label_hash
 std::unordered_map<std::string,unsigned int>::iterator lit1 = r->pri_label_hash.find(fields[2]);
 std::unordered_map<std::string,unsigned int>::iterator lit2 = r->pri_label_hash.find(fields[3]);
 // and then if not found, in alt_label_hash
 if (lit1 == r->pri_label_hash.end()) lit1 = r->alt_label_hash.find(fields[2]);
 if (lit2 == r->pri_label_hash.end()) lit2 = r->alt_label_hash.find(fields[3]);
-
 // if we did not find matches for both labels...
 if (lit1 == r->alt_label_hash.end() || lit2 == r->alt_label_hash.end())
 {	bool invalid_char = 0;
@@ -78,10 +76,15 @@ if (r->duplicate_labels.find(fields[3]) != r->duplicate_labels.end())
 	    << ". Unable to parse line: " << trim_line << '\n';
 	duplicate = 1;
 }
-if (duplicate) continue;
+if (duplicate)
+{	splist << orig_line << endlines[l];
+	continue;
+}
 // if both labels reference the same waypoint...
 if (lit1->second == lit2->second)
-	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
+{	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
+	splist << orig_line << endlines[l];
+}
 // otherwise both labels are valid; mark in use & proceed
 else {	r->system->lniu_mtx.lock();
 	r->system->listnamesinuse.insert(lookup);


### PR DESCRIPTION
* [UTF-8 byte order mark support](https://github.com/TravelMapping/DataProcessing/issues/215) added in #309 caused the BOM to be omitted from split-region .list files. Fixed.
* .list lines triggering the [duplicate label](https://github.com/TravelMapping/DataProcessing/issues/275) or [Equivalent waypoint labels mark zero distance traveled in line: ](https://github.com/TravelMapping/DataProcessing/issues/278#issuecomment-629478770) user log messages added in #330 were omitted from split-region .list files. Fixed.