### PR TITLE
LABEL_SELFREF improvements (DataProcessing)

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -40,6 +40,7 @@ CommonObjects = \
   functions/format_clinched_mi.o \
   functions/lower.o \
   functions/split.o \
+  functions/strd.o \
   functions/upper.o \
   functions/valid_num_str.o
 

--- a/siteupdate/cplusplus/classes/Route/compute_stats_r.cpp
+++ b/siteupdate/cplusplus/classes/Route/compute_stats_r.cpp
@@ -64,4 +64,5 @@ void Route::compute_stats_r()
 	} else	if (city.empty())
 		  Datacheck::add(this, "", "", "", "ABBREV_NO_CITY", CSV_LINE);
 	#undef CSV_LINE
+	for (Waypoint* w : point_list) w->label_selfref();
 }

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -92,7 +92,6 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 			w->label_invalid_ends();
 			w->label_looks_hidden();
 			w->label_parens();
-			w->label_selfref(slash);
 			w->label_slashes(slash);
 			w->lacks_generic();
 			w->underscore_datachecks(slash);

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -44,6 +44,11 @@ class Waypoint
 	void nmplogs(std::unordered_set<std::string> &, std::ofstream &, std::list<std::string> &);
 	Waypoint* hashpoint();
 	bool label_references_route(Route *);
+	Route* coloc_same_number(const char*);
+	Route* coloc_same_designation(const std::string&);
+	Route* self_intersection();
+	bool banner_after_slash(const char*);
+	Route* coloc_banner_matches_abbrev();
 
 	// Datacheck
 	void distance_update(char *, double &, Waypoint *);
@@ -55,7 +60,7 @@ class Waypoint
 	void label_invalid_ends();
 	void label_looks_hidden();
 	void label_parens();
-	void label_selfref(const char *);
+	void label_selfref();
 	void label_slashes(const char *);
 	void lacks_generic();
 	void underscore_datachecks(const char *);

--- a/siteupdate/cplusplus/functions/strd.cpp
+++ b/siteupdate/cplusplus/functions/strd.cpp
@@ -1,0 +1,16 @@
+const char* strdstr(const char* h, const char* n, const char& d)
+{	for (; *h && *h != d; h++)
+	{	const char* a = h;
+		const char* b = n;
+		while (*a != d)
+		  if (*a++ != *b++) break;
+		  else if (!*b) return h;
+	}
+	return 0;
+}
+
+int strdcmp(const char* a, const char* b, const char& d)
+{	do	if (!*b) return *a == d ? 0 : *a-*b;
+	while	(*a++ == *b++);
+	return	*--a - *--b;
+}

--- a/siteupdate/cplusplus/functions/strd.h
+++ b/siteupdate/cplusplus/functions/strd.h
@@ -1,0 +1,2 @@
+const char* strdstr(const char*, const char*, const char&);
+int strdcmp(const char*, const char*, const char&);


### PR DESCRIPTION
### Finally, here it is!
https://forum.travelmapping.net/index.php?topic=4716.msg27025#msg27025
33 commits *(including 3 merges)* squashed into one.
Several new functions help us along...
* Python gets 3 new functions in the` Waypoint` class, plus 2 new list comprehensions.
* C++ doesn't do list comprehensions, so it gets 5 new `Waypoint` functions. Plus 2 more functions for some nitty-gritty string searches & comparisons.

As for `Waypoint::label_selfref()` itself, it's a whole new Ship of Theseus.
**The rundown of what's changed:**
* inspect colocated routes, detect FPs, catecorize what's left
* more micro-optimizations where practicable
* close #28:  require banner match
* address #420: cope with banner after slash
* close #482: flag named routes after slash
* close #318: ignore banners starting with `-`, e.g. FRA depts
* close #355: cope with closed waypoints
* close #475: ignore same number different prefix
* close #264: account for abbrev
* ignore "Old" designations