### PR TITLE
HGEdge memory management / speed

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -11,12 +11,11 @@ class HGEdge
     edge that can incorporate intermediate points.
     */
 	public:
-	bool *s_written, *c_written, *t_written; // simple, collapsed, traveled
+	char *written;
 	std::string segment_name;
 	HGVertex *vertex1, *vertex2;
 	std::list<HGVertex*> intermediate_points; // if more than 1, will go from vertex1 to vertex2
 	HighwaySegment *segment;
-	std::list<std::pair<std::string, HighwaySystem*>> route_names_and_systems;
 	unsigned char format;
 
 	// constants for more human-readable format masks
@@ -24,12 +23,11 @@ class HGEdge
 	static const unsigned char collapsed = 2;
 	static const unsigned char traveled = 4;
 
-	HGEdge(HighwaySegment *, HighwayGraph *, int);
-	HGEdge(HGVertex *, unsigned char, int);
-	~HGEdge();
+	HGEdge(HighwaySegment *, HighwayGraph *);
+	HGEdge(HGVertex *, unsigned char);
 
+	void detach();
 	void detach(unsigned char);
-	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
 	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*);
 	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, std::list<TravelerList*>*);
 	std::string debug_tmg_line(std::list<HighwaySystem*> *, unsigned int);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -1,4 +1,5 @@
 #include "HGVertex.h"
+#include "../Args/Args.h"
 #include "../Datacheck/Datacheck.h"
 #include "../GraphGeneration/HGEdge.h"
 #include "../HighwaySystem/HighwaySystem.h"
@@ -6,13 +7,13 @@
 #include "../Route/Route.h"
 #include "../Waypoint/Waypoint.h"
 
-HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
+HGVertex::HGVertex(Waypoint *wpt, const std::string *n)
 {	lat = wpt->lat;
 	lng = wpt->lng;
 	wpt->vertex = this;
-	s_vertex_num = new int[numthreads];
-	c_vertex_num = new int[numthreads];
-	t_vertex_num = new int[numthreads];
+	s_vertex_num = new int[Args::numthreads];
+	c_vertex_num = new int[Args::numthreads];
+	t_vertex_num = new int[Args::numthreads];
 		       // deleted by ~HGVertex, called by HighwayGraph::clear
 	unique_name = n;
 	visibility = 0;
@@ -36,9 +37,9 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n, unsigned int numthreads)
 
 HGVertex::~HGVertex()
 {	//std::cout << "deleting vertex at " << first_waypoint->str() << std::endl;
-	while (incident_s_edges.size()) delete incident_s_edges.front();
-	while (incident_c_edges.size()) delete incident_c_edges.front();
-	while (incident_t_edges.size()) delete incident_t_edges.front();
+	while (incident_s_edges.size()) incident_s_edges.front()->detach();
+	while (incident_c_edges.size()) incident_c_edges.front()->detach();
+	while (incident_t_edges.size()) incident_t_edges.front()->detach();
 	delete[] s_vertex_num;
 	delete[] c_vertex_num;
 	delete[] t_vertex_num;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -21,6 +21,6 @@ class HGVertex
 	int *t_vertex_num;
 	char visibility;
 
-	HGVertex(Waypoint*, const std::string*, unsigned int);
+	HGVertex(Waypoint*, const std::string*);
 	~HGVertex();
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.cpp
@@ -45,11 +45,6 @@ bool PlaceRadius::contains_vertex(double vlat, double vlng)
 	return ans <= r;
 }
 
-bool PlaceRadius::contains_edge(HGEdge *e)
-{	/* return whether both endpoints of edge e are within this area */
-	return contains_vertex(e->vertex1) and contains_vertex(e->vertex2);
-}
-
 std::unordered_set<HGVertex*> PlaceRadius::vertices(WaypointQuadtree *qt, HighwayGraph *g)
 {	// Compute and return a set of graph vertices within r miles of (lat, lng).
 	// This function handles setup & sanity checks, passing control over

--- a/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
@@ -21,7 +21,6 @@ class PlaceRadius
 
 	bool contains_vertex(HGVertex *);
 	bool contains_vertex(double, double);
-	bool contains_edge(HGEdge *);
 	std::unordered_set<HGVertex*> vertices(WaypointQuadtree *, HighwayGraph *);
 	std::unordered_set<HGVertex*> v_search(WaypointQuadtree *, HighwayGraph *, double, double);
 };

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -90,7 +90,7 @@ std::string HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_l
 		//std::cout << "\t" << num << ": TravNum%4 = " << TravNum%4 << std::endl;
 		//std::cout << "\t" << num << ": 2 ^ TravNum%4 = " << pow(2, TravNum%4) << std::endl;
 		//std::cout << "\t" << num << ": code[" << TravNum/4 << "] += int(" << pow(2, TravNum%4) << ")" << std::endl;
