### PR TITLE
Don't flag LONG_UNDERSCORE at U-turn ramps

### DIFF
--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -487,9 +487,10 @@ void Waypoint::underscore_datachecks(const char *slash)
 		if (strchr(underscore+1, '_'))
 			Datacheck::add(route, label, "", "", "LABEL_UNDERSCORES", "");
 		// look for too many characters after underscore in label
-		if (label.data()+label.size() > underscore+4)
-		    if (label.back() > 'Z' || label.back() < 'A' || label.data()+label.size() > underscore+5)
-			Datacheck::add(route, label, "", "", "LONG_UNDERSCORE", "");
+		if (	label.data()+label.size() > underscore+4
+		     && (label.back() > 'Z' || label.back() < 'A' || label.data()+label.size() > underscore+5)	// allow "CitA" city+letter
+		     && (underscore[1] != 'U' || !isdigit(underscore[2]))					// allow "_U100" U-turns
+		   )	Datacheck::add(route, label, "", "", "LONG_UNDERSCORE", "");
 		// look for labels with a slash after an underscore
 		if (slash > underscore)
 			Datacheck::add(route, label, "", "", "NONTERMINAL_UNDERSCORE", "");

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -4052,9 +4052,11 @@ for h in highway_systems:
 
                 # look for too many characters after underscore in label
                 if '_' in w.label:
-                    if w.label.index('_') < len(w.label) - 4:
-                        if w.label[-1] not in string.ascii_uppercase or w.label.index('_') < len(w.label) - 5:
-                            datacheckerrors.append(DatacheckEntry(r,[w.label],'LONG_UNDERSCORE'))
+                    u = w.label.index('_')
+                    if u < len(w.label) - 4 \
+                    and (w.label[-1] not in string.ascii_uppercase or u < len(w.label) - 5) \
+                    and (w.label[u+1] != 'U' or not w.label[u+2].isdigit()):
+                        datacheckerrors.append(DatacheckEntry(r,[w.label],'LONG_UNDERSCORE'))
 
                 # look for too many slashes in label
                 if w.label.count('/') > 1:


### PR DESCRIPTION
@neroute2's [forum post](https://forum.travelmapping.net/index.php?topic=3642.msg19824#msg19824)
Ping @michihdeu too

**diff:**
```diff
1c1
< Log file created at: Thu Nov  4 11:16:54 2021
---
> Log file created at: Thu Nov  4 15:36:50 2021
1672d1671
< chl.r005;R5_U1013S;;;LONG_UNDERSCORE;
1674d1672
< chl.r005;R5_U1026S;;;LONG_UNDERSCORE;
1676d1673
< chl.r005;R5_U1030S;;;LONG_UNDERSCORE;
1678d1674
< chl.r005;R5_U1059S;;;LONG_UNDERSCORE;
1680d1675
< chl.r005;R5_U294N;;;LONG_UNDERSCORE;
1682d1676
< chl.r005;R5_U301N;;;LONG_UNDERSCORE;
1684d1677
< chl.r005;R5_U311N;;;LONG_UNDERSCORE;
1686d1678
< chl.r005;R5_U320N;;;LONG_UNDERSCORE;
1688,1689d1679
< chl.r005;R5_U328N;;;LONG_UNDERSCORE;
< chl.r005;R5_U559;;;LONG_UNDERSCORE;
```

While my preference is still to avoid having this type of label, robustness is a Good Thing.
Even just going by [what's in the manual](https://travelmapping.net/devel/manual/wayptlabels.php#uturn) now, it's *possible* -- however unlikely -- that a route could have 100 U-turn interchanges. If a `_U100` suffix flags an error that can't be marked FP, that's plusungood.