### PR TITLE
threaded stats CSVs / breaking the 30s barrier

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -1,10 +1,14 @@
 MTObjects = siteupdateMT.o functions/sql_fileMT.o threads/threads.o \
   classes/GraphGeneration/HighwayGraphMT.o \
-  classes/WaypointQuadtree/WaypointQuadtreeMT.o
+  classes/WaypointQuadtree/WaypointQuadtreeMT.o \
+  functions/allbyregionactiveonlyMT.o \
+  functions/allbyregionactivepreviewMT.o
 
 STObjects = siteupdateST.o functions/sql_fileST.o \
   classes/GraphGeneration/HighwayGraphST.o \
-  classes/WaypointQuadtree/WaypointQuadtreeST.o
+  classes/WaypointQuadtree/WaypointQuadtreeST.o \
+  functions/allbyregionactiveonlyST.o \
+  functions/allbyregionactivepreviewST.o
 
 CommonObjects = \
   classes/Args/Args.o \

--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -6,6 +6,7 @@
 /* e */ bool Args::errorcheck = 0;
 /* k */ bool Args::skipgraphs = 0;
 /* v */ bool Args::mtvertices = 0;
+/* C */ bool Args::stcsvfiles = 0;
 /* w */ std::string Args::highwaydatapath = "../../../HighwayData";
 /* s */ std::string Args::systemsfile = "systems.csv";
 /* u */ std::string Args::userlistfilepath = "../../../UserData/list_files";
@@ -29,6 +30,7 @@ bool Args::init(int argc, char *argv[])
 	{	     if ARG(0, "-e", "--errorcheck")		 errorcheck = 1;
 		else if ARG(0, "-k", "--skipgraphs")		 skipgraphs = 1;
 		else if ARG(0, "-v", "--mt-vertices")		 mtvertices = 1;
+		else if ARG(0, "-C", "--st-csvs")		 stcsvfiles = 1;
 		else if ARG(0, "-h", "--help")			{show_help(); return 1;}
 		else if ARG(1, "-w", "--highwaydatapath")	{highwaydatapath  = argv[n+1]; n++;}
 		else if ARG(1, "-s", "--systemsfile")		{systemsfile      = argv[n+1]; n++;}
@@ -112,4 +114,5 @@ void Args::show_help()
 	std::cout  <<  "		        Number of digits (1-9) after decimal point in\n";
 	std::cout  <<  "		        timestamp readouts\n";
 	std::cout  <<  "  -v, --mt-vertices     Use multi-threaded vertex construction\n";
+	std::cout  <<  "  -C, --st-csvs         Disable multi-threaded stats csv files for systems with low memory bandwidth.\n";
 }

--- a/siteupdate/cplusplus/classes/Args/Args.h
+++ b/siteupdate/cplusplus/classes/Args/Args.h
@@ -18,6 +18,7 @@ class Args
 	/* e */ static bool errorcheck;
 	/* T */ static int timeprecision;
 	/* v */ static bool mtvertices;
+	/* C */ static bool stcsvfiles;
 		static const char* exec;
 
 	static bool init(int argc, char *argv[]);

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -57,4 +57,5 @@ class HighwaySystem
 	size_t con_route_index(ConnectedRoute*); // same thing for ConnectedRoutes
 	void route_integrity(ErrorList& el);
 	void insert_vertex(HGVertex*);
+	void stats_csv();
 };

