### PR TITLE
unused_alt_labels in 6-field lines

### DIFF
--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -145,6 +145,9 @@ r1->system->uarn_mtx.unlock();
 r1->liu_mtx.lock();
 r1->labels_in_use.insert(fields[2]);
 r1->liu_mtx.unlock();
+r1->ual_mtx.lock();
+r1->unused_alt_labels.erase(fields[2]);
+r1->ual_mtx.unlock();
 r2->system->lniu_mtx.lock();
 r2->system->listnamesinuse.insert(lookup2);
 r2->system->lniu_mtx.unlock();
@@ -154,6 +157,9 @@ r2->system->uarn_mtx.unlock();
 r2->liu_mtx.lock();
 r2->labels_in_use.insert(fields[5]);
 r2->liu_mtx.unlock();
+r2->ual_mtx.lock();
+r2->unused_alt_labels.erase(fields[5]);
+r2->ual_mtx.unlock();
 list_entries++;
 // new .list lines for region split-ups
 if (args->splitregion == r1->region->code || args->splitregion == r2->region->code)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1521,9 +1521,11 @@ class TravelerList:
                 r1.system.listnamesinuse.add(lookup1)
                 r1.system.unusedaltroutenames.discard(lookup1)
                 r1.labels_in_use.add(list_label_1)
+                r1.unused_alt_labels.discard(list_label_1)
                 r2.system.listnamesinuse.add(lookup2)
                 r2.system.unusedaltroutenames.discard(lookup2)
                 r2.labels_in_use.add(list_label_2)
+                r2.unused_alt_labels.discard(list_label_2)
                 list_entries += 1
             else:
                 self.log_entries.append("Incorrect format line (4 or 6 fields expected, found " + \


### PR DESCRIPTION
Right now, only master_son is using [AZ US89 I-40BL_E](https://github.com/TravelMapping/UserData/blob/21316c223569201dc0620f05904f32201ed7c494/list_files/master_son.list#L886) or [CO US87 I-25(148B)](https://github.com/TravelMapping/UserData/blob/21316c223569201dc0620f05904f32201ed7c494/list_files/master_son.list#L881), whether in a 4-field or 6-field line, and these labels improperly appear in unusedaltlabels.log
Fixed.