### PR TITLE
Waypoint RAM, speed, datacheck, etc.

### DIFF
--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
@@ -156,5 +156,6 @@ std::unordered_set<std::string> Datacheck::always_error
 	"MALFORMED_LON",
 	"MALFORMED_URL",
 	"NONTERMINAL_UNDERSCORE",
+	"SINGLE_FIELD_LINE",
 	"US_LETTER"
 };

--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
@@ -37,7 +37,7 @@ class Datacheck
     LABEL_PARENS           |
     LABEL_SELFREF          |
     LABEL_SLASHES          |
-    LABEL_TOO_LONG         |
+    LABEL_TOO_LONG         | excess label that can't fit in DB
     LABEL_UNDERSCORES      |
     LACKS_GENERIC          |
     LONG_SEGMENT           | distance in miles
@@ -48,6 +48,7 @@ class Datacheck
     NONTERMINAL_UNDERSCORE |
     OUT_OF_BOUNDS          | coordinate pair
     SHARP_ANGLE            | angle in degrees
+    SINGLE_FIELD_LINE      |
     US_LETTER              |
     VISIBLE_DISTANCE       | distance in miles
     VISIBLE_HIDDEN_COLOC   | hidden point at same coordinates

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -8,12 +8,10 @@
 #include "../WaypointQuadtree/WaypointQuadtree.h"
 #include <cstring>
 #include <fstream>
-#include <unordered_set>
 
 void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_flag)
 {	/* read data into the Route's waypoint list from a .wpt file */
 	std::string filename = Args::highwaydatapath + "/hwy_data" + "/" + rg_str + "/" + system->systemname + "/" + root + ".wpt";
-	std::unordered_set<Waypoint*> coords_used; // for finding duplicates
 	Waypoint *last_visible = 0;
 	double vis_dist = 0;
 	char fstr[112];
@@ -76,7 +74,6 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 
 		// single-point Datachecks, and HighwaySegment
 		w->out_of_bounds(fstr);
-		w->duplicate_coords(coords_used, fstr);
 		w->label_invalid_char();
 		if (point_list.size() > 1)
 		{	w->distance_update(fstr, vis_dist, point_list[point_list.size()-2]);

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -325,21 +325,6 @@ void Waypoint::distance_update(char *fstr, double &vis_dist, Waypoint *prev_w)
 	}
 }
 