--- a/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
@@ -1,0 +1,51 @@
+#include "../classes/Args/Args.h"
+#include "../classes/Region/Region.h"
+#include "../classes/TravelerList/TravelerList.h"
+#include "../threads/threads.h"
+#include <fstream>
+
+void allbyregionactiveonly(std::mutex* mtx)
+{	double total_mi;
+	char fstr[112];
+	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactiveonly.csv");
+	allfile << "Traveler,Total";
+	std::list<Region*> regions;
+	total_mi = 0;
+	for (Region* r : Region::allregions)
+	  if (r->active_only_mileage)
+	  {	regions.push_back(r);
+		total_mi += r->active_only_mileage;
+	  }
+	regions.sort(sort_regions_by_code);
+	for (Region *region : regions)
+		allfile << ',' << region->code;
+	allfile << '\n';
+	for (TravelerList *t : TravelerList::allusers)
+	{	double t_total_mi = 0;
+		for (std::pair<Region* const, double>& rm : t->active_only_mileage_by_region)
+			t_total_mi += rm.second;
+		sprintf(fstr, "%.2f", t_total_mi);
+		allfile << t->traveler_name << ',' << fstr;
+		for (Region *region : regions)
+		  try {	sprintf(fstr, "%.2f", t->active_only_mileage_by_region.at(region));
+			allfile << ',' << fstr;
+		      }
+		  catch (const std::out_of_range& oor)
+		      {	allfile << ",0";
+		      }
+		allfile << '\n';
+	}
+	sprintf(fstr, "TOTAL,%.2f", total_mi);
+	allfile << fstr;
+	for (Region *region : regions)
+	{	sprintf(fstr, ",%.2f", region->active_only_mileage);
+		allfile << fstr;
+	}
+	allfile << '\n';
+	allfile.close();
+
+#ifdef threading_enabled
+	if (mtx)
+	StatsCsvThread(0, mtx);
+#endif
+}

--- a/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
@@ -1,0 +1,51 @@
+#include "../classes/Args/Args.h"
+#include "../classes/Region/Region.h"
+#include "../classes/TravelerList/TravelerList.h"
+#include "../threads/threads.h"
+#include <fstream>
+
+void allbyregionactivepreview(std::mutex* mtx)
+{	double total_mi;
+	char fstr[112];
+	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactivepreview.csv");
+	allfile << "Traveler,Total";
+	std::list<Region*> regions;
+	total_mi = 0;
+	for (Region* r : Region::allregions)
+	  if (r->active_preview_mileage)
+	  {	regions.push_back(r);
+		total_mi += r->active_preview_mileage;
+	  }
+	regions.sort(sort_regions_by_code);
+	for (Region *region : regions)
+		allfile << ',' << region->code;
+	allfile << '\n';
+	for (TravelerList *t : TravelerList::allusers)
+	{	double t_total_mi = 0;
+		for (std::pair<Region* const, double>& rm : t->active_preview_mileage_by_region)
+			t_total_mi += rm.second;
+		sprintf(fstr, "%.2f", t_total_mi);
+		allfile << t->traveler_name << ',' << fstr;
+		for (Region *region : regions)
+		  try {	sprintf(fstr, "%.2f", t->active_preview_mileage_by_region.at(region));
+			allfile << ',' << fstr;
+		      }
+		  catch (const std::out_of_range& oor)
+		      {	allfile << ",0";
+		      }
+		allfile << '\n';
+	}
+	sprintf(fstr, "TOTAL,%.2f", total_mi);
+	allfile << fstr;
+	for (Region *region : regions)
+	{	sprintf(fstr, ",%.2f", region->active_preview_mileage);
+		allfile << fstr;
+	}
+	allfile << '\n';
+	allfile.close();
+
+#ifdef threading_enabled
+	if (mtx)
+	StatsCsvThread(1, mtx);
+#endif
+}

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -609,7 +609,7 @@ int main(int argc, char *argv[])
 	cout << et.et() << "Writing stats csv files." << endl;
       #ifdef threading_enabled
 	HighwaySystem::it = HighwaySystem::syslist.begin();