-		code[t->traveler_num[threadnum]/4] += int(pow(2, t->traveler_num[threadnum]%4));
+		code[t->traveler_num[threadnum]/4] += 1 << t->traveler_num[threadnum]%4;
 		//num++;
 	}
 	//std::cout << "travelers written to array" << std::endl;

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -3,6 +3,7 @@
 #include "../Route/Route.h"
 #include "../TravelerList/TravelerList.h"
 #include "../Waypoint/Waypoint.h"
+#include "../../templates/contains.cpp"
 #include <cmath>
 
 HighwaySegment::HighwaySegment(Waypoint *w1, Waypoint *w2, Route *rte)
@@ -96,6 +97,37 @@ std::string HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_l
 	for (char &nibble : code) if (nibble > '9') nibble += 7;
 	//std::cout << "nibbles >9 -> letters" << std::endl;
 	return code;
+}
+
+bool HighwaySegment::system_match(std::list<HighwaySystem*>* systems)
+{	if (!systems) return 1;
+	// devel routes are already excluded from graphs,
+	// so no need to check on non-concurrent segments
+	if (!concurrent) return contains(*systems, route->system);
+	for (HighwaySegment *cs : *(concurrent))
+	  // no devel systems should be listed
+	  // in CSVs, so no need for that check
+	  if (contains(*systems, cs->route->system)) return 1;
+	return 0;
+}
+
+// compute an edge label, optionally restricted by systems
+void HighwaySegment::write_label(std::ofstream& file, std::list<HighwaySystem*> *systems)
+{	if (concurrent)
+	     {	bool write_comma = 0;
+		for (HighwaySegment* cs : *concurrent)
+		  if ( !cs->route->system->devel() && (!systems || contains(*systems, cs->route->system)) )
+		  {	if  (write_comma) file << ',';
+			else write_comma = 1;
+			file << cs->route->route;
+			file << cs->route->banner;
+			file << cs->route->abbrev;
+		  }
+	     }
+	else {	file << route->route;
+		file << route->banner;
+		file << route->abbrev;
+	     }
 }
 
 #include "compute_stats_t.cpp"

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -1,3 +1,4 @@
+class HighwaySystem;
 class Route;
 class TravelerList;
 class Waypoint;
@@ -30,5 +31,7 @@ class HighwaySegment
 	unsigned int index();
 	//std::string concurrent_travelers_sanity_check();
 	std::string clinchedby_code(std::list<TravelerList*> *, unsigned int);
+	bool system_match(std::list<HighwaySystem*>*);
+	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
 	void compute_stats_t(TravelerList*);
 };

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -32,11 +32,9 @@ class WaypointQuadtree
 	unsigned int total_nodes();
 	void get_tmg_lines(std::list<std::string> &, std::list<std::string> &, std::string);
 	void write_qt_tmg(std::string);
-      #ifdef threading_enabled
-	void terminal_nodes(std::forward_list<WaypointQuadtree*>*, size_t&, int&);
-	void sort(int);
-	static void sortnodes(std::forward_list<WaypointQuadtree*>*);
-      #else
 	void sort();
+      #ifdef threading_enabled
+	void terminal_nodes(std::forward_list<WaypointQuadtree*>*, size_t&);
+	static void sortnodes(std::forward_list<WaypointQuadtree*>*);
       #endif
 };

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -234,11 +234,7 @@ int main(int argc, char *argv[])
 	//cout << et.et() << "Writing WaypointQuadtree.tmg." << endl;
 	//all_waypoints.write_qt_tmg(Args::logfilepath+"/WaypointQuadtree.tmg");
 	cout << et.et() << "Sorting waypoints in Quadtree." << endl;
-      #ifdef threading_enabled
-	all_waypoints.sort(Args::numthreads);
-      #else
 	all_waypoints.sort();
-      #endif
 
 	cout << et.et() << "Finding unprocessed wpt files." << endl;
 	if (Route::all_wpt_files.size())

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -77,4 +77,5 @@ else {	list<Region*> *regions;
       #endif
      }
 
+cout << et.et() << "Clearing HighwayGraph contents from memory." << endl;
 graph_data.clear();

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1919,7 +1919,7 @@ class HGEdge:
                 self.vertex1.incident_t_edges.append(self)
                 self.vertex2.incident_t_edges.append(self)
 
-    # compute an edge label, optionally resticted by systems
+    # compute an edge label, optionally restricted by systems
     def label(self,systems=None):
         the_label = ""
         for (name, system) in self.route_names_and_systems:
@@ -2008,11 +2008,6 @@ class PlaceRadius:
 
         return ans <= self.r
 
-    def contains_edge(self, e):
-        """return whether both endpoints of edge e are within this area"""
-        return (self.contains_vertex(e.vertex1) and
-                self.contains_vertex(e.vertex2))
-        
     def vertices(self, qt, g):
         # Compute and return a set of graph vertices within r miles of (lat, lng).
         # This function handles setup & sanity checks, passing control over
