### PR TITLE
WaypointQuadtree::final_report

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -59,7 +59,7 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 		  for (HighwaySegment *s : r->segment_list)
 		    if (!s->concurrent || s == s->concurrent->front())
 		      new HGEdge(s, this);
-		      // deleted by ~HGVertex, called by HighwayGraph::clear
+		      // deleted by HGEdge::detach via ~HGVertex via HighwayGraph::clear
 	}
 	std::cout << '!' << std::endl;
 
@@ -106,9 +106,9 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 				new HGEdge(w->vertex, HGEdge::collapsed | HGEdge::traveled);
 			else {	new HGEdge(w->vertex, HGEdge::collapsed);
 				new HGEdge(w->vertex, HGEdge::traveled);
-				// Final collapsed edges are deleted by ~HGVertex, called by HighwayGraph::clear.
-				// Partially collapsed edges created during the compression process are deleted
-				// upon detachment from all graphs.
+				// Final collapsed edges are deleted by HGEdge::detach via ~HGVertex via HighwayGraph::clear.
+				// Partially collapsed edges created during the compression process
+				// are deleted by HGEdge::detach upon detachment from all graphs.
 			     }
 		}
 	}

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -65,7 +65,7 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 		} // ...and from beginning
 		while (lines[l][0] == ' ' || lines[l][0] == '\t') lines[l]++;
 		Waypoint *w = new Waypoint(lines[l], this);
-			      // deleted on termination of program, or immediately below if invalid
+			      // deleted by WaypointQuadtree::final_report, or immediately below if invalid
 		if (w->label_too_long() || (w->lat == 0 && w->lng == 0))
 		{	delete w;
 			continue;

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -106,12 +106,6 @@ bool Waypoint::nearby(Waypoint *other, double tolerance)
 	return fabs(lat - other->lat) < tolerance && fabs(lng - other->lng) < tolerance;
 }
 
-unsigned int Waypoint::num_colocated()
-{	/* return the number of points colocated with this one (including itself) */
-	if (!colocated) return 1;
-	else return colocated->size();
-}
-
 double Waypoint::distance_to(Waypoint *other)
 {	/* return the distance in miles between this waypoint and another
 	including the factor defined by the CHM project to adjust for

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -36,7 +36,6 @@ class Waypoint
 	std::string csv_line(unsigned int);
 	bool same_coords(Waypoint *);
 	bool nearby(Waypoint *, double);
-	unsigned int num_colocated();
 	double distance_to(Waypoint *);
 	double angle(Waypoint *, Waypoint *);
 	std::string canonical_waypoint_name(HighwayGraph*);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -28,10 +28,10 @@ class WaypointQuadtree
 	std::list<Waypoint*> point_list();
 	void graph_points(std::vector<Waypoint*>&, std::vector<Waypoint*>&);
 	bool is_valid(ErrorList &);
-	unsigned int max_colocated();
 	unsigned int total_nodes();
 	void get_tmg_lines(std::list<std::string> &, std::list<std::string> &, std::string);
 	void write_qt_tmg(std::string);
+	void final_report(std::vector<unsigned int>&);
 	void sort();
       #ifdef threading_enabled
 	void terminal_nodes(std::forward_list<WaypointQuadtree*>*, size_t&);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -692,25 +692,13 @@ int main(int argc, char *argv[])
 	if (!Args::errorcheck)
 	{	// compute colocation of waypoints stats
 		cout << et.et() << "Computing waypoint colocation stats, reporting all with 8 or more colocations:" << endl;
-		unsigned int largest_colocate_count = all_waypoints.max_colocated();
-		vector<unsigned int> colocate_counts(largest_colocate_count+1, 0);
-		for (Waypoint *w : all_waypoints.point_list())
-		{	unsigned int c = w->num_colocated();
-			colocate_counts[c] += 1;
-			if (c >= 8 && w == w->colocated->front())
-			{	printf("(%.15g, %.15g) is occupied by %i waypoints: ['", w->lat, w->lng, c);
-				list<Waypoint*>::iterator p = w->colocated->begin();
-				cout << (*p)->route->root << ' ' << (*p)->label << '\'';
-				for (p++; p != w->colocated->end(); p++)
-					cout << ", '" << (*p)->route->root << ' ' << (*p)->label << '\'';
-				cout << "]\n";//*/
-			}
-		}
+		vector<unsigned int> colocate_counts(2,0);
+		all_waypoints.final_report(colocate_counts);
 		cout << "Waypoint colocation counts:" << endl;
 		unsigned int unique_locations = 0;
-		for (unsigned int c = 1; c <= largest_colocate_count; c++)
-		{	unique_locations += colocate_counts[c]/c;
-			printf("%6i are each occupied by %2i waypoints.\n", colocate_counts[c]/c, c);
+		for (unsigned int c = 1; c < colocate_counts.size(); c++)
+		{	unique_locations += colocate_counts[c];
+			printf("%6i are each occupied by %2i waypoints.\n", colocate_counts[c], c);
 		}
 		cout << "Unique locations: " << unique_locations << endl;
 	}

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -305,15 +305,6 @@ class WaypointQuadtree:
 
         return True
 
-    def max_colocated(self):
-        """return the maximum number of waypoints colocated at any one location"""
-        max_col = 1
-        for p in self.point_list():
-            if max_col < p.num_colocated():
-                max_col = p.num_colocated()
-        print("Largest colocate count = " + str(max_col))
-        return max_col
-
     def total_nodes(self):
         if self.points is not None:
             # not refined, no children, return 1 for self
