### PR TITLE
nmp detection: remove extraneous if

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1031,11 +1031,7 @@ class Route:
                     #    print(str(dbg_w) + " ", end="")
                     #print()
                     if len(nmps) > 0:
-                        if w.near_miss_points is None:
-                            w.near_miss_points = nmps
-                        else:
-                            w.near_miss_points.extend(nmps)
-    
+                        w.near_miss_points = nmps
                         for other_w in nmps:
                             if other_w.near_miss_points is None:
                                 other_w.near_miss_points = [ w ]


### PR DESCRIPTION
We know `w.near_miss_points is None`, because the Waypoint object is newly initialized, and `w.near_miss_points` is set to `None` in the constructor.