### PR TITLE
remove unused HGVertex member variables

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -24,8 +24,6 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
 	first_waypoint = wpt;
 	if (!wpt->colocated)
 	{	if (!wpt->is_hidden) visibility = 2;
-		regions.insert(wpt->route->region);
-		systems.insert(wpt->route->system);
 		wpt->route->region->vertices.insert(this);
 		wpt->route->system->vertices.insert(this);
 		return;
@@ -33,8 +31,6 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
 	for (Waypoint *w : *(wpt->colocated))
 	{	// will consider hidden iff all colocated waypoints are hidden
 		if (!w->is_hidden) visibility = 2;
-		regions.insert(w->route->region);
-		systems.insert(w->route->system);
 		w->route->region->vertices.insert(this);
 		w->route->system->vertices.insert(this);
 	}
@@ -61,6 +57,4 @@ HGVertex::~HGVertex()
 	while (incident_c_edges.size()) delete incident_c_edges.front();
 	delete[] s_vertex_num;
 	delete[] c_vertex_num;
-	regions.clear();
-	systems.clear();
 }

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -15,8 +15,6 @@ class HGVertex
 	const std::string *unique_name;
 	char visibility;
 	Waypoint *first_waypoint;
-	std::unordered_set<Region*> regions;
-	std::unordered_set<HighwaySystem*> systems;
 	std::list<HGEdge*> incident_s_edges; // simple
 	std::list<HGEdge*> incident_c_edges; // collapsed
 	std::list<HGEdge*> incident_t_edges; // traveled

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1696,16 +1696,12 @@ class HGVertex:
         # note: if saving the first waypoint, no longer need
         # lat & lng and can replace with methods
         self.first_waypoint = wpt
-        self.regions = set()
-        self.systems = set()
         self.incident_s_edges = [] # simple
         self.incident_c_edges = [] # collapsed
         self.incident_t_edges = [] # traveled
         if wpt.colocated is None:
             if not wpt.is_hidden:
                 self.visibility = 2
-            self.regions.add(wpt.route.region)
-            self.systems.add(wpt.route.system)
             wpt.route.system.vertices.add(self)
             if wpt.route.region not in rg_vset_hash:
                 rg_vset_hash[wpt.route.region] = set()
@@ -1717,8 +1713,6 @@ class HGVertex:
             # will consider hidden iff all colocated waypoints are hidden
             if not w.is_hidden:
                 self.visibility = 2
-            self.regions.add(w.route.region)
-            self.systems.add(w.route.system)
             if w.route.region not in rg_vset_hash:
                 rg_vset_hash[w.route.region] = set()
                 rg_vset_hash[w.route.region].add(self)


### PR DESCRIPTION
Remove sets populated during vertex construction but never used.
* Saves > 82 MB RAM in C++ version.
* A decent speedup `Creating unique names and vertices`:
  * \>23% C++ on lab2 (4.3s -> 3.48s)
  * \~44% Python on noreaster (17.6s -> 12.2s)