### PR TITLE
fix obscure concurrencies.log diffs

### DIFF
--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -327,7 +327,7 @@ void Waypoint::duplicate_coords(std::unordered_set<Waypoint*> &coords_used, char
 {	// duplicate coordinates
 	Waypoint *w;
 	if (!colocated) w = this;
-	else w = colocated->back();
+	else w = colocated->front();
 	if (!coords_used.insert(w).second)
 	  for (Waypoint *other_w : route->point_list)
 	  {	if (this == other_w) break;

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -56,13 +56,13 @@ void WaypointQuadtree::insert(Waypoint *w, bool init)
 				if (!other_w->colocated)
 				{	other_w->colocated = new std::list<Waypoint*>;
 							     // deleted on termination of program
-					other_w->colocated->push_front(other_w);
+					other_w->colocated->push_back(other_w);
 				}
-				other_w->colocated->push_front(w);
+				other_w->colocated->push_back(w);
 				w->colocated = other_w->colocated;
 			}
 		}
-		if (!w->colocated || w == w->colocated->back())
+		if (!w->colocated || w == w->colocated->front())
 		{	//std::cout << "QTDEBUG: " << str() << " at " << unique_locations << " unique locations" << std::endl;
 			unique_locations++;
 		}


### PR DESCRIPTION
closes https://github.com/yakra/DataProcessing/issues/151
lists populated in reverse order + stable sort + [another US19TrkPit + a DUPLICATE_LABEL](https://travelmapping.net/hb/showroute.php?r=ausvic.td098&lat=-38.249657&lon=146.55118&zoom=14) = wacky antics.