@@ -2208,9 +2203,9 @@ class HighwayGraph:
         # mvset		 # a set of vertices, optionally restricted by region or system or placeradius area
         cv_count = 0	 # the number of collapsed vertices in this set
         tv_count = 0	 # the number of traveled vertices in this set
-        mse = set()	 # matching    simple edges
-        mce = set()	 # matching collapsed edges
-        mte = set()	 # matching  traveled edges
+        mse = []	 # matching    simple edges
+        mce = []	 # matching collapsed edges
+        mte = []	 # matching  traveled edges
         trav_set = set() # sorted into a list of travelers for traveled graphs
         # ...as a tuple
 
@@ -2243,12 +2238,21 @@ class HighwayGraph:
             for v in self.vertices.values():
                 mvset.add(v)
         
+        # initialize *_written booleans
+        for v in mvset:
+            for e in v.incident_s_edges:
+                e.s_written = 0
+            for e in v.incident_c_edges:
+                e.c_written = 0
+            for e in v.incident_t_edges:
+                e.t_written = 0
+
         # Compute sets of edges for subgraphs, optionally
         # restricted by region or system or placeradius.
         # Keep a count of collapsed & traveled vertices as we go.
         for v in mvset:
             for e in v.incident_s_edges:
-                if placeradius is None or placeradius.contains_edge(e):
+                if not e.s_written and (placeradius is None or e.vertex1 in mvset and e.vertex2 in mvset):
                     if regions is None or e.segment.route.region in regions:
                         system_match = systems is None
                         if not system_match:
@@ -2257,12 +2261,13 @@ class HighwayGraph:
                                     system_match = True
                                     break
                         if system_match:
-                            mse.add(e)
+                            mse.append(e)
+                            e.s_written = 1
             if v.visibility < 1:
                 continue
             tv_count += 1
             for e in v.incident_t_edges:
-                if placeradius is None or placeradius.contains_edge(e):
+                if not e.t_written and (placeradius is None or e.vertex1 in mvset and e.vertex2 in mvset):
                     if regions is None or e.segment.route.region in regions:
                         system_match = systems is None
                         if not system_match:
@@ -2271,14 +2276,15 @@ class HighwayGraph:
                                     system_match = True
                                     break
                         if system_match:
-                            mte.add(e)
+                            mte.append(e)
+                            e.t_written = 1
                             for t in e.segment.clinched_by:
                                 trav_set.add(t)
             if v.visibility < 2:
                 continue
             cv_count += 1
             for e in v.incident_c_edges:
-                if placeradius is None or placeradius.contains_edge(e):
+                if not e.c_written and (placeradius is None or e.vertex1 in mvset and e.vertex2 in mvset):
                     if regions is None or e.segment.route.region in regions:
                         system_match = systems is None
                         if not system_match:
@@ -2287,7 +2293,8 @@ class HighwayGraph:
                                     system_match = True
                                     break
                         if system_match:
-                            mce.add(e)
+                            mce.append(e)
+                            e.c_written = 1
         return (mvset, cv_count, tv_count, mse, mce, mte, sorted(trav_set, key=lambda TravelerList: TravelerList.traveler_name))
 
     # write the entire set of highway data in .tmg format.

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -874,7 +874,7 @@ class HighwaySegment:
         code = ""
         clinch_array = [0]*( math.ceil(len(traveler_lists)/4) )
         for t in self.clinched_by:
-            clinch_array[t.traveler_num // 4] += 2 ** (t.traveler_num % 4)
+            clinch_array[t.traveler_num // 4] += 1 << t.traveler_num % 4
         for c in clinch_array:
             code += "0123456789ABCDEF"[c]
         return code


### PR DESCRIPTION
closes yakra#175
closes yakra#176
closes yakra#182
Yes, there's still room to squeeze some more efficiency out of writing subgraphs.
Good RAM savings. Speedwise, we have several nickel-and-dime improvements that add up to like a quarter. ;P
Code reorganization better sets us up for potential future enhancements.
Most everything squashed down into one commit for cleaner commit history, as successive commits edited and re-edited the same code lines.

**All affected tasks together:**
![all_Total](https://user-images.githubusercontent.com/13720877/132972112-a2637b00-ced2-40f2-902c-d5ce4082da93.png)

**Broken down into the individual subtasks:**
![all_ctor1](https://user-images.githubusercontent.com/13720877/132972107-ce283649-d0c3-48c4-87c8-566c2f4affb5.png)
![all_ctor2](https://user-images.githubusercontent.com/13720877/132972108-b1b14bc9-0ced-47b9-8cc4-c59dd04f4008.png)
![all_dtor](https://user-images.githubusercontent.com/13720877/132972109-77fe4d9a-1d70-43cc-adec-4c29ae72007e.png)
![all_Subg](https://user-images.githubusercontent.com/13720877/132972111-82ff72d5-90d6-48ad-b7f6-e9b26be9d089.png)

More detailed comments about the individual changes will be in the posts below.