### PR TITLE
HgVertex cleanup/speedup; LABEL_INVALID_CHAR fixes

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -19,9 +19,6 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
 	    // 0: never visible outside of simple graphs
 	    // 1: visible only in traveled graph; hidden in collapsed graph
 	    // 2: visible in both traveled & collapsed graphs
-	// note: if saving the first waypoint, no longer need
-	// lat & lng and can replace with methods
-	first_waypoint = wpt;
 	if (!wpt->colocated)
 	{	if (!wpt->is_hidden) visibility = 2;
 		wpt->route->region->vertices.insert(this);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -14,7 +14,6 @@ class HGVertex
 	double lat, lng;
 	const std::string *unique_name;
 	char visibility;
-	Waypoint *first_waypoint;
 	std::list<HGEdge*> incident_s_edges; // simple
 	std::list<HGEdge*> incident_c_edges; // collapsed
 	std::list<HGEdge*> incident_t_edges; // traveled

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -346,7 +346,11 @@ void Waypoint::label_invalid_char()
 		if ((*c == 42 || *c == 43) && c > label.data()
 		 || (*c < 40)	|| (*c == 44)	|| (*c > 57 && *c < 65)
 		 || (*c == 96)	|| (*c > 122)	|| (*c > 90 && *c < 95))
-		  Datacheck::add(route, label, "", "", "LABEL_INVALID_CHAR", "");
+		{	if (!strncmp(label.data(), "\xEF\xBB\xBF", 3))
+				Datacheck::add(route, label, "", "", "LABEL_INVALID_CHAR", "UTF-8 BOM");
+			else	Datacheck::add(route, label, "", "", "LABEL_INVALID_CHAR", "");
+			break;
+		}
 	for (std::string& lbl : alt_labels)
 	  if (lbl == "*")
 		  Datacheck::add(route, lbl, "", "", "LABEL_INVALID_CHAR", "");
@@ -354,7 +358,9 @@ void Waypoint::label_invalid_char()
 		if (*c == '+' && c > lbl.data() || *c == '*' && (c > lbl.data()+1 || lbl[0] != '+')
 		 || (*c < 40)	|| (*c == 44)	|| (*c > 57 && *c < 65)
 		 || (*c == 96)	|| (*c > 122)	|| (*c > 90 && *c < 95))
-		  Datacheck::add(route, lbl, "", "", "LABEL_INVALID_CHAR", "");
+		{	Datacheck::add(route, lbl, "", "", "LABEL_INVALID_CHAR", "");
+			break;
+		}
 }
 
 bool Waypoint::label_too_long()

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -1,10 +1,10 @@
 // Tab Width = 8
 
-// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2020
+// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2021
 /* Code to read .csv and .wpt files and prepare for
 adding to the Travel Mapping Project database.
 
-(c) 2015-2020, Jim Teresco and Eric Bryant
+(c) 2015-2021, Jim Teresco and Eric Bryant
 Original Python version by Jim Teresco, with contributions from Eric Bryant and the TravelMapping team
 C++ translation by Eric Bryant
 

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2135,7 +2135,7 @@ class HighwayGraph:
         # compress edges adjacent to hidden vertices
         counter = 0
         print("!\n" + et.et() + "Compressing collapsed edges", end="", flush=True)
-        for label, v in self.vertices.items():
+        for w, v in self.vertices.items():
             if counter % 10000 == 0:
                 print('.', end="", flush=True)
             counter += 1
@@ -2146,8 +2146,7 @@ class HighwayGraph:
                     continue
                 # if >2 edges, flag HIDDEN_JUNCTION, mark as visible, and do not compress
                 if len(v.incident_c_edges) > 2:
-                    datacheckerrors.append(DatacheckEntry(v.first_waypoint.colocated[0].route,
-                                           [v.first_waypoint.colocated[0].label],
+                    datacheckerrors.append(DatacheckEntry(w.colocated[0].route,[w.colocated[0].label],
                                            "HIDDEN_JUNCTION",str(len(v.incident_c_edges))))
                     v.visibility = 2
                     continue

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2307,19 +2307,20 @@ class HighwayGraph:
         cv = 0
         tv = 0
         for v in self.vertices.values():
+            vstr = v.unique_name+' '+str(v.lat)+' '+str(v.lng)+'\n'
             # all vertices for simple graph
-            simplefile.write(v.unique_name+' '+str(v.lat)+' '+str(v.lng)+'\n')
+            simplefile.write(vstr)
             v.s_vertex_num = sv
             sv += 1
             # visible vertices...
             if v.visibility >= 1:
                 # for traveled graph,
-                travelfile.write(v.unique_name+' '+str(v.lat)+' '+str(v.lng)+'\n')
+                travelfile.write(vstr)
                 v.t_vertex_num = tv
                 tv += 1
                 if v.visibility == 2:
                     # and for collapsed graph
-                    collapfile.write(v.unique_name+' '+str(v.lat)+' '+str(v.lng)+'\n')
+                    collapfile.write(vstr)
                     v.c_vertex_num = cv
                     cv += 1
         # now edges, only write if not already written
@@ -2391,19 +2392,20 @@ class HighwayGraph:
         cv = 0
         tv = 0
         for v in mv:
+            vstr = v.unique_name + ' ' + str(v.lat) + ' ' + str(v.lng) + '\n'
             # all vertices, for simple graph
-            simplefile.write(v.unique_name + ' ' + str(v.lat) + ' ' + str(v.lng) + '\n')
+            simplefile.write(vstr)
             v.s_vertex_num = sv
             sv += 1
             # visible vertices
             if v.visibility >= 1:
                 # for traveled graph
-                travelfile.write(v.unique_name + ' ' + str(v.lat) + ' ' + str(v.lng) + '\n')
+                travelfile.write(vstr)
                 v.t_vertex_num = tv
                 tv += 1
                 if v.visibility == 2:
                     # for collapsed graph
-                    collapfile.write(v.unique_name + ' ' + str(v.lat) + ' ' + str(v.lng) + '\n')
+                    collapfile.write(vstr)
                     v.c_vertex_num = cv
                     cv += 1
         # write edges

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1689,9 +1689,6 @@ class HGVertex:
             # 0: never visible outside of simple graphs
             # 1: visible only in traveled graph; hidden in collapsed graph
             # 2: visible in both traveled & collapsed graphs
-        # note: if saving the first waypoint, no longer need
-        # lat & lng and can replace with methods
-        self.first_waypoint = wpt
         self.incident_s_edges = [] # simple
         self.incident_c_edges = [] # collapsed
         self.incident_t_edges = [] # traveled

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Travel Mapping Project, Jim Teresco, 2015-2020
+# Travel Mapping Project, Jim Teresco, 2015-2021
 """Python code to read .csv and .wpt files and prepare for
 adding to the Travel Mapping Project database.
 
-(c) 2015-2020, Jim Teresco, Eric Bryant, and Travel Mapping Project contributors
+(c) 2015-2021, Jim Teresco, Eric Bryant, and Travel Mapping Project contributors
 
 This module defines classes to represent the contents of a
 .csv file that lists the highways within a system, and a
@@ -3916,7 +3916,10 @@ for h in highway_systems:
 
             # look for labels with invalid characters
             if not re.fullmatch('\+?\*?[a-zA-Z0-9()/_\-\.]+', w.label):
-                datacheckerrors.append(DatacheckEntry(r,[w.label],'LABEL_INVALID_CHAR'))
+                if w.label.encode('utf-8')[0:3] == b'\xef\xbb\xbf':
+                    datacheckerrors.append(DatacheckEntry(r,[w.label],'LABEL_INVALID_CHAR', "UTF-8 BOM"))
+                else:
+                    datacheckerrors.append(DatacheckEntry(r,[w.label],'LABEL_INVALID_CHAR'))
             for a in w.alt_labels:
                 if not re.fullmatch('\+?\*?[a-zA-Z0-9()/_\-\.]+', a):
                     datacheckerrors.append(DatacheckEntry(r,[a],'LABEL_INVALID_CHAR'))


### PR DESCRIPTION
* closes yakra#107
  * 3f938cbc0339c9ddf9bd101efd1c3dfa3a36ce9a cleans up vertex iteration. Dict keys are Waypoint objects rather than vertex labels now, and can be used for the HIDDEN_JUNCTION datacheck rather than the vestigial `first_waypoint` variable.
  * A [longstanding comment](https://github.com/TravelMapping/DataProcessing/blob/79bf1cda27cedb02d1d04408100af38fc2676743/siteupdate/python-teresco/siteupdate.py#L1692-L1693) notes that we can remove either `lat` & `lng` or `first_waypoint` from HGVertex, but not both. 315f834302e66636c5002678cba8262cb53ec2c0 removes `first_waypoint`. This option takes up about 4 MB more RAM, but the other option is slightly slower and requires minor changes to `PlaceRadius`.
* closes yakra#153
  * ac65bc389b28c48eaef53554ec494872d2165888 constructs & stores .tmg vertex line strings only once, retrieving them to write to all 3 graph files. This saves a surprising amount of time, subgraphs down to 67.23 s from 74.77 s on lab1. Python string construction gets pretty expensive what with interning, automatic hashing, etc.
* closes https://github.com/TravelMapping/HighwayData/issues/4561
  * b155944c33c1b5b4470bf1b1b16a42a54fff79ea flags LABEL_INVALID_CHAR only once per waypoint label, and notes cases caused by a UTF-8 BOM.
  * See also: https://github.com/TravelMapping/Web/pull/630