### PR TITLE
C++ subgraph generation speed

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -29,9 +29,9 @@ class HGEdge
 	~HGEdge();
 
 	void detach(unsigned char);
-	std::string label(std::list<HighwaySystem*> *);
-	std::string collapsed_tmg_line(std::list<HighwaySystem*> *, unsigned int);
-	std::string traveled_tmg_line(std::list<HighwaySystem*> *, std::list<TravelerList*> *, unsigned int);
+	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
+	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*);
+	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, std::list<TravelerList*>*);
 	std::string debug_tmg_line(std::list<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -11,7 +11,7 @@ class HGEdge
     edge that can incorporate intermediate points.
     */
 	public:
-	bool s_written, c_written, t_written; // simple, collapsed, traveled
+	bool *s_written, *c_written, *t_written; // simple, collapsed, traveled
 	std::string segment_name;
 	HGVertex *vertex1, *vertex2;
 	std::list<HGVertex*> intermediate_points; // if more than 1, will go from vertex1 to vertex2
@@ -24,8 +24,8 @@ class HGEdge
 	static const unsigned char collapsed = 2;
 	static const unsigned char traveled = 4;
 
-	HGEdge(HighwaySegment *, HighwayGraph *);
-	HGEdge(HGVertex *, unsigned char);
+	HGEdge(HighwaySegment *, HighwayGraph *, int);
+	HGEdge(HGVertex *, unsigned char, int);
 	~HGEdge();
 
 	void detach(unsigned char);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -55,6 +55,8 @@ HGVertex::~HGVertex()
 {	//std::cout << "deleting vertex at " << first_waypoint->str() << std::endl;
 	while (incident_s_edges.size()) delete incident_s_edges.front();
 	while (incident_c_edges.size()) delete incident_c_edges.front();
+	while (incident_t_edges.size()) delete incident_t_edges.front();
 	delete[] s_vertex_num;
 	delete[] c_vertex_num;
+	delete[] t_vertex_num;
 }

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -293,22 +293,25 @@ void HighwayGraph::write_master_graphs_tmg(std::vector<GraphListEntry> &graph_ve
 	{	for (HGEdge *e : wv.second->incident_s_edges)
 		  if (!e->s_written)
 		  {	e->s_written = 1;
-			simplefile << e->vertex1->s_vertex_num[0] << ' ' << e->vertex2->s_vertex_num[0] << ' ' << e->label(0) << '\n';
+			simplefile << e->vertex1->s_vertex_num[0] << ' ' << e->vertex2->s_vertex_num[0] << ' ';
+			e->write_label(simplefile, 0);
+			simplefile << '\n';
 		  }
 		// write edges if vertex is visible...
 		if (wv.second->visibility >= 1)
-		{	// in traveled graph,
+		{	char fstr[57];
+			// in traveled graph,
 			for (HGEdge *e : wv.second->incident_t_edges)
 			  if (!e->t_written)
 			  {	e->t_written = 1;
-				travelfile << e->traveled_tmg_line(0, &traveler_lists, 0) << '\n';
+				e->traveled_tmg_line(travelfile, fstr, 0, 0, &traveler_lists);
 			  }
 			if (wv.second->visibility == 2)
 			{	// and in collapsed graph
 				for (HGEdge *e : wv.second->incident_c_edges)
 				  if (!e->c_written)
 				  {	e->c_written = 1;
-					collapfile << e->collapsed_tmg_line(0, 0) << '\n';
+					e->collapsed_tmg_line(collapfile, fstr, 0, 0);
 				  }
 			}
 		}
@@ -391,13 +394,16 @@ void HighwayGraph::write_subgraphs_tmg
 	}
 	// write edges
 	for (HGEdge *e : mse)
-		simplefile << e->vertex1->s_vertex_num[threadnum] << ' '
-			   << e->vertex2->s_vertex_num[threadnum] << ' '
-			   << e->label(graph_vector[graphnum].systems) << '\n';
+	{	simplefile << e->vertex1->s_vertex_num[threadnum] << ' '
+			   << e->vertex2->s_vertex_num[threadnum] << ' ';
+		e->write_label(simplefile, graph_vector[graphnum].systems);
+		simplefile << '\n';
+	}
+	char fstr[57];
 	for (HGEdge *e : mce)
-		collapfile << e->collapsed_tmg_line(graph_vector[graphnum].systems, threadnum) << '\n';
+		e->collapsed_tmg_line(collapfile, fstr, threadnum, graph_vector[graphnum].systems);
 	for (HGEdge *e : mte)
-		travelfile << e->traveled_tmg_line(graph_vector[graphnum].systems, &traveler_lists, threadnum) << '\n';
+		e->traveled_tmg_line(travelfile, fstr, threadnum, graph_vector[graphnum].systems, &traveler_lists);
 	// traveler names
 	for (TravelerList *t : traveler_lists)
 		travelfile << t->traveler_name << ' ';

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -186,7 +186,7 @@ inline void HighwayGraph::matching_vertices_and_edges
 	else if (g.placeradius)
 		mvset = pvset;
 	else	// no restrictions via region, system, or placeradius, so include everything
-		for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
+		for (std::pair<Waypoint* const, HGVertex*>& wv : vertices)
 		  mvset.insert(wv.second);
 
 	// initialize *_written booleans
@@ -284,7 +284,7 @@ void HighwayGraph::write_master_graphs_tmg(std::vector<GraphListEntry> &graph_ve
 	unsigned int sv = 0;
 	unsigned int cv = 0;
 	unsigned int tv = 0;
-	for (std::pair<Waypoint* const, HGVertex*> wv : vertices)
+	for (std::pair<Waypoint* const, HGVertex*>& wv : vertices)
 	{	char fstr[57];
 		sprintf(fstr, " %.15g %.15g", wv.second->lat, wv.second->lng);
 		// all vertices for simple graph
@@ -306,7 +306,7 @@ void HighwayGraph::write_master_graphs_tmg(std::vector<GraphListEntry> &graph_ve
 		}
 	}
 	// now edges, only write if not already written
-	for (std::pair<const Waypoint*, HGVertex*> wv : vertices)
+	for (std::pair<Waypoint* const, HGVertex*>& wv : vertices)
 	{	for (HGEdge *e : wv.second->incident_s_edges)
 		  if (!e->s_written[0])
 		  {	e->s_written[0] = 1;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -42,7 +42,7 @@ class HighwayGraph
 		std::unordered_set<HGEdge*>&,	// matching    simple edges
 		std::unordered_set<HGEdge*>&,	// matching collapsed edges
 		std::unordered_set<HGEdge*>&,	// matching  traveled edges
-		unsigned int&, unsigned int&
+		int, unsigned int&, unsigned int&
 	);
 
 	void write_master_graphs_tmg(std::vector<GraphListEntry>&, std::string, std::list<TravelerList*>&);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -39,9 +39,9 @@ class HighwayGraph
 	(	GraphListEntry&, WaypointQuadtree*,
 		std::list<TravelerList*> &,
 		std::unordered_set<HGVertex*>&,	// final set of vertices matching all criteria
-		std::unordered_set<HGEdge*>&,	// matching    simple edges
-		std::unordered_set<HGEdge*>&,	// matching collapsed edges
-		std::unordered_set<HGEdge*>&,	// matching  traveled edges
+		std::list<HGEdge*>&,		// matching    simple edges
+		std::list<HGEdge*>&,		// matching collapsed edges
+		std::list<HGEdge*>&,		// matching  traveled edges
 		int, unsigned int&, unsigned int&
 	);
 

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -18,8 +18,10 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 	preview_systems_traveled = 0;
 	preview_systems_clinched = 0;
 	unsigned int list_entries = 0;
+	in_subgraph = new bool[args->numthreads];
 	traveler_num = new unsigned int[args->numthreads];
 		       // deleted on termination of program
+	for (size_t i = 0; i < args->numthreads; i++) in_subgraph[i] = 0;
 	traveler_name = travname.substr(0, travname.size()-5); // strip ".list" from end of travname
 	if (traveler_name.size() > DBFieldLength::traveler)
 	  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -30,6 +30,7 @@ class TravelerList
 	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only
 	std::unordered_map<HighwaySystem*, std::unordered_map<Region*, double>> system_region_mileages;	// mileage per region per system
 	std::unordered_set<Route*> routes;
+	bool* in_subgraph;
 	unsigned int *traveler_num;
 	unsigned int active_systems_traveled;
 	unsigned int active_systems_clinched;


### PR DESCRIPTION
Closes yakra#127.
Closes yakra#147.

### Memory bandwidth
We can avoid a lot of expensive string construction, reconstruction, and memory copies by just writing the individual components of a .tmg edge line directly to the file, rather than concatenating them together into one big long std::string. This principle extends to edge labels as well, though the effects aren't as visible.
This provides a modest boost in performance at any number of threads, 5-10% range. The benefit is more pronounced when combined with...

### Raw speed solutions
This is where things get interesting.
* **Edges:** Having `HighwayGraph::matching_vertices_and_edges` compute *sets* of matching edges is overkill. Instead, store edges as a *list*, and avoid adding edges > once by using the `*_written` bools already used in master graphs; this works for subgraphs too.
* **Travelers:** Same idea when finding travelers for each graph.
* **Vertices:** We can also do this when combining vertex lists in multiregion  & multisystem graphs. However, it breaks the implemented-but-unused code for [full custom graphs](https://github.com/TravelMapping/DataProcessing/issues/401), forcing us to find a new solution.

Put all of these together, and *whoa mama.* 70% improvement @ 1 thread on most lab machines. 98% on BiggaTomato. Improvements of ~40-60% are common even up to ~4-6 threads.
* However: This all requires more memory bandwidth. (Without the memory bandwidth solution above, all these changes together perform worse than no-build @ 9+ threads on lab3.) We start hitting a RAM bottleneck, with more muted performance improvements beyond ~7 threads.
* Compromise: We can trade off some raw speed for some more RAM efficiency, allowing the algorithm to more gracefully scale to a larger number of threads. Thus we get higher overall efficiency, less wall time, at a higher number of threads.
* Convert over any 1 or 2 of vertices/edges/travelers, whatever produces the best results.

---

![Subg_RE-2](https://user-images.githubusercontent.com/13720877/105646240-dcdecd00-5e6c-11eb-81b1-bdf7df222757.gif)
The selected alternative is **etF3**, the dark purple line. It scales well to a large number of threads, hitting lab2's sweet spot at 7-8, and doesn't break [full custom graph](https://github.com/TravelMapping/DataProcessing/issues/401) support, leaving our options open in the future.

---

![Subg_RE-3](https://user-images.githubusercontent.com/13720877/105646465-1d8b1600-5e6e-11eb-9293-5f427fe34ead.gif)
Lab3 has the least memory bandwidth divided by the most cores. Compare how the different alternatives stack up at 2, 3 or 5 threads vs. how they stack up at 15 or 18.

---

![Subg_RE-4](https://user-images.githubusercontent.com/13720877/105646570-a1450280-5e6e-11eb-9607-7cab7e726f99.gif)
Newcomer lab4 has the same hardware as lab3, running Ubuntu instead of CentOS. Ubuntu works more efficiently at a higher # of threads.

---

![Subg](https://user-images.githubusercontent.com/13720877/105646831-1107bd00-5e70-11eb-9e5c-7d22c1cbe583.gif)
Finally, a traditional wall time chart of the selected alternative vs. the old version.