### PR TITLE
object alignment tweaks / "defrag" waypoint

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
@@ -7,21 +7,21 @@ class Region;
 
 class GraphListEntry
 {	/* This class encapsulates information about generated graphs for
-	inclusion in the DB table.  Field names here match column names
-	in the "graphs" DB table. */
+	inclusion in the DB table.  Field names here
+	(or function names if both are on the same line)
+	match column names in the "graphs" DB table. */
 	public:
-	std::string filename();
+	std::string root;	std::string filename();
 	std::string descr;
+	std::list<Region*> *regions;		// C++ only, not in DB or Python
+	std::list<HighwaySystem*> *systems;	// C++ only, not in DB or Python
+	PlaceRadius *placeradius;		// C++ only, not in DB or Python
 	unsigned int vertices;
 	unsigned int edges;
 	unsigned int travelers;
-	char form;	std::string format();
-	char cat;	std::string category();
-	// additional data for the C++ version, for multithreaded subgraph writing
-	std::string root;
-	std::list<Region*> *regions;
-	std::list<HighwaySystem*> *systems;
-	PlaceRadius *placeradius;
+	char form;		std::string format();
+	char cat;		std::string category();
+
 	static std::vector<GraphListEntry> entries;
 	static size_t num; // iterator for entries
 	std::string tag();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -13,13 +13,13 @@ class HGVertex
 	public:
 	double lat, lng;
 	const std::string *unique_name;
-	char visibility;
 	std::list<HGEdge*> incident_s_edges; // simple
 	std::list<HGEdge*> incident_c_edges; // collapsed
 	std::list<HGEdge*> incident_t_edges; // traveled
 	int *s_vertex_num;
 	int *c_vertex_num;
 	int *t_vertex_num;
+	char visibility;
 
 	HGVertex(Waypoint*, const std::string*, unsigned int);
 	~HGVertex();

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -26,11 +26,11 @@ class Waypoint
 	std::list<Waypoint*> *colocated;
 	HGVertex *vertex;
 	double lat, lng;
-	unsigned int point_num;
 	std::string label;
 	std::deque<std::string> alt_labels;
 	std::vector<Waypoint*> ap_coloc;
 	std::forward_list<Waypoint*> near_miss_points;
+	unsigned int point_num;
 	bool is_hidden;
 
 	Waypoint(char *, Route *);


### PR DESCRIPTION
Tweaks the order of objects in class headers to pay attention to [alignment requirements](https://en.cppreference.com/w/cpp/language/object#Alignment), and get rid of dead space in the *middle* of class objects, minimizing & consolidating it at the end.

**Waypoint:**
An [earlier go-round](https://github.com/TravelMapping/DataProcessing/pull/407/files#diff-9721521117deb219880b84df9ea144d87b74f1decb8ba492bf6f20a8eac159c6) changed the relative position of the `colocated` pointer, which either solved [the first big insidious clang/BSD bug](https://github.com/TravelMapping/DataProcessing/issues/375#issuecomment-764962926) or just made the symptom go away.
This time, moving `unsigned int point_num` "defrags" Waypoint: 4B padding + 7B padding = 3B padding + 8B smaller object size.
With about a million Waypoints, that saves about 8 MB overall.

**HGVertex & GraphListEntry:**
Rearranged to keep dead space at the end of the object, but no `sizeof` improvement here.