### PR TITLE
prevent empty routes from crashing DISCONNECTED_ROUTE datacheck

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem.cpp
@@ -75,6 +75,8 @@ class HighwaySystem
 		if (level_str != "active" && level_str != "preview" && level_str != "devel")
 			el.add_error("Unrecognized level in " + systemsfile + " line: " + line);
 
+		std::cout << systemname << '.' << std::flush;
+
 		// read chopped routes CSV
 		file.open(path+"/"+systemname+".csv");
 		if (!file) el.add_error("Could not open "+path+"/"+systemname+".csv");

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -12,7 +12,7 @@ void Route::read_wpt
 	std::vector<char*> lines;
 	std::ifstream file(filename);
 	if (!file)
-	{	el->add_error("Could not open " + filename);
+	{	el->add_error("[Errno 2] No such file or directory: '" + filename + '\'');
 		file.close();
 		return;
 	}

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -244,7 +244,6 @@ int main(int argc, char *argv[])
 					    // deleted on termination of program
 			if (!hs->is_valid) delete hs;
 			else {	highway_systems.push_back(hs);
-				cout << hs->systemname << '.' << std::flush;
 			     }
 		}
 		cout << endl;
@@ -999,8 +998,7 @@ int main(int argc, char *argv[])
 	}
 	fpfile.close();
 	cout << '!' << endl;
-	cout << et.et() << "Found " << datacheckerrors->entries.size() << " datacheck errors." << endl;
-	cout << et.et() << "Matched " << fpcount << " FP entries." << endl;
+	cout << et.et() << "Found " << datacheckerrors->entries.size() << " datacheck errors and matched " << fpcount << " FP entries." << endl;
 
 	// write log of unmatched false positives from the datacheckfps.csv
 	cout << et.et() << "Writing log of unmatched datacheck FP entries." << endl;

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
 
 		// check for mismatched route endpoints within connected routes
 		#define q r.con_route->roots[r.rootOrder-1]
-		if ( r.rootOrder > 0 && q->point_list.size() > 1 && !r.con_beg()->same_coords(q->con_end()) )
+		if ( r.rootOrder > 0 && q->point_list.size() > 1 && r.point_list.size() > 1 && !r.con_beg()->same_coords(q->con_end()) )
 		{	if ( q->con_beg()->same_coords(r.con_beg()) )
 			{	//std::cout << "DEBUG: marking only " << q->str() << " reversed" << std::endl;
 				//if (q->is_reversed) std::cout << "DEBUG: " << q->str() << " already reversed!" << std::endl;

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1045,6 +1045,7 @@ class Route:
                         self.segment_list.append(HighwaySegment(previous_point, w, self))
             if len(self.point_list) < 2:
                 el.add_error("Route contains fewer than 2 points: " + str(self))
+            print(".", end="",flush=True)
 
     def print_route(self):
         for point in self.point_list:
@@ -2581,7 +2582,7 @@ else:
 
 # Create a list of HighwaySystem objects, one per system in systems.csv file
 highway_systems = []
-print(et.et() + "Reading systems list in " + args.highwaydatapath+"/"+args.systemsfile + ".  ",flush=True)
+print(et.et() + "Reading systems list in " + args.highwaydatapath+"/"+args.systemsfile + ".",flush=True)
 try:
     file = open(args.highwaydatapath+"/"+args.systemsfile, "rt",encoding='utf-8')
 except OSError as e:
@@ -2676,7 +2677,6 @@ def read_wpts_for_highway_system(h):
             all_wpt_files.remove(wpt_path)
         r.read_wpt(all_waypoints,all_waypoints_lock,datacheckerrors,
                    el,args.highwaydatapath+"/hwy_data")
-        print(".", end="",flush=True)
         #print(str(r))
         #r.print_route()
     print("!", flush=True)
@@ -2960,7 +2960,7 @@ for h in highway_systems:
 # Read updates.csv file, just keep in the fields array for now since we're
 # just going to drop this into the DB later anyway
 updates = []
-print(et.et() + "Reading updates file.  ",end="",flush=True)
+print(et.et() + "Reading updates file.",end="",flush=True)
 with open(args.highwaydatapath+"/updates.csv", "rt", encoding='UTF-8') as file:
     lines = file.readlines()
 file.close()
@@ -2998,7 +2998,7 @@ print("")
 # array for now since we're just going to drop this into the DB later
 # anyway
 systemupdates = []
-print(et.et() + "Reading systemupdates file.  ",end="",flush=True)
+print(et.et() + "Reading systemupdates file.",end="",flush=True)
 with open(args.highwaydatapath+"/systemupdates.csv", "rt", encoding='UTF-8') as file:
     lines = file.readlines()
 file.close()
@@ -3997,7 +3997,6 @@ for h in highway_systems:
                     datacheckerrors.append(DatacheckEntry(r,labels,'SHARP_ANGLE',
                                                           "{0:.2f}".format(angle)))
 print("!", flush=True)
-print(et.et() + "Found " + str(len(datacheckerrors)) + " datacheck errors.")
 
 datacheckerrors.sort(key=lambda DatacheckEntry: str(DatacheckEntry))
 
@@ -4005,7 +4004,6 @@ datacheckerrors.sort(key=lambda DatacheckEntry: str(DatacheckEntry))
 print(et.et() + "Marking datacheck false positives.",end="",flush=True)
 fpfile = open(args.logfilepath+'/nearmatchfps.log','w',encoding='utf-8')
 fpfile.write("Log file created at: " + str(datetime.datetime.now()) + "\n")
-toremove = []
 counter = 0
 fpcount = 0
 for d in datacheckerrors:
@@ -4026,7 +4024,7 @@ for d in datacheckerrors:
             fpfile.write("CHANGETO: " + fp[0] + ';' + fp[1] + ';' + fp[2] + ';' + fp[3] + ';' + fp[4] + ';' + d.info + '\n')
 fpfile.close()
 print("!", flush=True)
-print(et.et() + "Matched " + str(fpcount) + " FP entries.", flush=True)
+print(et.et() + "Found " + str(len(datacheckerrors)) + " datacheck errors and matched " + str(fpcount) + " FP entries.", flush=True)
 
 # write log of unmatched false positives from the datacheckfps.csv
 print(et.et() + "Writing log of unmatched datacheck FP entries.", flush=True)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2887,7 +2887,7 @@ for h in highway_systems:
 
         # check for mismatched route endpoints within connected routes
         q = r.con_route.roots[r.rootOrder-1]
-        if r.rootOrder > 0 and len(q.point_list) > 1 and not r.con_beg().same_coords(q.con_end()):
+        if r.rootOrder > 0 and len(q.point_list) > 1 and len(r.point_list) > 1 and not r.con_beg().same_coords(q.con_end()):
             if q.con_beg().same_coords(r.con_beg()):
                 q.is_reversed = True
             elif q.con_end().same_coords(r.con_end()):


### PR DESCRIPTION
Prepping usanyp for activation provided an unexpected stress test.
Forgetting to move files from usasf/ to usanyp/ -> some file not found errors -> Routes with 0 waypoints -> `Route.con_beg()` crashing when it tries to index an empty array.
Fixed.

---
Along for the ride: Some tweaks to how siteupdate.log is written to reduce Python<->C++ diffs.
* Relative position of ErrorList errors & system codes when *Reading systems list*
* When *Reading waypoints for all routes*, don't print a period when a .wpt file is not found
* Report total datacheck errors & marked FPs on same line