@@ -332,6 +323,25 @@ class WaypointQuadtree:
             for w in self.points:
                 if w.colocated:
                     w.colocated.sort(key=lambda waypoint: waypoint.route.root + "@" + waypoint.label)
+
+    def final_report(self, colocate_counts):
+        """gather & print info for final colocation stats report"""
+        if self.points is None:
+            self.ne_child.final_report(colocate_counts)
+            self.nw_child.final_report(colocate_counts)
+            self.se_child.final_report(colocate_counts)
+            self.sw_child.final_report(colocate_counts)
+        else:
+            for w in self.points:
+                if w.colocated is None:
+                    colocate_counts[1] +=1
+                elif w == w.colocated[0]:
+                    while len(w.colocated) >= len(colocate_counts):
+                        colocate_counts.append(0)
+                    colocate_counts[len(w.colocated)] += 1
+                    if len(w.colocated) >= 8:
+                        print('('+str(w.lat)+', '+str(w.lng)+') is occupied by '+str(len(w.colocated))+\
+                              ' waypoints: '+str([p.route.root+' '+p.label for p in w.colocated]), flush=True)
 
 class Waypoint:
     """This class encapsulates the information about a single waypoint
@@ -409,13 +419,6 @@ class Waypoint:
         tolerance (in degrees) of the other"""
         return abs(self.lat - other.lat) < tolerance and \
             abs(self.lng - other.lng) < tolerance
-
-    def num_colocated(self):
-        """return the number of points colocated with this one (including itself)"""
-        if self.colocated is None:
-            return 1
-        else:
-            return len(self.colocated)
 
     def distance_to(self,other):
         """return the distance in miles between this waypoint and another
@@ -4641,32 +4644,13 @@ print("WaypointQuadtree contains " + str(all_waypoints.total_nodes()) + " total 
 if not args.errorcheck:
     # compute colocation of waypoints stats
     print(et.et() + "Computing waypoint colocation stats, reporting all with 8 or more colocations:", flush=True)
-    largest_colocate_count = all_waypoints.max_colocated()
-    colocate_counts = [0]*(largest_colocate_count+1)
-    big_colocate_locations = dict()
-    for w in all_waypoints.point_list():
-        c = w.num_colocated()
-        if c >= 8:
-            point = (w.lat, w.lng)
-            entry = w.route.root + " " + w.label
-            if point in big_colocate_locations:
-                the_list = big_colocate_locations[point]
-                the_list.append(entry)
-                big_colocate_locations[point] = the_list
-            else:
-                the_list = []
-                the_list.append(entry)
-                big_colocate_locations[point] = the_list
-            #print(str(w) + " with " + str(c) + " other points.", flush=True)
-        colocate_counts[c] += 1
-    for place in big_colocate_locations:
-        the_list = big_colocate_locations[place]
-        print(str(place) + " is occupied by " + str(len(the_list)) + " waypoints: " + str(the_list), flush=True)
+    colocate_counts = [0,0]
+    all_waypoints.final_report(colocate_counts)
     print("Waypoint colocation counts:", flush=True)
     unique_locations = 0
-    for c in range(1,largest_colocate_count+1):
-        unique_locations += colocate_counts[c]//c
-        print("{0:6d} are each occupied by {1:2d} waypoints.".format(colocate_counts[c]//c, c), flush=True)
+    for c in range(1,len(colocate_counts)):
+        unique_locations += colocate_counts[c]
+        print("{0:6d} are each occupied by {1:2d} waypoints.".format(colocate_counts[c], c), flush=True)
     print("Unique locations: " + str(unique_locations), flush=True)
 
 if args.errorcheck:


### PR DESCRIPTION
([Anakin & Padme meme, large image](https://www.reddit.com/r/ProgrammerHumor/comments/pq0ia7/oh_the_leaks/))
Part of [making siteupdate "Valgrind clean"](https://github.com/TravelMapping/DataProcessing/issues/375#issuecomment-874435287) is explicitly [`delete`ing dynamically allocated memory. Compared to just letting the OS magically delete everything allocated](https://github.com/TravelMapping/DataProcessing/issues/375#issuecomment-875238626) when the program stops running, it's a bit expensive though.

I opted to keep costs down by leveraging some recursion, iteration & branching that's already happening anyway, and folding deletion of quadtree nodes, waypoints, and colcation lists into a new function that handles gathering/printing data for the final colocation stats report.
Along the way, getting rid of some redundant iteration, counting, list construction, etc. speeds things up, eliminating `WaypointQuadtree::max_colocated()` and `Waypoint::num_colocated()` in the process, changes which also make it into the Python version.
* **C++:** The colocation report itself is down from 0.91 to 0.2 s on BiggaTomato. Add in 0.825 s for the deletions, and we're only 0.115 s above where we started. 
* **Python:** Colocation reports are faster. No deletions added to the process though; that's still all handled by the garbage collector when the program terminates. The "during" version listed in the table below has all the changes except for `WaypointQuadtree.final_report` being carved out into its own function.

  Box | Before | During | After
  | - | - | - | - |
  BT | 2.5 | 1.2 | .8
  lab1 | 1.5 | .8 | .5
  lab1.5 | 1.3 | .7 | .5
  lab2 | 1.6 | .9 | .7
  lab3 | 2.1 | 1.2 | 1.0
  lab4 | 1.9 | 1.2 | .7