### PR TITLE
Exit/Intersection & Exit_number enhancements

### DIFF
--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit-intersection.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit-intersection.cpp
@@ -54,7 +54,9 @@ for (Waypoint* match : ap_coloc)
 		if (match->label[0] >= '0' && match->label[0] <= '9')
 			newname +=  '(' + match->label + ')';
 		for (unsigned int add_index = 0; add_index < ap_coloc.size(); add_index++)
-		{	if (match == ap_coloc[add_index]) continue;
+		{	if (match == ap_coloc[add_index]
+			 || (add_index && ap_coloc[add_index]->route == ap_coloc[add_index-1]->route)
+			   ) continue;
 			newname += '/' + ap_coloc[add_index]->route->list_entry_name();
 		}
 		g->namelog("Exit/Intersection: " + name + " -> " + newname);

--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit-intersection.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit-intersection.cpp
@@ -12,25 +12,49 @@
 // becomes
 // US20/NY30A/NY162
 
-for (unsigned int match_index = 0; match_index < ap_coloc.size(); match_index++)
-{	std::string lookfor1 = ap_coloc[match_index]->route->list_entry_name();
-	std::string lookfor2 = ap_coloc[match_index]->route->list_entry_name() + '(' + ap_coloc[match_index]->label + ')';
+for (Waypoint* match : ap_coloc)
+{	std::string no_abbrev = match->route->name_no_abbrev();
+	size_t list_name_size = no_abbrev.size()+match->route->abbrev.size();
 	bool all_match = 1;
-	for (unsigned int check_index = 0; check_index < ap_coloc.size(); check_index++)
-	{	if (match_index == check_index) continue;
-		if ((ap_coloc[check_index]->label != lookfor1)
-		&&  (ap_coloc[check_index]->label != lookfor2))
-		{	all_match = 0;
-			break;
-		}
+	for (Waypoint* check : ap_coloc)
+	{	if (check == match) continue;
+
+		// if name_no_abbrev() matches, check for...
+		if ( !strncmp(check->label.data(),
+			      no_abbrev.data(),
+			      no_abbrev.size())
+		   ) {	if (	check->label[no_abbrev.size()] == 0	// no_abbrev match
+			   )	continue;
+			if (	check->label[no_abbrev.size()] == '('
+			     && !strncmp(check->label.data()+no_abbrev.size()+1,
+					 match->label.data(),
+					 match->label.size())
+			     && check->label[no_abbrev.size()+match->label.size()+1] == ')'
+			   )	continue;				// match with exit number in parens
+
+			// if abbrev matches, check for...
+			if ( !strncmp(check->label.data()+no_abbrev.size(),
+				      match->route->abbrev.data(),
+				      match->route->abbrev.size())
+			   ) {	if (	check->label[list_name_size] == 0	// full match with abbrev field
+				   )	continue;
+				if (	check->label[list_name_size] == '('
+				     && !strncmp(check->label.data()+list_name_size+1,
+						 match->label.data(),
+						 match->label.size())
+				     && check->label[list_name_size+match->label.size()+1] == ')'
+				   )	continue;				// match with exit number in parens
+			     }
+		     }
+		all_match = 0;
+		break;
 	}
 	if (all_match)
-	{	std::string newname;
-		if (ap_coloc[match_index]->label[0] >= '0' && ap_coloc[match_index]->label[0] <= '9')
-			newname = lookfor2;
-		else	newname = lookfor1;
+	{	std::string newname(match->route->list_entry_name());
+		if (match->label[0] >= '0' && match->label[0] <= '9')
+			newname +=  '(' + match->label + ')';
 		for (unsigned int add_index = 0; add_index < ap_coloc.size(); add_index++)
-		{	if (match_index == add_index) continue;
+		{	if (match == ap_coloc[add_index]) continue;
 			newname += '/' + ap_coloc[add_index]->route->list_entry_name();
 		}
 		g->namelog("Exit/Intersection: " + name + " -> " + newname);

--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit_number.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit_number.cpp
@@ -34,7 +34,7 @@ for (Waypoint* exit : ap_coloc)
 	{	if (exit == match) continue;
 		// check for any of the patterns that make sense as a match:
 
-		// if label_no_abbrev() matches, check for...
+		// if name_no_abbrev() matches, check for...
 		if ( !strncmp(match->label.data(),
 			      no_abbrev.data(),
 			      no_abbrev.size())

--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit_number.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/exit_number.cpp
@@ -74,14 +74,11 @@ for (Waypoint* exit : ap_coloc)
 		}
 	}
 	if (all_match)
-	{	std::string newname;
+	{	std::string newname(exit->route->list_entry_name() + '(' + exit->label + ')');
 		for (unsigned int pos = 0; pos < ap_coloc.size(); pos++)
-		{	if (ap_coloc[pos] == exit)
-				newname += ap_coloc[pos]->route->list_entry_name() + '(' + ap_coloc[pos]->label + ')';
-			else	newname += ap_coloc[pos]->route->list_entry_name();
-			newname += '/';
+		{	if (ap_coloc[pos] != exit)
+				newname += '/' + ap_coloc[pos]->route->list_entry_name();
 		}
-		newname.pop_back();
 		g->namelog("Exit_number: " + name + " -> " + newname);
 		return newname;
 	}

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -596,7 +596,8 @@ class Waypoint:
                 if (match.label[0].isnumeric()):
                     label += "(" + match.label + ")"
                 for add_index in range(0,len(self.ap_coloc)):
-                    if match == self.ap_coloc[add_index]:
+                    if match == self.ap_coloc[add_index] \
+                    or (add_index and self.ap_coloc[add_index].route == self.ap_coloc[add_index-1].route):
                         continue
                     label += '/' + self.ap_coloc[add_index].route.list_entry_name()
                 log.append("Exit/Intersection: " + name + " -> " + label)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -707,13 +707,10 @@ class Waypoint:
                     all_match = False
                     break
             if all_match:
-                label = ""
+                label = exit.route.list_entry_name() + '(' + exit.label + ')'
                 for pos in range(len(self.ap_coloc)):
-                    label += self.ap_coloc[pos].route.list_entry_name()
-                    if self.ap_coloc[pos] == exit:
-                        label += "(" + self.ap_coloc[pos].label + ")"
-                    if pos < len(self.ap_coloc) - 1:
-                        label += "/"
+                    if self.ap_coloc[pos] != exit:
+                        label += "/" + self.ap_coloc[pos].route.list_entry_name()
                 log.append("Exit_number: " + name + " -> " + label)
                 return label
 


### PR DESCRIPTION
## 3bf54bdc7c29f93fa69087aa8b93505fd50d7f48 & 43c127a5a2fa0418e68a61c7e37ab62573346646: name_no_abbrev checks for Exit/Intersection

• Simplify 196 add'l labels from Keep_failsafe.
• Save a few bytes on 18 more.

Quote from https://github.com/TravelMapping/DataProcessing/issues/421#issuecomment-860153634
> > The Exit/Intersection CWN routine checks for list_entry_name() but not name_no_abbrev().
> 
> HighwayData @ 8ff82de099da29963190be37677060b775d8c6cc
> 
> **1053 new Exit/Intersection simplifications**
> * **469** formerly 3+_intersection
>   * 133 exact same label
>   * 318 with same slashed components in different order
>   * 18 with same slashed components minus any directional or city _suffixes
> * **388** formerly Exit_number
>   * 310 exact same label
>   * 78 with same slashed components in different order
> * **196** formerly Keep_failsafe
>   * 108 with French departmental "banners"
>   * 88 things that fall into the categories [above](https://github.com/TravelMapping/DataProcessing/issues/421#issuecomment-860134598), IBNLT genuine HighwayData errors.