### PR TITLE
threaded WaypointQuadtree::sort

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -1,5 +1,11 @@
-MTObjects = siteupdateMT.o classes/GraphGeneration/HighwayGraphMT.o functions/sql_fileMT.o threads/threads.o
-STObjects = siteupdateST.o classes/GraphGeneration/HighwayGraphST.o functions/sql_fileST.o
+MTObjects = siteupdateMT.o functions/sql_fileMT.o threads/threads.o \
+  classes/GraphGeneration/HighwayGraphMT.o \
+  classes/WaypointQuadtree/WaypointQuadtreeMT.o
+
+STObjects = siteupdateST.o functions/sql_fileST.o \
+  classes/GraphGeneration/HighwayGraphST.o \
+  classes/WaypointQuadtree/WaypointQuadtreeST.o
+
 CommonObjects = \
   classes/Arguments/Arguments.o \
   classes/ClinchedDBValues/ClinchedDBValues.o \
@@ -19,7 +25,6 @@ CommonObjects = \
   classes/TravelerList/TravelerList.o \
   classes/Waypoint/Waypoint.o \
   classes/Waypoint/canonical_waypoint_name/canonical_waypoint_name.o \
-  classes/WaypointQuadtree/WaypointQuadtree.o \
   functions/crawl_hwy_data.o \
   functions/double_quotes.o \
   functions/format_clinched_mi.o \

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -29,7 +29,13 @@ class WaypointQuadtree
 	bool is_valid(ErrorList &);
 	unsigned int max_colocated();
 	unsigned int total_nodes();
-	void sort();
 	void get_tmg_lines(std::list<std::string> &, std::list<std::string> &, std::string);
 	void write_qt_tmg(std::string);
+      #ifdef threading_enabled
+	void terminal_nodes(std::forward_list<WaypointQuadtree*>*, size_t&, int&);
+	void sort(int);
+	static void sortnodes(std::forward_list<WaypointQuadtree*>*);
+      #else
+	void sort();
+      #endif
 };

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -243,7 +243,11 @@ int main(int argc, char *argv[])
 	//cout << et.et() << "Writing WaypointQuadtree.tmg." << endl;
 	//all_waypoints.write_qt_tmg(args.logfilepath+"/WaypointQuadtree.tmg");
 	cout << et.et() << "Sorting waypoints in Quadtree." << endl;
+      #ifdef threading_enabled
+	all_waypoints.sort(args.numthreads);
+      #else
 	all_waypoints.sort();
+      #endif
 
 	cout << et.et() << "Finding unprocessed wpt files." << endl;
 	if (all_wpt_files.size())


### PR DESCRIPTION
![MULTI-THREAD ALL THE THINGS](https://camo.githubusercontent.com/a5ff22b2e04dad19ee0d7d859824dac2d34fcce8c61d8f2992dbc477c869bcc9/68747470733a2f2f6d656d6567656e657261746f722e6e65742f696d672f696e7374616e6365732f31343338323037302f6d756c74692d7468726561642d616c6c2d7468652d7468696e67732e6a7067)
![csv](https://user-images.githubusercontent.com/13720877/103467368-60991400-4d1c-11eb-87e3-91469e4fb2f2.png)
A curiosity of these graphs is the slight decrease in efficiency when we first exceed the # of physical cores and start getting into the logical cores. After that, efficiency improves again. Save for that small blip, for the most part, more is better.
* If this effect is present on lab3, it's slight enough to get lost in the noise & quantization of the measurements. 11-13 threads stays at a flat 0.6s. The effect was more visible in an earlier version of the code that used doubly-linked instead of singly-linked lists.
* This doesn't apply to BiggaTomato, which only has physical cores and no Hyper-threading.