### PR TITLE
userlog rte update alerts: good rtes + bad labels

### DIFF
--- a/siteupdate/cplusplus/.gitignore
+++ b/siteupdate/cplusplus/.gitignore
@@ -2,6 +2,6 @@ graphs
 logs
 nmp_merged
 stats
-
-siteupdate
 TravelMapping.sql
+listupdates.txt
+siteupdate

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -60,6 +60,8 @@ if (lit1 == r->alt_label_hash.end() || lit2 == r->alt_label_hash.end())
 	if (invalid_char) log << " [contains invalid character(s)]";
 	log << '\n';
 	splist << orig_line << endlines[l];
+	if (routes.insert(r).second && r->last_update && update && (*r->last_update)[0] >= *update)
+		log << "Route updated " << (*r->last_update)[0] << ": " << r->readable_name() << '\n';
 	continue;
 }
 // are either of the labels used duplicates?
@@ -78,12 +80,16 @@ if (r->duplicate_labels.find(fields[3]) != r->duplicate_labels.end())
 }
 if (duplicate)
 {	splist << orig_line << endlines[l];
+	if (routes.insert(r).second && r->last_update && update && (*r->last_update)[0] >= *update)
+		log << "Route updated " << (*r->last_update)[0] << ": " << r->readable_name() << '\n';
 	continue;
 }
 // if both labels reference the same waypoint...
 if (lit1->second == lit2->second)
 {	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
 	splist << orig_line << endlines[l];
+	if (routes.insert(r).second && r->last_update && update && (*r->last_update)[0] >= *update)
+		log << "Route updated " << (*r->last_update)[0] << ": " << r->readable_name() << '\n';
 }
 // otherwise both labels are valid; mark in use & proceed
 else {	r->system->lniu_mtx.lock();

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -111,6 +111,8 @@ if (r1 == r2)
 	if (index1 == index2)
 	{	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
 		splist << orig_line << endlines[l];
+		if (routes.insert(r1).second && r1->last_update && update && (*r1->last_update)[0] >= *update)
+			log << "Route updated " << (*r1->last_update)[0] << ": " << r1->readable_name() << '\n';
 		continue;
 	}
 	if (index1 <= index2)

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -41,6 +41,24 @@ Route* r2 = rit2->second;
 if (r1->con_route != r2->con_route)
 {	log << lookup1 << " and " << lookup2 << " not in same connected route in line: " << trim_line << '\n';
 	splist << orig_line << endlines[l];
+	// log updates for routes beginning/ending r1's ConnectedRoute
+	Route* cr = r1->con_route->roots.front();
+	if (routes.insert(cr).second && cr->last_update && update && (*cr->last_update)[0] >= *update)
+		  log << "Route updated " << (*cr->last_update)[0] << ": " << cr->readable_name() << '\n';
+	if (r1->con_route->roots.size() > 1)
+	{	Route* cr = r1->con_route->roots.back();
+		if (routes.insert(cr).second && cr->last_update && update && (*cr->last_update)[0] >= *update)
+		  log << "Route updated " << (*cr->last_update)[0] << ": " << cr->readable_name() << '\n';
+	}
+	// log updates for routes beginning/ending r2's ConnectedRoute
+	cr = r2->con_route->roots.front();
+	if (routes.insert(cr).second && cr->last_update && update && (*cr->last_update)[0] >= *update)
+		  log << "Route updated " << (*cr->last_update)[0] << ": " << cr->readable_name() << '\n';
+	if (r2->con_route->roots.size() > 1)
+	{	Route* cr = r2->con_route->roots.back();
+		if (routes.insert(cr).second && cr->last_update && update && (*cr->last_update)[0] >= *update)
+		  log << "Route updated " << (*cr->last_update)[0] << ": " << cr->readable_name() << '\n';
+	}
 	continue;
 }
 if (r1->system->devel())

--- a/siteupdate/python-teresco/.gitignore
+++ b/siteupdate/python-teresco/.gitignore
@@ -3,3 +3,4 @@ logs
 nmp_merged
 stats
 TravelMapping.sql
+listupdates.txt

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1447,6 +1447,30 @@ class TravelerList:
                     continue
                 if r1.con_route != r2.con_route:
                     self.log_entries.append(lookup1 + " and " + lookup2 + " not in same connected route in line: " + line)
+                    # log updates for routes beginning/ending r1's ConnectedRoute
+                    cr = r1.con_route.roots[0]
+                    if cr not in self.routes:
+                        self.routes.add(cr)
+                        if cr.last_update and self.update and cr.last_update[0] >= self.update:
+                            self.log_entries.append("Route updated " + cr.last_update[0] + ": " + cr.readable_name())
+                        if len(r1.con_route.roots) > 1:
+                            cr = r1.con_route.roots[-1]
+                            if cr not in self.routes:
+                                self.routes.add(cr)
+                                if cr.last_update and self.update and cr.last_update[0] >= self.update:
+                                    self.log_entries.append("Route updated " + cr.last_update[0] + ": " + cr.readable_name())
+                    # log updates for routes beginning/ending r2's ConnectedRoute
+                    cr = r2.con_route.roots[0]
+                    if cr not in self.routes:
+                        self.routes.add(cr)
+                        if cr.last_update and self.update and cr.last_update[0] >= self.update:
+                            self.log_entries.append("Route updated " + cr.last_update[0] + ": " + cr.readable_name())
+                        if len(r2.con_route.roots) > 1:
+                            cr = r2.con_route.roots[-1]
+                            if cr not in self.routes:
+                                self.routes.add(cr)
+                                if cr.last_update and self.update and cr.last_update[0] >= self.update:
+                                    self.log_entries.append("Route updated " + cr.last_update[0] + ": " + cr.readable_name())
                     continue
                 if r1.system.devel():
                     self.log_entries.append("Ignoring line matching highway in system in development: " + line)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1507,6 +1507,10 @@ class TravelerList:
                     # if both labels reference the same waypoint...
                     if index1 == index2:
                         self.log_entries.append("Equivalent waypoint labels mark zero distance traveled in line: " + line)
+                        if r1 not in self.routes:
+                            self.routes.add(r1)
+                            if r1.last_update and self.update and r1.last_update[0] >= self.update:
+                                self.log_entries.append("Route updated " + r1.last_update[0] + ": " + r1.readable_name())
                         continue
                     if index1 <= index2:
                         r1.store_traveled_segments(self, index1, index2)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1361,6 +1361,10 @@ class TravelerList:
                         self.log_entries.append(log_entry)
                     if invchar:
                         self.log_entries[-1] += " [contains invalid character(s)]"
+                    if r not in self.routes:
+                        self.routes.add(r)
+                        if r.last_update and self.update and r.last_update[0] >= self.update:
+                            self.log_entries.append("Route updated " + r.last_update[0] + ": " + r.readable_name())
                     continue
                 # are either of the labels used duplicates?
                 duplicate = False
@@ -1377,10 +1381,18 @@ class TravelerList:
                     self.log_entries.append(log_entry)
                     duplicate = True
                 if duplicate:
+                    if r not in self.routes:
+                        self.routes.add(r)
+                        if r.last_update and self.update and r.last_update[0] >= self.update:
+                            self.log_entries.append("Route updated " + r.last_update[0] + ": " + r.readable_name())
                     continue
                 # if both labels reference the same waypoint...
                 if index1 == index2:
                     self.log_entries.append("Equivalent waypoint labels mark zero distance traveled in line: " + line)
+                    if r not in self.routes:
+                        self.routes.add(r)
+                        if r.last_update and self.update and r.last_update[0] >= self.update:
+                            self.log_entries.append("Route updated " + r.last_update[0] + ": " + r.readable_name())
                 # otherwise both labels are valid; mark in use & proceed
                 else:
                     r.system.listnamesinuse.add(lookup)


### PR DESCRIPTION
Some additions to userlog route update alerts per https://github.com/TravelMapping/DataProcessing/issues/189#issuecomment-738938540

* 4-field lines
  * label(s) not found
  * duplicate label
  * same-point AltLabels (zero-distance)
* 6-field lines
  * [not in same connected route](https://github.com/TravelMapping/DataProcessing/issues/189#issuecomment-740306360)
    (assumes routes were previously connected; reports start/end of ConRte)
  * same-point AltLabels (zero-distance)

Alerts for some 6-field error types are not yet implemented:
* `Waypoint label... not found` and `duplicate label` are the most sensible, and their 4-field counterparts are implemented. These are postponed pending a [potential reorganization of that part of the code](https://forum.travelmapping.net/index.php?topic=3965).
* Reports for `Unknown region/highway combo` might be going a bit overboard...

Don't know what the merge conflict is all about. I'll see what I can see.