### PR TITLE
Operation Valgrind Parts 1&2

### DIFF
--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
@@ -88,8 +88,8 @@ void Datacheck::mark_fps(std::string& path, ElapsedTime &et)
 		    {	//std::cout << "Match!" << std::endl;
 			d.fp = 1;
 			fpcount++;
-			fps.erase(fp);
 			delete[] *fp;
+			fps.erase(fp);
 			break;
 		    }
 		    else

--- a/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.cpp
+++ b/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.cpp
@@ -13,3 +13,7 @@ std::string ElapsedTime::et()
 	sprintf(str, format.data(), elapsed.count());
 	return str;
 }
+
+ElapsedTime::~ElapsedTime()
+{	delete[] str;
+}

--- a/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.h
+++ b/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.h
@@ -9,5 +9,6 @@ class ElapsedTime
 
 	public:
 	ElapsedTime(int);
+	~ElapsedTime();
 	std::string et();
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -20,6 +20,7 @@ HGEdge::HGEdge(HighwaySegment *s, HighwayGraph *graph, int numthreads)
 	t_written[0] = 0;
 	vertex1 = s->waypoint1->hashpoint()->vertex;
 	vertex2 = s->waypoint2->hashpoint()->vertex;
+	format = simple | collapsed | traveled;
 	// checks for the very unusual cases where an edge ends up
 	// in the system as itself and its "reverse"
 	for (HGEdge *e : vertex1->incident_s_edges)
@@ -32,7 +33,6 @@ HGEdge::HGEdge(HighwaySegment *s, HighwayGraph *graph, int numthreads)
 	  {	delete this;
 		return;
 	  }
-	format = simple | collapsed | traveled;
 	segment_name = s->segment_name();
 	vertex1->incident_s_edges.push_back(this);
 	vertex2->incident_s_edges.push_back(this);

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -96,11 +96,12 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 		// strip whitespace
 		while (lines[l][0] == ' ' || lines[l][0] == '\t') lines[l]++;
 		char * endchar = lines[l+1]-2; // -2 skips over the 0 inserted while separating listdata into lines
-		while (*endchar == 0 && endchar > lines[l]) endchar--;  // skip back more for CRLF cases, and lines followed by blank lines
-		while (*endchar == ' ' || *endchar == '\t')
-		{	*endchar = 0;
+		while (endchar > lines[l] && *endchar == 0) endchar--;  // skip back more for CRLF cases, and lines followed by blank lines
+		if (endchar > lines[l])
+		  while (*endchar == ' ' || *endchar == '\t')
+		  {	*endchar = 0;
 			endchar--;
-		}
+		  }
 		std::string trim_line(lines[l]);
 		// ignore empty or "comment" lines
 		if (lines[l][0] == 0 || lines[l][0] == '#')

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -26,6 +26,13 @@ WaypointQuadtree::WaypointQuadtree(double MinLat, double MinLng, double MaxLat, 
 	unique_locations = 0;
 }
 
+WaypointQuadtree::~WaypointQuadtree()
+{	if(nw_child) delete nw_child;
+	if(ne_child) delete ne_child;
+	if(sw_child) delete sw_child;
+	if(se_child) delete se_child;
+}
+
 void WaypointQuadtree::refine()
 {	// refine a quadtree into 4 sub-quadrants"""
 	//std::cout << "QTDEBUG: " << str() << " being refined" << std::endl;

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -17,8 +17,10 @@ class WaypointQuadtree
 	unsigned int unique_locations;
 	std::recursive_mutex mtx;
 
-	bool refined();
 	WaypointQuadtree(double, double, double, double);
+	~WaypointQuadtree();
+
+	bool refined();
 	void refine();
 	void insert(Waypoint*, bool);
 	Waypoint *waypoint_at_same_point(Waypoint*);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -269,7 +269,8 @@ int main(int argc, char *argv[])
 	unordered_set<string> nmpfps;
 	file.open(Args::highwaydatapath+"/nmpfps.log");
 	while (getline(file, line))
-	{	while (line.back() == 0x0D || line.back() == ' ') line.erase(line.end()-1);	// trim DOS newlines & whitespace
+	{	while (line.size() && (line.back() == 0x0D || line.back() == ' '))
+			line.pop_back(); // trim DOS newlines & whitespace
 		if (line.size()) nmpfps.insert(line);
 	}
 	file.close();


### PR DESCRIPTION
Datacheck: delete fp before invalidating iterator
HGEdge: prevent memory leak from "reversed" edges
WaypointQuadtree: proper recursive destructor
main: prevent improper line.back() on empty nmpfps

---
TravelerList: don't "strip whitespace" before file BOF
ElapsedTime: plug memory leak on internal str buffer