### PR TITLE
LOOKS INTENTIONAL matching

### DIFF
--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -228,8 +228,6 @@ void Waypoint::nmplogs(std::unordered_set<std::string> &nmpfps, std::ofstream &n
 		for (Waypoint *other_w : near_miss_points) nmpline += " " + other_w->str();
 		// check for string in fp list
 		std::unordered_set<std::string>::iterator fpit = nmpfps.find(nmpline);
-		if (fpit == nmpfps.end())		  fpit = nmpfps.find(nmpline+" [LOOKS INTENTIONAL]");
-		if (fpit == nmpfps.end())		  fpit = nmpfps.find(nmpline+" [SOME LOOK INTENTIONAL]");
 		bool fp = fpit != nmpfps.end();
 		// write lines to tm-master.nmp
 		size_t li_count = 0;

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -265,9 +265,16 @@ int main(int argc, char *argv[])
 	unordered_set<string> nmpfps;
 	file.open(Args::highwaydatapath+"/nmpfps.log");
 	while (getline(file, line))
-	{	while (line.size() && (line.back() == 0x0D || line.back() == ' '))
+	{	while (line.size() && (line.back() == ' ' || line.back() == '\r'))
 			line.pop_back(); // trim DOS newlines & whitespace
-		if (line.size()) nmpfps.insert(line);
+		if (line.size())
+		    if (line.size() >= 51)
+			if (!strcmp(line.data()+line.size()-20, " [LOOKS INTENTIONAL]"))
+				nmpfps.emplace(line, 0, line.size()-20);
+			else if (line.size() >= 55 && !strcmp(line.data()+line.size()-24, " [SOME LOOK INTENTIONAL]"))
+				nmpfps.emplace(line, 0, line.size()-24);
+			else	nmpfps.emplace(std::move(line));
+		    else	nmpfps.emplace(std::move(line));
 	}
 	file.close();
 

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2839,10 +2839,15 @@ print(et.et() + "Near-miss point log and tm-master.nmp file.", flush=True)
 # read in fp file
 nmpfps = set()
 nmpfpfile = open(args.highwaydatapath+'/nmpfps.log','r')
-nmpfpfilelines = nmpfpfile.readlines()
-for line in nmpfpfilelines:
-    if len(line.rstrip('\n ')) > 0:
-        nmpfps.add(line.rstrip('\n '))
+for line in nmpfpfile.readlines():
+    line = line.rstrip('\n ')
+    if len(line) > 0:
+        if line.endswith(" [LOOKS INTENTIONAL]"):
+            nmpfps.add(line[:-20])
+        elif line.endswith(" [SOME LOOK INTENTIONAL]"):
+            nmpfps.add(line[:-24])
+        else:
+            nmpfps.add(line)
 nmpfpfile.close()
 
 nmploglines = []
@@ -2860,15 +2865,6 @@ for w in all_waypoints.point_list():
             nmpline += " " + str(other_w)
         # check for string in fp list
         fp = nmpline in nmpfps
-        lifp_tag = 0
-        if not fp:
-            if nmpline+" [LOOKS INTENTIONAL]" in nmpfps:
-                fp = True
-                lifp_tag = 1
-        if not fp:
-            if nmpline+" [SOME LOOK INTENTIONAL]" in nmpfps:
-                fp = True
-                lifp_tag = 2
         #  write lines to tm-master.nmp
         li_count = 0
         for other_w in w.near_miss_points:
@@ -2908,12 +2904,7 @@ for w in all_waypoints.point_list():
                 logline += " [SOME LOOK INTENTIONAL]"
             w.near_miss_points = None
         if fp:
-            if lifp_tag == 0:
-                nmpfps.remove(nmpline)
-            elif lifp_tag == 1:
-                nmpfps.remove(nmpline+" [LOOKS INTENTIONAL]")
-            else:
-                nmpfps.remove(nmpline+" [SOME LOOK INTENTIONAL]")
+            nmpfps.remove(nmpline)
             logline += " [MARKED FP]"
             w.near_miss_points = None
         nmploglines.append(logline)


### PR DESCRIPTION
Closes #455.
Strips ` [LOOKS INTENTIONAL]` or ` [SOME LOOK INTENTIONAL]` from nmpfps.log entries if present, storing just the raw NMP line itself. This means checking each NMP entry for a corresponding `nmpfps` entry once, rather than up to 3 times.

The amount of time and RAM this saves is pretty close to, but still greater than, zero.
Nonetheless,
![Cool Obama meme template: "It's the right thing to do!"](https://i.imgflip.com/5qob64.jpg)