-void Waypoint::duplicate_coords(std::unordered_set<Waypoint*> &coords_used, char *fstr)
-{	// duplicate coordinates
-	Waypoint *w;
-	if (!colocated) w = this;
-	else w = colocated->front();
-	if (!coords_used.insert(w).second)
-	  for (Waypoint *other_w : route->point_list)
-	  {	if (this == other_w) break;
-		if (lat == other_w->lat && lng == other_w->lng)
-		{	sprintf(fstr, "(%.15g,%.15g)", lat, lng);
-			Datacheck::add(route, other_w->label, label, "", "DUPLICATE_COORDS", fstr);
-		}
-	  }
-}
-
 void Waypoint::label_invalid_char()
 {	// look for labels with invalid characters
 	if (label == "*")

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -16,32 +16,54 @@ Waypoint::Waypoint(char *line, Route *rte)
 {	/* initialize object from a .wpt file line */
 	route = rte;
 
-	// parse WPT line
-	size_t spn = 0;
-	for (char* c = line; *c; c += spn)
-	{	for (spn = strcspn(c, " "); c[spn] == ' '; spn++) c[spn] = 0;
-		alt_labels.emplace_back(c);
+	// split line into fields
+	char* c = strchr(line, ' ');
+	if (c){	do *c = 0; while (*++c == ' ');
+		// alt labels & URL
+		for (size_t spn = 0; *c; c += spn)
+		{	for (spn = strcspn(c, " "); c[spn] == ' '; spn++) c[spn] = 0;
+			alt_labels.emplace_back(c);
+		}
+	      }
+	label = line;
+
+	// datachecks
+	bool valid_line = 1;
+	if (label.size() > DBFieldLength::label)
+	{	// SINGLE_FIELD_LINE, looks like a URL
+		if (alt_labels.empty() && !strncmp(label.data(), "http", 4))		// If the "label" is a URL, and the only field...
+		{	label = "..."+label.substr(label.size()-DBFieldLength::label+3);// the end is more useful than "http://www.openstreetma..."
+			while (label.front() < 0)	label.erase(label.begin());	// Strip any partial multi-byte characters off the beginning
+			Datacheck::add(route, label, "", "", "SINGLE_FIELD_LINE", "");
+			lat = 0;	lng = 0;	return;
+		}
+		// LABEL_TOO_LONG
+		size_t slicepoint = DBFieldLength::label-3;				// Prepare a truncated label that will fit in the DB
+		while (label[slicepoint-1] < 0) slicepoint--;				// Avoid slicing within a multi-byte character
+		std::string excess = label.data()+slicepoint;				// Save excess beyond what fits in DB, to put in info field
+		if (excess.size() > DBFieldLength::dcErrValue-3)			// If it's too long for the info field,
+		{	excess = excess.substr(0, DBFieldLength::dcErrValue-6);		// cut it down to what will fit,
+			while (excess.back() < 0)	excess.erase(excess.end()-1);	// strip any partial multi-byte characters off the end,
+			excess += "...";						// and append "..."
+		}
+		label = label.assign(label, 0, slicepoint);				// Now truncate the label itself
+		Datacheck::add(route, label+"...", "", "", "LABEL_TOO_LONG", "..."+excess);
+		valid_line = 0;
+	}
+	// SINGLE_FIELD_LINE, looks like a label
+	if (alt_labels.empty())
+	{	Datacheck::add(route, label, "", "", "SINGLE_FIELD_LINE", "");
+		lat = 0;	lng = 0;	return;
 	}
 
-	// We know alt_labels will have at least one element, because if the WPT line is
-	// blank or contains only spaces, Route::read_wpt will not call this constructor.
-	std::string URL = alt_labels.back();	// last token is actually the URL...
-	alt_labels.pop_back();			// ...and not a label.
-	if (alt_labels.empty()) label = "NULL";
-	else {	label = alt_labels.front();	// first token is the primary label...
-		alt_labels.pop_front();		// ...and not an alternate.
-	     }
-	is_hidden = label[0] == '+';
-	colocated = 0;
-
 	// parse URL
+	std::string& URL = alt_labels.back();	// last field is actually the URL, not a label.
 	size_t latBeg = URL.find("lat=")+4;
 	size_t lonBeg = URL.find("lon=")+4;
 	if (latBeg == 3 || lonBeg == 3)
 	{	Datacheck::add(route, label, "", "", "MALFORMED_URL", "MISSING_ARG(S)");
 		lat = 0;	lng = 0;	return;
 	}
-	bool valid_coords = 1;
 	if (!valid_num_str(URL.data()+latBeg, '&'))
 	{	size_t ampersand = URL.find('&', latBeg);
 		std::string lat_string = (ampersand == -1) ? URL.data()+latBeg : URL.substr(latBeg, ampersand-latBeg);
@@ -51,7 +73,7 @@ Waypoint::Waypoint(char *line, Route *rte)
 			lat_string += "...";
 		}
 		Datacheck::add(route, label, "", "", "MALFORMED_LAT", lat_string);
-		valid_coords = 0;
+		valid_line = 0;
 	}
 	if (!valid_num_str(URL.data()+lonBeg, '&'))
 	{	size_t ampersand = URL.find('&', lonBeg);
@@ -62,11 +84,14 @@ Waypoint::Waypoint(char *line, Route *rte)
 			lng_string += "...";
 		}
 		Datacheck::add(route, label, "", "", "MALFORMED_LON", lng_string);
-		valid_coords = 0;
+		valid_line = 0;
 	}
-	if (valid_coords)
+	if (valid_line)
 	     {	lat = strtod(&URL[latBeg], 0);
 		lng = strtod(&URL[lonBeg], 0);
+		alt_labels.pop_back(); // remove URL
+		is_hidden = label[0] == '+';
+		colocated = 0;
 	     }
 	else {	lat = 0;
 		lng = 0;
@@ -338,32 +363,6 @@ void Waypoint::label_invalid_char()
 		{	Datacheck::add(route, lbl, "", "", "LABEL_INVALID_CHAR", "");
 			break;
 		}
-}
-
-bool Waypoint::label_too_long()
-{	// label longer than the DB can store
-	if (label.size() > DBFieldLength::label)
-	{	// save the excess beyond what can fit in a DB field, to put in the info/value column
-		std::string excess = label.data()+DBFieldLength::label-3;
-		// strip any partial multi-byte characters off the beginning
-		while (excess.front() < 0)	excess.erase(excess.begin());
-		// if it's too long for the info/value column,
-		if (excess.size() > DBFieldLength::dcErrValue-3)
-		{	// cut it down to what will fit,
-			excess = excess.substr(0, DBFieldLength::dcErrValue-6);
-			// strip any partial multi-byte characters off the end,
-			while (excess.back() < 0)	excess.erase(excess.end()-1);
-			// and append "..."
-			excess += "...";
-		}
-		// now truncate the label itself
-		label = label.substr(0, DBFieldLength::label-3);
-		// and strip any partial multi-byte characters off the end
-		while (label.back() < 0)	label.erase(label.end()-1);
-		Datacheck::add(route, label+"...", "", "", "LABEL_TOO_LONG", "..."+excess);
-		return 1;
-	}
-	return 0;
 }
 
 void Waypoint::out_of_bounds(char *fstr)

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -47,7 +47,6 @@ class Waypoint
 
 	// Datacheck
 	void distance_update(char *, double &, Waypoint *);
-	void duplicate_coords(std::unordered_set<Waypoint*> &, char *);
 	void label_invalid_char();
 	void out_of_bounds(char *);
 	// checks for visible points

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -1,7 +1,6 @@
 class HGVertex;
 class HighwayGraph;
 class Route;
-#include <deque>
 #include <forward_list>
 #include <fstream>
 #include <list>
@@ -24,7 +23,7 @@ class Waypoint
 	HGVertex *vertex;
 	double lat, lng;
 	std::string label;
-	std::deque<std::string> alt_labels;
+	std::vector<std::string> alt_labels;
 	std::vector<Waypoint*> ap_coloc;
 	std::forward_list<Waypoint*> near_miss_points;
 	unsigned int point_num;
@@ -50,7 +49,6 @@ class Waypoint
 	void distance_update(char *, double &, Waypoint *);
 	void duplicate_coords(std::unordered_set<Waypoint*> &, char *);
 	void label_invalid_char();
-	bool label_too_long();
 	void out_of_bounds(char *);
 	// checks for visible points
 	void bus_with_i();

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -59,6 +59,13 @@ void WaypointQuadtree::insert(Waypoint *w, bool init)
 							     // deleted by final_report
 					other_w->colocated->push_back(other_w);
 				}