-	switch(Args::numthreads)
+	switch(Args::stcsvfiles ? 1 : Args::numthreads)
 	{   case 1:
       #endif
 		cout << et.et() << "Writing allbyregionactiveonly.csv." << endl;

--- a/siteupdate/cplusplus/threads/StatsCsvThread.cpp
+++ b/siteupdate/cplusplus/threads/StatsCsvThread.cpp
@@ -1,0 +1,16 @@
+void StatsCsvThread(unsigned int id, std::mutex* hs_mtx)
+{	//printf("Starting StatsCsvThread %02i\n", id); fflush(stdout);
+	while (HighwaySystem::it != HighwaySystem::syslist.end())
+	{	hs_mtx->lock();
+		if (HighwaySystem::it == HighwaySystem::syslist.end())
+		{	hs_mtx->unlock();
+			return;
+		}
+		HighwaySystem *h(*HighwaySystem::it);
+		//printf("StatsCsvThread %02i assigned %s\n", id, h->systemname.data()); fflush(stdout);
+		(HighwaySystem::it)++;
+		//printf("StatsCsvThread %02i (HighwaySystem::it)++\n", id); fflush(stdout);
+		hs_mtx->unlock();
+		h->stats_csv();
+	}
+}

--- a/siteupdate/cplusplus/threads/threads.cpp
+++ b/siteupdate/cplusplus/threads/threads.cpp
@@ -18,5 +18,6 @@
 #include "ReadListThread.cpp"
 #include "ReadWptThread.cpp"
 #include "RteIntThread.cpp"
+#include "StatsCsvThread.cpp"
 #include "SubgraphThread.cpp"
 #include "UserLogThread.cpp"

--- a/siteupdate/cplusplus/threads/threads.h
+++ b/siteupdate/cplusplus/threads/threads.h
@@ -15,5 +15,6 @@ void NmpSearchThread (unsigned int, std::mutex*, WaypointQuadtree*);
 void ReadListThread  (unsigned int, std::mutex*, ErrorList*);
 void ReadWptThread   (unsigned int, std::mutex*, ErrorList*, WaypointQuadtree*);
 void RteIntThread    (unsigned int, std::mutex*, ErrorList*);
+void StatsCsvThread  (unsigned int, std::mutex*);
 void SubgraphThread  (unsigned int, std::mutex*, std::mutex*, HighwayGraph*, WaypointQuadtree*, ElapsedTime*);
 void UserLogThread   (unsigned int, std::mutex*, ClinchedDBValues*, const double, const double);


### PR DESCRIPTION
### AW YISS.
The 30-second barrier has been broken! A full `siteupdate -v` run, complete with nmp_merged files, subgraphs and DB file, took **29.6s** compiled with clang++ on lab1.5 (running Ubuntu).

### Threaded stats csv files
Most of the speedup benefits single-threaded operation -- Sometimes the *same damn code*, when refactored off into its own function, will magically run faster than when just included inline. Don't know why, but I've seen it happen. This is one of those times. With basically nothing changed, the stats csv file writing is >twice as fast. I'll take it!

There are 3 different components. Here they are with approximate times from BiggaTomato for illustrative purposes:
* **0.6s** allbyregionactiveonly.csv
* **0.9s** allbyregionactivepreview.csv
* **0.7s** all per-system csv files
* **2.2s** TOTAL

The approach here differs from other multi-threaded tasks.
With allbyregionactivepreview.csv taking up >1/3 of total time, there's no point in using >3 threads. So:
* **1** thread: Do allbyregionactiveonly.csv, allbyregionactivepreview.csv, all per-system csv files in order. Same as now.
* **2** threads:
  1. allbyregionactiveonly.csv, then share per-system csv files when done
  2. allbyregionactivepreview.csv, then share per-system csv files when done
* **3+** threads:
  1. allbyregionactiveonly.csv
  2. allbyregionactivepreview.csv
  3. all per-system csv files

Thus the benefits of the actual multi-threading are less pronounced.
* 0.3s dead time on one core + 0.2s on another while waiting 0.9s total for allbyregionactivepreview.csv to finish. Compared to a theoretical 0.73s for 1/3 the total time or 1.1s for 2 threads.
* In practice, things don't scale that well, even to 2 threads. 2 thr ~= 67-79% the total time of 1 thr, depending on what machine. Seems that there's a lot of data to pull from main memory wicked fast. Consistent with the systems with most RAM bandwidth (lab1, lab2) having the best scaling, and the systems with the least (lab3, BiggaTomato) actually performing worse with >1 thread. Accordingly, added a `-C` or `--st-csvs` commandline switch to disable multi-threaded stats csvs for systems with low memory bandwidth.