### PR TITLE
VISIBLE_HIDDEN_COLOC for devel systems

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -32,21 +32,6 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
 		w->route->region->insert_vertex(this);
 		w->route->system->insert_vertex(this);
 	}
-	// VISIBLE_HIDDEN_COLOC datacheck
-	std::list<Waypoint*>::iterator p = wpt->colocated->begin();
-	for (p++; p != wpt->colocated->end(); p++)
-	  if ((*p)->is_hidden != wpt->colocated->front()->is_hidden)
-	  {	// determine which route, label, and info to use for this entry asciibetically
-		std::list<Waypoint*> vis_list;
-		std::list<Waypoint*> hid_list;
-		for (Waypoint *w : *(wpt->colocated))
-		  if (w->is_hidden)
-			hid_list.push_back(w);
-		  else	vis_list.push_back(w);
-		Datacheck::add(vis_list.front()->route, vis_list.front()->label, "", "", "VISIBLE_HIDDEN_COLOC",
-			       hid_list.front()->route->root+"@"+hid_list.front()->label);
-		break;
-	  }
 }
 
 HGVertex::~HGVertex()

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -233,11 +233,22 @@ class WaypointQuadtree:
             self.sw_child.graph_points(hi_priority_points, lo_priority_points)
         else:
             for w in self.points:
+                if  w.colocated is not None:
+                    # skip if not at front of list
+                    if w != w.colocated[0]:
+                        continue
+                    # VISIBLE_HIDDEN_COLOC datacheck
+                    for p in w.colocated[1:]:
+                        if p.is_hidden != w.colocated[0].is_hidden:
+                            if p.is_hidden:
+                                datacheckerrors.append(DatacheckEntry(w.route,[w.label],"VISIBLE_HIDDEN_COLOC",
+                                                                      p.route.root+"@"+p.label))
+                            else:
+                                datacheckerrors.append(DatacheckEntry(p.route,[p.label],"VISIBLE_HIDDEN_COLOC",
+                                                                      w.route.root+"@"+w.label))
+                            break;
                 # skip if this point is occupied by only waypoints in devel systems
                 if not w.is_or_colocated_with_active_or_preview():
-                    continue
-                # skip if colocated and not at front of list
-                if  w.colocated is not None and w != w.colocated[0]:
                     continue
                 # store a colocated list with any devel system entries removed
                 if w.colocated is None:
@@ -1745,20 +1756,6 @@ class HGVertex:
             else:
                 rg_vset_hash[w.route.region].add(self)
             w.route.system.vertices.add(self)
-        # VISIBLE_HIDDEN_COLOC datacheck
-        for p in range(1, len(wpt.colocated)):
-            if wpt.colocated[p].is_hidden != wpt.colocated[0].is_hidden:
-                # determine which route, label, and info to use for this entry asciibetically
-                vis_list = []
-                hid_list = []
-                for w in wpt.colocated:
-                    if w.is_hidden:
-                        hid_list.append(w)
-                    else:
-                        vis_list.append(w)
-                datacheckerrors.append(DatacheckEntry(vis_list[0].route,[vis_list[0].label],"VISIBLE_HIDDEN_COLOC",
-                                                      hid_list[0].route.root+"@"+hid_list[0].label))
-                break;
 
     # printable string
     def __str__(self):


### PR DESCRIPTION
1st of 2 ToDo items for #433.
Refactors the VISIBLE_HIDDEN_COLOC datacheck to detect cases involving only devel systems.
In the process, cuts out some dead weight that's not been relevant a long time.

C++
Moved to a single-threaded part of the HighwayGraph ctor from a part that *can be* multi-threaded, but runs single-threaded by default. No big loss; `Setting up for graphs of highway data` takes 0.058s longer. :P