### PR TITLE
g++ -> clang++

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -1,3 +1,6 @@
+CXX = clang++
+CXXFLAGS = -std=c++11 -Wno-comment -Wno-dangling-else -Wno-logical-op-parentheses
+
 MTObjects = siteupdateMT.o functions/sql_fileMT.o threads/threads.o \
   classes/GraphGeneration/HighwayGraphMT.o \
   classes/WaypointQuadtree/WaypointQuadtreeMT.o \
@@ -43,24 +46,36 @@ CommonObjects = \
 .PHONY: all clean
 all: siteupdate siteupdateST
 
-%MT.d: %.cpp ; g++ -std=c++11 -MM -D threading_enabled $< | sed -r "s~.*:~$*MT.o:~" > $@
-%ST.d: %.cpp ; g++ -std=c++11 -MM $< | sed -r "s~.*:~$*ST.o:~" > $@
-%.d  : %.cpp ; g++ -std=c++11 -MM $< | sed -r "s~.*:~$*.o:~" > $@
+%MT.d: %.cpp
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -MM -D threading_enabled $< | sed -r "s~.*:~$*MT.o:~" > $@
+%ST.d: %.cpp
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -MM $< | sed -r "s~.*:~$*ST.o:~" > $@
+%.d  : %.cpp
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -MM $< | sed -r "s~.*:~$*.o:~" > $@
 
 -include $(MTObjects:.o=.d)
 -include $(STObjects:.o=.d)
 -include $(CommonObjects:.o=.d)
 
-%MT.o: ; g++ -std=c++11 -o $@ -D threading_enabled -c $<
-%ST.o: ; g++ -std=c++11 -o $@ -c $<
-%.o  : ; g++ -std=c++11 -o $@ -c $<
+%MT.o:
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -o $@ -D threading_enabled -c $<
+%ST.o:
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -o $@ -c $<
+%.o:
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 siteupdate: $(MTObjects) $(CommonObjects)
-	@echo Linking siteupdate...
-	@g++ -std=c++11 -pthread -o siteupdate $(MTObjects) $(CommonObjects)
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -pthread -o siteupdate $(MTObjects) $(CommonObjects)
 siteupdateST: $(STObjects) $(CommonObjects)
-	@echo Linking siteupdateST...
-	@g++ -std=c++11 -o siteupdateST $(STObjects) $(CommonObjects)
+	@echo $@
+	@$(CXX) $(CXXFLAGS) -o siteupdateST $(STObjects) $(CommonObjects)
 
 clean:
 	@rm -f $(MTObjects)       $(STObjects)       $(CommonObjects)

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
       #endif
 	TravelerList::ids.clear();
 	TravelerList::listupdates.clear();
-	cout << endl << et.et() << "Processed " << TravelerList::allusers.size() << " traveler list files." << endl;
+	cout << endl << et.et() << "Processed " << TravelerList::allusers.size() << " traveler list files. Sorting and numbering." << endl;
 	TravelerList::allusers.sort(sort_travelers_by_name);
 	// assign traveler numbers for master traveled graph
 	unsigned int travnum = 0;

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3119,7 +3119,7 @@ for t in traveler_ids:
         traveler_lists.append(TravelerList(t,update,el,args.userlistfilepath))
 del traveler_ids
 del listupdates
-print('\n' + et.et() + "Processed " + str(len(traveler_lists)) + " traveler list files.")
+print('\n' + et.et() + "Processed " + str(len(traveler_lists)) + " traveler list files. Sorting and numbering.")
 traveler_lists.sort(key=lambda TravelerList: TravelerList.traveler_name)
 # assign traveler numbers
 travnum = 0


### PR DESCRIPTION
* Closes #377. Replacing gcc with clang is necessary to run multithreaded on FreeBSD.
  On Linux, The clang build performs comparable or better. I'm fine with keeping it simple, not worrying about conditional checks, and compiling with clang all the time.
  * `siteupdateST`: Some tasks are faster with clang, some slower.
    Overall, total run time is faster with clang, on all machines. By ~1s on my CentOS boxes, up to 4-6s on Ubuntu.
  * Multi-threaded `siteupdate` is a bit less clear-cut...:
    * The tasks that stay single-threaded in `siteupdate` appear to account for a smaller part of the time savings in `siteupdateST`. Seems pretty close to margin of error. Faster on some machines, slower on others.
    * Combined times for multi-threaded tasks are faster across the board on Ubuntu. On CentOS, higher thread counts lean toward gcc, and lower thread counts lean toward clang. Clock speed may play a role -- lab1 was faster in 6/8 trials, by 0.83 s average across all thread counts; lab2 was slower by 0.07 s, and lab3 by 0.24 s.
    * Total run time, ST & MT tasks together: Consistently faster on Ubuntu, by about 2.1 s. The only trial that was slower was BiggaTomato @ 4 threads, by 0.35 s. If I test it again maybe it'll be faster. :) On CentOS, lower thread counts favor clang; overall gcc is faster by .08 - .24 s ballpark, so a pretty slim margin.
* Closes yakra#188. That issue has enough speed measurements, tables and charts to make your eyes bleed.