+				// DUPLICATE_COORDS datacheck
+				for (Waypoint* p : *other_w->colocated)
+				  if (p->route == w->route)
+				  {	char fstr[44];
+					sprintf(fstr, "(%.15g,%.15g)", w->lat, w->lng);
+					Datacheck::add(w->route, p->label, w->label, "", "DUPLICATE_COORDS", fstr);
+				  }
 				other_w->colocated->push_back(w);
 				w->colocated = other_w->colocated;
 			}

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -255,7 +255,7 @@ void WaypointQuadtree::final_report(std::vector<unsigned int>& colocate_counts)
 		else if (w == w->colocated->front())
 		{   while (w->colocated->size() >= colocate_counts.size()) colocate_counts.push_back(0);
 		    colocate_counts[w->colocated->size()] += 1;
-		    if (w->colocated->size() >= 8)
+		    if (w->colocated->size() >= 9)
 		    {	printf("(%.15g, %.15g) is occupied by %i waypoints: ['", w->lat, w->lng, (unsigned int)w->colocated->size());
 			std::list<Waypoint*>::iterator p = w->colocated->begin();
 			std::cout << (*p)->route->root << ' ' << (*p)->label << '\'';

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
 
 	if (!Args::errorcheck)
 	{	// compute colocation of waypoints stats
-		cout << et.et() << "Computing waypoint colocation stats, reporting all with 8 or more colocations:" << endl;
+		cout << et.et() << "Computing waypoint colocation stats, reporting all with 9 or more colocations:" << endl;
 		vector<unsigned int> colocate_counts(2,0);
 		all_waypoints.final_report(colocate_counts);
 		cout << "Waypoint colocation counts:" << endl;


### PR DESCRIPTION
# RAM
(C++ only)

The impetus behind this operation was to save a big chunk of RAM.
`Waypoint::alt_labels` was a bit overbuilt. The idea behind having it as a [std::deque](http://www.cplusplus.com/reference/deque/deque/) *(vice, say, a [std::vector](http://www.cplusplus.com/reference/vector/vector/))* was to facilitate some notional `demote` function that would keep the primary &  alt. labels in a nice newest-to-oldest order. Of course, such a function would only be used when a user requests it, so I don't think we need to worry about speed here. We're not going to run thousands of `demote`s in series in every siteupdate.

Deques take up a lot of RAM; `sizeof(std::deque)` is 80 B on Ubuntu with clang & 48 B on FreeBSD, vice 24 B for a std::vector on both.
HighwayData@`2ea2e86` has 1095548 Waypoints, saving us:
* 25.1 MiB on FreeBSD
* 58.5 MiB on Ubuntu

That's just the container itself. How about the contained data? The old Waypoint constructor worked by dumping all the fields in a .wpt line into `alt_labels`, then popping the primary label off the front and the URL off the back. It's safe to assume a deque doesn't resize itself downward, potentially needing the freed storage for future elements. So we're left with, *at minimum*, enough empty space for a `std::string` (24 B FreeBSD, 32 B Ubuntu) at both ends of each deque. This brings our RAM savings up to:
* 91.9 MiB on FreeBSD
* 108.7 MiB on Ubuntu

How much savings did I actually observe in my System Monitor on Ubuntu?
* 655 MiB ballpark.

Wow, that's more than I expected. Enough for about 18 more strings' worth of storage on average (571 B dead space outside of the container object itself), including the two empty spaces we know will be there. A deque seems to allocate space a lot more proactively than a vector...

---

# Speed
(C++ only)
![Rwpt_11de8e3](https://user-images.githubusercontent.com/13720877/136456257-090ace10-6c47-491c-8ea4-02aa32b6544b.png)

### deque -> vector
The extra data in a `std::deque` is used to store *some kind of* info about its state, and must be calculated & written when the container is pushed, popped, etc.  So that's a bit of overhead. And TIL that deques are more complex under the hood...
From http://www.cplusplus.com/reference/deque/deque/ :
> unlike vectors, deques are not guaranteed to store all its elements in contiguous storage locations: accessing elements in a deque by offsetting a pointer to another element causes undefined behavior.
>
> Both vectors and deques provide a very similar interface and can be used for similar purposes, but internally both work in quite different ways: While vectors use a single array that needs to be occasionally reallocated for growth, the elements of a deque can be scattered in different chunks of storage, with the container keeping the necessary information internally to provide direct access to any of its elements in constant time and with a uniform sequential interface (through iterators). Therefore, deques are a little more complex internally than vectors

### reduced memory copies
* Since `std::vector` doesn't have a `pop_front` function, we need to get the primary label some other way. Now it's constructed in place in the `label` string. Don't need to worry about any expensive memory copies or moves.
* While we're at it, copying (or even moving) the last "alt_label" into the `URL` variable was already wholly unnecessary. Now, it's just declared as a reference to `alt_labels.back()`, parsed in place, then destroyed.

### refactor DUPLICATE_COORDS into colocation detection
Closes yakra#193.
Saves a small but consistent amount of time.
Didn't yield a speed increase in Python, so no-build there.
* **Old:** When coords already used in a route are detected, iterate thru points in the route & look for the same coords.
* **New:** When a colocated point is first detected in the quadtree, iterate thru the colocation list & look for the same route.

---

# Datacheck
(Both C++ & Python)

### SINGLE_FIELD_LINE
Was this completely necessary to add? Not *really*, but...
The existing **Python** Waypoint constructor would treat a single-field line as both the label and the URL. This means,
• A label with no URL would get flagged as MALFORMED_URL.
• A URL with no label would get flagged as LABEL_TOO_LONG.
So either way, a collaborator would know that *something* is wrong with that line.
**C++?** I *could have* done it the same way originally, but didn't. Single-field lines were just treated as URLs, and slapped with a placeholder label, "NULL".
• A label with no URL would still be flagged MALFORMED_URL, but
• A URL with no label would stay in the DB with no indication anything is wrong, unless a file contains >1. Or an actual "NULL" label.
That ain't exactly graceful degradation! ;)

With the changes to C++ primary label construction and the goal of avoiding unnecessary memory copies, this was just the most expedient way to take care of these cases. Probably a bit more clear for collaborators too.
Python was changed to conform, removing one of the last few Python<->C++ differences in logfile output.

### LABEL_TOO_LONG bugfixes
Closes #467.
While in there, I noticed that LABEL_TOO_LONG in combination with malformed URLs would try to insert a label that's too long to fit into the DB. Fixed.
In the process, another super-obscure Python<->C++ diff was eliminated: the datacheck output when an overlength label has a multi-byte character straddling the boundary of what fits in the DB. You have to be *trying* to break stuff to notice that one. :)

---

# Waypoint colocation stats verbosity
(Both C++ & Python)
Closes #462.
Slims down the wall of text in siteupdate's final colocation stats report, listing only locations with 9+ waypoints rather than 8+.