### PR TITLE
delete unused functions

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -49,14 +49,6 @@ std::string HighwaySegment::segment_name()
 	return segment_name;
 }
 
-unsigned int HighwaySegment::index()
-{	// segment number:
-	// return this segment's index within its route's segment_list vector
-	for (unsigned int i = 0; i < route->segment_list.size(); i++)
-	  if (route->segment_list[i] == this) return i;
-	return -1;	// error; this segment not found in vector
-}
-
 /*std::string HighwaySegment::concurrent_travelers_sanity_check()
 {	if (route->system->devel()) return "";
 	if (concurrent)

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -28,7 +28,6 @@ class HighwaySegment
 	bool add_clinched_by(TravelerList *);
 	std::string csv_line(unsigned int);
 	std::string segment_name();
-	unsigned int index();
 	//std::string concurrent_travelers_sanity_check();
 	std::string clinchedby_code(std::list<TravelerList*> *, unsigned int);
 	bool system_match(std::list<HighwaySystem*>*);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -83,21 +83,6 @@ void WaypointQuadtree::insert(Waypoint *w, bool init)
 	     }
 }
 
-Waypoint *WaypointQuadtree::waypoint_at_same_point(Waypoint *w)
-{	// find an existing waypoint at the same coordinates as w
-	if (refined())
-		if (w->lat < mid_lat)
-			if (w->lng < mid_lng)
-				return sw_child->waypoint_at_same_point(w);
-			else	return se_child->waypoint_at_same_point(w);
-		else	if (w->lng < mid_lng)
-				return nw_child->waypoint_at_same_point(w);
-			else	return ne_child->waypoint_at_same_point(w);
-	for (Waypoint *p : points)
-		if (p->same_coords(w)) return p;
-	return 0;
-}
-
 std::forward_list<Waypoint*> WaypointQuadtree::near_miss_waypoints(Waypoint *w, double tolerance)
 {	// compute and return a list of existing waypoints which are
 	// within the near-miss tolerance (in degrees lat, lng) of w

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -21,7 +21,6 @@ class WaypointQuadtree
 	WaypointQuadtree(double, double, double, double);
 	void refine();
 	void insert(Waypoint*, bool);
-	Waypoint *waypoint_at_same_point(Waypoint*);
 	std::forward_list<Waypoint*> near_miss_waypoints(Waypoint*, double);
 	std::string str();
 	unsigned int size();

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -140,25 +140,6 @@ class WaypointQuadtree:
                 else:
                     self.ne_child.insert(w, init)
 
-    def waypoint_at_same_point(self,w):
-        """find an existing waypoint at the same coordinates as w"""
-        if self.points is not None:
-            for p in self.points:
-                if p.same_coords(w):
-                    return p
-            return None
-        else:
-            if w.lat < self.mid_lat:
-                if w.lng < self.mid_lng:
-                    return self.sw_child.waypoint_at_same_point(w)
-                else:
-                    return self.se_child.waypoint_at_same_point(w)
-            else:
-                if w.lng < self.mid_lng:
-                    return self.nw_child.waypoint_at_same_point(w)
-                else:
-                    return self.ne_child.waypoint_at_same_point(w)
-
     def near_miss_waypoints(self, w, tolerance):
         """compute and return a list of existing waypoints which are
         within the near-miss tolerance (in degrees lat, lng) of w"""


### PR DESCRIPTION
* `HighwaySegment::index` was already unused when the C++ version was first committed to GitHub. Don't remember what happened before that.
* `WaypointQuadtree::waypoint_at_same_point` was supplanted in d247442592e72ed4219a2d22251a2eda43870dd1, when colocation detection was moved into `WaypointQuadtree::insert` to avoid redundant iteration down through the quadtree.