### PR TITLE
reorder NMP criteria (Python)

### DIFF
--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -151,7 +151,7 @@ class WaypointQuadtree:
         if self.points is not None:
             #print("DEBUG: terminal quadrant (self.points is not None) comparing with " + str(len(self.points)) + " points.")
             for p in self.points:
-                if p != w and not p.same_coords(w) and p.nearby(w, tolerance):
+                if p.nearby(w, tolerance) and not p.same_coords(w):
                     #print("DEBUG: found nmp " + str(p))
                     near_miss_points.append(p)
 


### PR DESCRIPTION
NMP criteria:
https://github.com/TravelMapping/DataProcessing/blob/78a4bead69862229f4d770c1420779b3f4205bef/siteupdate/python-teresco/siteupdate.py#L154

The `p != w` test isn't needed, because `w` has not yet been added to the quadtree when searching for NMPs.
https://github.com/TravelMapping/DataProcessing/blob/78a4bead69862229f4d770c1420779b3f4205bef/siteupdate/python-teresco/siteupdate.py#L1027

Of the remaining 2 criteria, a lot more points will be not `nearby` than will be `same_coords`. Putting the `nearby` test first will rule out more points earlier in the process, which then don't need to have the 2nd test performed.
This saves a surprising amount of time: 7.7-9.8 s on the Linux machines I tested, about 13.3% of the time spent `Reading waypoints for all routes.`
FreeBSD, saves about 15.8%, \~22.5s on my machine. I estimate that'd work out to about 19 s on noreaster.

---

C++ is a bit of a different story.
There, `w` is already added to the quadtree when searching for NMPs. The `p != w` test still isn't strictly needed, because if they're the same point they'll have the same coords. However -- what's less expensive, performing a large number of fast operations or a small number of slow operations? In this case the former -- Testing whether ` p != w` on every point in our terminal quadtree nodes is outweighed by not having to test whether that one point is `nearby` & `same_coords`.

More to come. Big improvements for the C++ version; unsure if they'll translate to much savings for Python. Nothing that will re-edit this particular line of code though. :)