### PR TITLE
update notification bugfixes (#500) / speedup

### DIFF
--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -237,7 +237,7 @@ void Route::store_traveled_segments(TravelerList* t, std::ofstream& log, unsigne
 		hs->add_clinched_by(t);
 		t->clinched_segments.insert(hs);
 	}
-	if (t->routes.insert(this).second && last_update && t->update && last_update[0] >= *t->update)
+	if (last_update && t->updated_routes.insert(this).second && t->update && last_update[0] >= *t->update)
 		log << "Route updated " << last_update[0] << ": " << readable_name() << '\n';
 }
 

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -117,6 +117,10 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 			if (*c == '#') break;
 			else fields.push_back(c);
 		}
+		#define UPDATE_NOTE(R) if (R->last_update) \
+		{	updated_routes.insert(R); \
+			log << "  Route updated " << R->last_update[0] << ": " << R->readable_name() << '\n'; \
+		}
 		if (fields.size() == 4)
 		     {
 			#include "mark_chopped_route_segments.cpp"
@@ -129,6 +133,7 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 			    << fields.size() << "): " << trim_line << '\n';
 			splist << orig_line << endlines[l];
 		     }
+		#undef UPDATE_NOTE
 	}
 	delete[] listdata;
 	log << "Processed " << list_entries << " good lines marking " << clinched_segments.size() << " segments traveled.\n";

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -28,7 +28,7 @@ class TravelerList
 	std::unordered_map<Region*, double> active_preview_mileage_by_region;				// total mileage per region, active+preview only
 	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only
 	std::unordered_map<HighwaySystem*, std::unordered_map<Region*, double>> system_region_mileages;	// mileage per region per system
-	std::unordered_set<Route*> routes;
+	std::unordered_set<Route*> updated_routes;
 	bool* in_subgraph;
 	unsigned int *traveler_num;
 	unsigned int active_systems_traveled;

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -61,8 +61,7 @@ if (lit1 == r->alt_label_hash.end() || lit2 == r->alt_label_hash.end())
 	if (invalid_char) log << " [contains invalid character(s)]";
 	log << '\n';
 	splist << orig_line << endlines[l];
-	if (routes.insert(r).second && r->last_update)
-		log << "  Route updated " << r->last_update[0] << ": " << r->readable_name() << '\n';
+	UPDATE_NOTE(r)
 	continue;
 }
 // are either of the labels used duplicates?
@@ -85,8 +84,7 @@ if (duplicate)
 if (lit1->second == lit2->second)
 {	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
 	splist << orig_line << endlines[l];
-	if (routes.insert(r).second && r->last_update)
-		log << "  Route updated " << r->last_update[0] << ": " << r->readable_name() << '\n';
+	UPDATE_NOTE(r)
 }
 // otherwise both labels are valid; mark in use & proceed
 else {	r->system->lniu_mtx.lock();

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -43,24 +43,8 @@ Route* r2 = rit2->second;
 if (r1->con_route != r2->con_route)
 {	log << lookup1 << " and " << lookup2 << " not in same connected route in line: " << trim_line << '\n';
 	splist << orig_line << endlines[l];
-	// log updates for routes beginning/ending r1's ConnectedRoute
-	Route* cr = r1->con_route->roots.front();
-	if (routes.insert(cr).second && cr->last_update)
-		  log << "  Route updated " << cr->last_update[0] << ": " << cr->readable_name() << '\n';
-	if (r1->con_route->roots.size() > 1)
-	{	Route* cr = r1->con_route->roots.back();
-		if (routes.insert(cr).second && cr->last_update)
-		  log << "  Route updated " << cr->last_update[0] << ": " << cr->readable_name() << '\n';
-	}
-	// log updates for routes beginning/ending r2's ConnectedRoute
-	cr = r2->con_route->roots.front();
-	if (routes.insert(cr).second && cr->last_update)
-		  log << "  Route updated " << cr->last_update[0] << ": " << cr->readable_name() << '\n';
-	if (r2->con_route->roots.size() > 1)
-	{	Route* cr = r2->con_route->roots.back();
-		if (routes.insert(cr).second && cr->last_update)
-		  log << "  Route updated " << cr->last_update[0] << ": " << cr->readable_name() << '\n';
-	}
+	UPDATE_NOTE(r1->con_route->roots.front()) if (r1->con_route->roots.size() > 1) UPDATE_NOTE(r1->con_route->roots.back())
+	UPDATE_NOTE(r2->con_route->roots.front()) if (r2->con_route->roots.size() > 1) UPDATE_NOTE(r2->con_route->roots.back())
 	continue;
 }
 if (r1->system->devel())
@@ -102,10 +86,8 @@ if (lit1 == r1->alt_label_hash.end() || lit2 == r2->alt_label_hash.end())
 	if (invalid_char) log << " [contains invalid character(s)]";
 	log << '\n';
 	splist << orig_line << endlines[l];
-	if (lit1 == r1->alt_label_hash.end() && routes.insert(r1).second && r1->last_update)
-		log << "  Route updated " << r1->last_update[0] << ": " << r1->readable_name() << '\n';
-	if (lit2 == r2->alt_label_hash.end() && routes.insert(r2).second && r2->last_update)
-		log << "  Route updated " << r2->last_update[0] << ": " << r2->readable_name() << '\n';
+	if (lit1 == r1->alt_label_hash.end() && lit1 != lit2)	UPDATE_NOTE(r1)
+	if (lit2 == r2->alt_label_hash.end()) /*^diff rtes^*/	UPDATE_NOTE(r2)
 	continue;
 }
 // are either of the labels used duplicates?
@@ -133,8 +115,7 @@ if (r1 == r2)
 	if (index1 == index2)
 	{	log << "Equivalent waypoint labels mark zero distance traveled in line: " << trim_line << '\n';
 		splist << orig_line << endlines[l];
-		if (routes.insert(r1).second && r1->last_update)
-			log << "  Route updated " << r1->last_update[0] << ": " << r1->readable_name() << '\n';
+		UPDATE_NOTE(r1)
 		continue;
 	}
 	if (index1 <= index2)

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -139,8 +139,8 @@ void TravelerList::userlog(ClinchedDBValues *clin_db_val, const double total_act
 	// updated routes, sorted by date
 	log << "\nMost recent updates for listed routes:\n";
 	std::list<Route*> route_list;
-	for (Route* r : routes) if (r->last_update) route_list.push_back(r);
-	routes.clear();
+	for (Route* r : updated_routes) if (r->last_update) route_list.push_back(r);
+	updated_routes.clear();
 	route_list.sort(sort_route_updates_oldest);
 	for (Route* r : route_list)
 	    log	<< r->last_update[0] << " | " << r->last_update[1] << " | " << r->last_update[2] << " | "


### PR DESCRIPTION
* Closes #500
  * Fixes Python bug where entries for the first chopped route in a ConnectedRoute would prevent update notifications for the last chopped route for "not in same connected route" errors.
  * Always show updates for broken entries; avoid having good entries updated before the .list file prevent them
* Closes yakra#202
  * C++ is about 2% faster Processing traveler list files.
  * Python is faster only in theory, not noticeably so in practice. Within margin of error.