### PR TITLE
various minor improvements

### DIFF
--- a/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.cpp
+++ b/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.cpp
@@ -76,14 +76,6 @@ std::string ConnectedRoute::connected_rtes_line()
 	return line;
 }
 
-std::string ConnectedRoute::csv_line()
-{	/* return csv line to insert into a table */
-	char fstr[32];
-	sprintf(fstr, "','%.15g'", mileage);
-	return "'" + system->systemname + "','" + route + "','" + banner + "','" + double_quotes(groupname)
-		   + "','" + (roots.size() ? roots[0]->root.data() : "ERROR_NO_ROOTS") + fstr;
-}
-
 std::string ConnectedRoute::readable_name()
 {	/* return a string for a human-readable connected route name */
 	std::string ans = route + banner;

--- a/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.h
+++ b/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.h
@@ -21,7 +21,6 @@ class ConnectedRoute
 	ConnectedRoute(std::string &, HighwaySystem *, ErrorList &);
 
 	std::string connected_rtes_line();
-	std::string csv_line();
 	std::string readable_name();
 	//std::string list_lines(int, int, std::string, size_t);
 };

--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
@@ -64,7 +64,7 @@ void Datacheck::read_fps(std::string& path, ErrorList &el)
 				   + "], expected 6 fields, found " + std::to_string(NumFields));
 			continue;
 		}
-		if (always_error.find(fields[4]) != always_error.end())
+		if (always_error.count(fields[4]))
 			std::cout << "datacheckfps.csv line not allowed (always error): " << line << std::endl;
 		else	fps.push_back(fields);
 	}

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -91,8 +91,7 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 				w->vertex->visibility = 1;
 			// next, compare clinched_by sets; look for any element in the 1st not in the 2nd
 			else for (TravelerList *t : w->vertex->incident_t_edges.front()->segment->clinched_by)
-				if (w->vertex->incident_t_edges.back()->segment->clinched_by.find(t)
-				 == w->vertex->incident_t_edges.back()->segment->clinched_by.end())
+				if (!w->vertex->incident_t_edges.back()->segment->clinched_by.count(t))
 				{	w->vertex->visibility = 1;
 					break;
 				}
@@ -228,7 +227,7 @@ inline void HighwayGraph::matching_vertices_and_edges
 	// Compute sets of edges for subgraphs, optionally
 	// restricted by region or system or placeradius.
 	// Keep a count of collapsed & traveled vertices as we go.
-	#define AREA (!g.placeradius || mvset.find(e->vertex1) != mvset.end() && mvset.find(e->vertex2) != mvset.end())
+	#define AREA (!g.placeradius || mvset.count(e->vertex1) && mvset.count(e->vertex2))
 	#define REGION (!g.regions || contains(*g.regions, e->segment->route->region))
 	for (HGVertex *v : mvset)
 	{	for (HGEdge *e : v->incident_s_edges)

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -59,7 +59,7 @@ std::string HighwaySegment::segment_name()
 			     + other->str() + "] clinched by " + std::to_string(other->clinched_by.size()) + '\n';
 		}
 		else	for (TravelerList *t : clinched_by)
-			  if (other->clinched_by.find(t) == other->clinched_by.end())
+			  if (other->clinched_by.count(t))
 			    return t->traveler_name + " has clinched [" + str() + "], but not [" + other->str() + "]\n";
 	  }
 	return "";

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -164,7 +164,7 @@ void HighwaySystem::stats_csv()
 	sysfile << '\n';
 	for (TravelerList *t : TravelerList::allusers)
 	  // only include entries for travelers who have any mileage in system
-	  if (t->system_region_mileages.find(this) != t->system_region_mileages.end())
+	  if (t->system_region_mileages.count(this))
 	  {	sprintf(fstr, ",%.2f", t->system_region_miles(this));
 		sysfile << t->traveler_name << fstr;
 		for (Region *region : regions)

--- a/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
@@ -20,7 +20,7 @@ void HighwaySystem::route_integrity(ErrorList& el)
 			std::string upper_label(lbegin);
 			upper(upper_label.data());
 			// if primary label not duplicated, add to pri_label_hash
-			if (r->alt_label_hash.find(upper_label) != r->alt_label_hash.end())
+			if (r->alt_label_hash.count(upper_label))
 			{	Datacheck::add(r, r->point_list[index]->label, "", "", "DUPLICATE_LABEL", "");
 				r->duplicate_labels.insert(upper_label);
 			}

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -140,20 +140,6 @@ std::string Route::chopped_rtes_line()
 	return line;
 }
 
-std::string Route::csv_line()
-{	/* return csv line to insert into a table */
-	// note: alt_route_names does not need to be in the db since
-	// list preprocessing uses alt or canonical and no longer cares
-	std::string line = "'" + system->systemname + "','" + region->code + "','" + route + "','" + banner
-			 + "','" + abbrev + "','" + double_quotes(city) + "','" + root + "','";
-	char mstr[51];
-	sprintf(mstr, "%.17g", mileage);
-	if (!strchr(mstr, '.')) strcat(mstr, ".0"); // add single trailing zero to ints for compatibility with Python
-	line += mstr;
-	line += "','" + std::to_string(rootOrder) + "'";
-	return line;
-}
-
 std::string Route::readable_name()
 {	/* return a string for a human-readable route name */
 	return rg_str + " " + route + banner + abbrev;

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -214,14 +214,14 @@ void Route::write_nmp_merged()
 	wptfile.close();
 }
 
-void Route::store_traveled_segments(TravelerList* t, std::ofstream& log, unsigned int beg, unsigned int end)
+void Route::store_traveled_segments(TravelerList* t, std::ofstream& log, std::string* update, unsigned int beg, unsigned int end)
 {	// store clinched segments with traveler and traveler with segments
 	for (unsigned int pos = beg; pos < end; pos++)
 	{	HighwaySegment *hs = segment_list[pos];
 		hs->add_clinched_by(t);
 		t->clinched_segments.insert(hs);
 	}
-	if (last_update && t->updated_routes.insert(this).second && t->update && last_update[0] >= *t->update)
+	if (last_update && t->updated_routes.insert(this).second && update && last_update[0] >= *update)
 		log << "Route updated " << last_update[0] << ": " << readable_name() << '\n';
 }
 

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -90,7 +90,7 @@ Route::Route(std::string &line, HighwaySystem *sys, ErrorList &el)
 	// insert list name into pri_list_hash, checking for duplicate .list names
 	std::string list_name(readable_name());
 	upper(list_name.data());
-	if (alt_list_hash.find(list_name) != alt_list_hash.end())
+	if (alt_list_hash.count(list_name))
 		el.add_error("Duplicate main list name in " + root + ": '" + readable_name() +
 			     "' already points to " + alt_list_hash.at(list_name)->root);
 	else if (!pri_list_hash.insert(std::pair<std::string,Route*>(list_name, this)).second)
@@ -100,7 +100,7 @@ Route::Route(std::string &line, HighwaySystem *sys, ErrorList &el)
 	for (std::string& a : alt_route_names)
 	{   list_name = rg_str + ' ' + a;
 	    upper(list_name.data());
-	    if (pri_list_hash.find(list_name) != pri_list_hash.end())
+	    if (pri_list_hash.count(list_name))
 		el.add_error("Duplicate alt route name in " + root + ": '" + region->code + ' ' + a +
 			     "' already points to " + pri_list_hash.at(list_name)->root);
 	    else if (!alt_list_hash.insert(std::pair<std::string, Route*>(list_name, this)).second)
@@ -175,9 +175,7 @@ std::string Route::name_no_abbrev()
 double Route::clinched_by_traveler(TravelerList *t)
 {	double miles = 0;
 	for (HighwaySegment *s : segment_list)
-	{	std::unordered_set<TravelerList*>::iterator t_found = s->clinched_by.find(t);
-		if (t_found != s->clinched_by.end()) miles += s->length;
-	}
+		if (s->clinched_by.count(t)) miles += s->length;
 	return miles;
 }
 

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -88,7 +88,6 @@ class Route
 	void print_route();
 	HighwaySegment* find_segment_by_waypoints(Waypoint*, Waypoint*);
 	std::string chopped_rtes_line();
-	std::string csv_line();
 	std::string readable_name();
 	std::string list_entry_name();
 	std::string name_no_abbrev();

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -94,7 +94,7 @@ class Route
 	double clinched_by_traveler(TravelerList *);
 	//std::string list_line(int, int);
 	void write_nmp_merged();
-	void store_traveled_segments(TravelerList*, std::ofstream &, unsigned int, unsigned int);
+	void store_traveled_segments(TravelerList*, std::ofstream&, std::string*, unsigned int, unsigned int);
 	void compute_stats_r();
 	void con_mismatch();
 	Waypoint* con_beg();

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -11,7 +11,7 @@
 #include "../../functions/upper.h"
 #include <cstring>
 
-TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorList* el)
+TravelerList::TravelerList(std::string travname, ErrorList* el)
 {	// initialize object variables
 	active_systems_traveled = 0;
 	active_systems_clinched = 0;
@@ -39,13 +39,15 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 	log << ctime(&StartTime);
 	mtx.unlock();
 	// write last update date & time if known
-	if (updarr)
-	{	log << travname << " last updated: " << *updarr[1] << ' ' << *updarr[2] << ' ' << *updarr[3] << '\n';
+	try {	std::string** updarr = TravelerList::listupdates.at(travname);
+		log << travname << " last updated: " << *updarr[1] << ' ' << *updarr[2] << ' ' << *updarr[3] << '\n';
 		update = updarr[1];
 		delete updarr[2];
 		delete updarr[3];
 		delete[] updarr;
-	} else	update = 0;
+	    }	catch (const std::out_of_range& oor)
+	    {	update = 0;
+	    }
 
 	// read .list file into memory
 	  // we can't getline here because it only allows one delimiter, and we need two; '\r' and '\n'.

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -28,6 +28,7 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 	// variables used in construction
 	unsigned int list_entries = 0;
 	std::ofstream splist;
+	std::string* update;
 	if (Args::splitregionpath != "") splist.open(Args::splitregionpath+"/list_files/"+travname);
 
 	// init user log
@@ -136,6 +137,7 @@ TravelerList::TravelerList(std::string travname, std::string* updarr[], ErrorLis
 		#undef UPDATE_NOTE
 	}
 	delete[] listdata;
+	if (update) delete update;
 	log << "Processed " << list_entries << " good lines marking " << clinched_segments.size() << " segments traveled.\n";
 	log.close();
 	splist.close();

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -43,7 +43,7 @@ class TravelerList
 	static std::list<TravelerList*>::iterator tl_it;
 	static std::unordered_map<std::string, std::string**> listupdates;
 
-	TravelerList(std::string, std::string*[], ErrorList*);
+	TravelerList(std::string, ErrorList*);
 	double active_only_miles();
 	double active_preview_miles();
 	double system_region_miles(HighwaySystem *);

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -24,7 +24,6 @@ class TravelerList
 	public:
 	std::unordered_set<HighwaySegment*> clinched_segments;
 	std::string traveler_name;
-	std::string *update;
 	std::unordered_map<Region*, double> active_preview_mileage_by_region;				// total mileage per region, active+preview only
 	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only
 	std::unordered_map<HighwaySystem*, std::unordered_map<Region*, double>> system_region_mileages;	// mileage per region per system

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -112,7 +112,7 @@ else {	r->system->lniu_mtx.lock();
 		index2 = lit1->second;
 		reverse = 1;
 	     }
-	r->store_traveled_segments(this, log, index1, index2);
+	r->store_traveled_segments(this, log, update, index1, index2);
 	// new .list lines for region split-ups
 	if (Args::splitregion == r->region->code)
 	{

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -66,11 +66,11 @@ if (lit1 == r->alt_label_hash.end() || lit2 == r->alt_label_hash.end())
 }
 // are either of the labels used duplicates?
 char duplicate = 0;
-if (r->duplicate_labels.find(fields[2]) != r->duplicate_labels.end())
+if (r->duplicate_labels.count(fields[2]))
 {	log << r->region->code << ": duplicate label " << fields[2] << " in " << r->root << '\n';
 	duplicate = 1;
 }
-if (r->duplicate_labels.find(fields[3]) != r->duplicate_labels.end())
+if (r->duplicate_labels.count(fields[3]))
 {	log << r->region->code << ": duplicate label " << fields[3] << " in " << r->root << '\n';
 	duplicate = 1;
 }

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -119,8 +119,8 @@ if (r1 == r2)
 		continue;
 	}
 	if (index1 <= index2)
-		r1->store_traveled_segments(this, log, index1, index2);
-	else	r1->store_traveled_segments(this, log, index2, index1);
+		r1->store_traveled_segments(this, log, update, index1, index2);
+	else	r1->store_traveled_segments(this, log, update, index2, index1);
      }
 else {	// user log warning for DISCONNECTED_ROUTE errors
 	if (r1->con_route->disconnected)
@@ -145,15 +145,15 @@ else {	// user log warning for DISCONNECTED_ROUTE errors
 	}
 	// mark the beginning chopped route from index1 to its end
 	if (r1->is_reversed())
-		r1->store_traveled_segments(this, log, 0, index1);
-	else	r1->store_traveled_segments(this, log, index1, r1->segment_list.size());
+		r1->store_traveled_segments(this, log, update, 0, index1);
+	else	r1->store_traveled_segments(this, log, update, index1, r1->segment_list.size());
 	// mark the ending chopped route from its beginning to index2
 	if (r2->is_reversed())
-		r2->store_traveled_segments(this, log, index2, r2->segment_list.size());
-	else	r2->store_traveled_segments(this, log, 0, index2);
+		r2->store_traveled_segments(this, log, update, index2, r2->segment_list.size());
+	else	r2->store_traveled_segments(this, log, update, 0, index2);
 	// mark any intermediate chopped routes in their entirety.
 	for (size_t r = r1->rootOrder+1; r < r2->rootOrder; r++)
-	  r1->con_route->roots[r]->store_traveled_segments(this, log, 0, r1->con_route->roots[r]->segment_list.size());
+	  r1->con_route->roots[r]->store_traveled_segments(this, log, update, 0, r1->con_route->roots[r]->segment_list.size());
      }
 // both labels are valid; mark in use & proceed
 r1->system->lniu_mtx.lock();

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -92,11 +92,11 @@ if (lit1 == r1->alt_label_hash.end() || lit2 == r2->alt_label_hash.end())
 }
 // are either of the labels used duplicates?
 char duplicate = 0;
-if (r1->duplicate_labels.find(fields[2]) != r1->duplicate_labels.end())
+if (r1->duplicate_labels.count(fields[2]))
 {	log << r1->region->code << ": duplicate label " << fields[2] << " in " << r1->root << ".\n";
 	duplicate = 1;
 }
-if (r2->duplicate_labels.find(fields[5]) != r2->duplicate_labels.end())
+if (r2->duplicate_labels.count(fields[5]))
 {	log << r2->region->code << ": duplicate label " << fields[5] << " in " << r2->root << ".\n";
 	duplicate = 1;
 }

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -65,7 +65,7 @@ void TravelerList::userlog(ClinchedDBValues *clin_db_val, const double total_act
 			sysregions.sort(sort_regions_by_code);
 			for (Region *region : sysregions)
 			{	double system_region_mileage = 0;
-				if (system_region_mileages.count(h) && system_region_mileages.at(h).count(region))
+				if (system_region_mileages.at(h).count(region))
 				{	system_region_mileage = system_region_mileages.at(h).at(region);
 					sprintf(fstr, "%.15g", system_region_mileage);
 					if (!strchr(fstr, '.')) strcat(fstr, ".0");

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -100,16 +100,10 @@ Waypoint::Waypoint(char *line, Route *rte)
 }
 
 std::string Waypoint::str()
-{	std::string ans = route->root + " " + label;
-	char coordstr[51];
-	sprintf(coordstr, "%.15g", lat);
-	if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-	ans += " (";
-	ans += coordstr;
-	ans += ',';
-	sprintf(coordstr, "%.15g", lng);
-	if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-	ans += coordstr;
+{	std::string ans = route->root + " " + label + " (";
+	char s[51]; int
+	e=sprintf(s,"%.15g",lat); if (lat==int(lat)) strcpy(s+e,".0"); ans+=s; ans+=',';
+	e=sprintf(s,"%.15g",lng); if (lng==int(lng)) strcpy(s+e,".0"); ans+=s;
 	return ans + ')';
 }
 
@@ -238,15 +232,11 @@ void Waypoint::nmplogs(std::unordered_set<std::string> &nmpfps, std::ofstream &n
 			// make sure we only plot once, since the NMP should be listed
 			// both ways (other_w in w's list, w in other_w's list)
 			if (sort_root_at_label(this, other_w))
-			{	char coordstr[51];
-
-				nmpnmp << root_at_label();
-				sprintf(coordstr, " %.15g", lat);
-				if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-				nmpnmp << coordstr;
-				sprintf(coordstr, " %.15g", lng);
-				if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-				nmpnmp << coordstr;
+			{	char s[51];
+				#define PYTHON_STYLE_FLOAT(F) e=sprintf(s," %.15g",F); if (F==int(F)) strcpy(s+e,".0"); nmpnmp<<s;
+				nmpnmp << root_at_label(); int
+				PYTHON_STYLE_FLOAT(lat)
+				PYTHON_STYLE_FLOAT(lng)
 				if (fp || li)
 				{	nmpnmp << ' ';
 					if (fp) nmpnmp << "FP";
@@ -255,18 +245,15 @@ void Waypoint::nmplogs(std::unordered_set<std::string> &nmpfps, std::ofstream &n
 				nmpnmp << '\n';
 
 				nmpnmp << other_w->root_at_label();
-				sprintf(coordstr, " %.15g", other_w->lat);
-				if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-				nmpnmp << coordstr;
-				sprintf(coordstr, " %.15g", other_w->lng);
-				if (!strchr(coordstr, '.')) strcat(coordstr, ".0"); // add single trailing zero to ints for compatibility with Python
-				nmpnmp << coordstr;
+				PYTHON_STYLE_FLOAT(other_w->lat)
+				PYTHON_STYLE_FLOAT(other_w->lng)
 				if (fp || li)
 				{	nmpnmp << ' ';
 					if (fp) nmpnmp << "FP";
 					if (li) nmpnmp << "LI";
 				}
 				nmpnmp << '\n';
+				#undef PYTHON_STYLE_FLOAT
 			}
 		}
 		// indicate if this was in the FP list or if it's off by exact amt

--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/straightforward_intersection.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/straightforward_intersection.cpp
@@ -14,7 +14,7 @@ if (ap_coloc.size() == 2)
 		// if this is taken or if name_no_abbrev()s match, attempt to add in abbrevs if there's point in doing so
 		if (ap_coloc[0]->route->abbrev.size() || ap_coloc[1]->route->abbrev.size())
 		{    g->set_mtx[newname.back()].lock();
-		     bool taken = g->vertex_names[newname.back()].find(newname) != g->vertex_names[newname.back()].end();
+		     bool taken = g->vertex_names[newname.back()].count(newname);
 		     g->set_mtx[newname.back()].unlock();
 		     if (taken || ap_coloc[0]->route->name_no_abbrev() == ap_coloc[1]->route->name_no_abbrev())
 		     {	const char *u0 = strchr(ap_coloc[0]->label.data(), '_');

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -294,6 +294,7 @@ void WaypointQuadtree::terminal_nodes(std::forward_list<WaypointQuadtree*>* node
 
 void WaypointQuadtree::sort()
 {	std::forward_list<WaypointQuadtree*>* nodes = new std::forward_list<WaypointQuadtree*>[Args::numthreads];
+						      // deleted @ end of this function
 	size_t slot = 0;
 	terminal_nodes(nodes, slot);
 

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -62,7 +62,7 @@ void WaypointQuadtree::insert(Waypoint *w, bool init)
 				// DUPLICATE_COORDS datacheck
 				for (Waypoint* p : *other_w->colocated)
 				  if (p->route == w->route)
-				  {	char fstr[44];
+				  {	char fstr[48];
 					sprintf(fstr, "(%.15g,%.15g)", w->lat, w->lng);
 					Datacheck::add(w->route, p->label, w->label, "", "DUPLICATE_COORDS", fstr);
 				  }

--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -311,7 +311,7 @@ void sqlfile1
 	  {	if (!first) sqlfile << ',';
 		first = 0;
 		double active_miles = 0;
-		if (t->active_only_mileage_by_region.find(rm.first) != t->active_only_mileage_by_region.end())
+		if (t->active_only_mileage_by_region.count(rm.first))
 		  active_miles = t->active_only_mileage_by_region.at(rm.first);
 		char fstr[65];
 		sprintf(fstr, "','%.15g','%.15g')\n", active_miles, rm.second);

--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -23,7 +23,7 @@ void sqlfile1
 	std::list<std::string*> *updates,
 	std::list<std::string*> *systemupdates,
 	std::mutex* term_mtx
-    ){
+    ){	char fstr[65];
 	// Once all data is read in and processed, create a .sql file that will
 	// create all of the DB tables to be used by other parts of the project
 	std::ofstream sqlfile(Args::databasename+".sql");
@@ -142,7 +142,9 @@ void sqlfile1
 	  for (Route *r : h->route_list)
 	  {	if (!first) sqlfile << ',';
 		first = 0;
-		sqlfile << "(" << r->csv_line() << ",'" << csvOrder << "')\n";
+		sprintf(fstr, "%.17g", r->mileage);
+		sqlfile << "('" << r->system->systemname << "','" << r->region->code << "','" << r->route << "','" << r->banner << "','" << r->abbrev
+			<< "','" << double_quotes(r->city) << "','" << r->root << "','" << fstr << "','" << r->rootOrder << "','" << csvOrder << "')\n";
 		csvOrder += 1;
 	  }
 	sqlfile << ";\n";
@@ -164,7 +166,9 @@ void sqlfile1
 	  for (ConnectedRoute *cr : h->con_route_list)
 	  {	if (!first) sqlfile << ',';
 		first = 0;
-		sqlfile << "(" << cr->csv_line() << ",'" << csvOrder << "')\n";
+		sprintf(fstr, "','%.15g'", cr->mileage);
+		sqlfile << "('" << cr->system->systemname << "','" << cr->route << "','" << cr->banner << "','" << double_quotes(cr->groupname)
+			<< "','" << (cr->roots.size() ? cr->roots[0]->root.data() : "ERROR_NO_ROOTS") << fstr << ",'" << csvOrder << "')\n";
 		csvOrder += 1;
 	  }
 	sqlfile << ";\n";
@@ -269,7 +273,6 @@ void sqlfile1
 	{	if (region->active_only_mileage+region->active_preview_mileage == 0) continue;
 		if (!first) sqlfile << ',';
 		first = 0;
-		char fstr[65];
 		sprintf(fstr, "','%.15g','%.15g')\n", region->active_only_mileage, region->active_preview_mileage);
 		sqlfile << "('" << region->code << fstr;
 	}
@@ -290,7 +293,6 @@ void sqlfile1
 	    for (std::pair<Region* const,double>& rm : h->mileage_by_region)
 	    {	if (!first) sqlfile << ',';
 		first = 0;
-		char fstr[35];
 		sprintf(fstr, "','%.15f')\n", rm.second);
 		sqlfile << "('" << h->systemname << "','" << rm.first->code << fstr;
 	    }
@@ -313,7 +315,6 @@ void sqlfile1
 		double active_miles = 0;
 		if (t->active_only_mileage_by_region.count(rm.first))
 		  active_miles = t->active_only_mileage_by_region.at(rm.first);
-		char fstr[65];
 		sprintf(fstr, "','%.15g','%.15g')\n", active_miles, rm.second);
 		sqlfile << "('" << rm.first->code << "','" << t->traveler_name << fstr;
 	  }

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -477,6 +477,7 @@ int main(int argc, char *argv[])
 	cout << et.et() << "Augmenting travelers for detected concurrent segments." << flush;
       #ifdef threading_enabled
 	list<string>* augment_lists = new list<string>[Args::numthreads];
+				      // deleted once written to concurrencies.log
 	TravelerList::tl_it = TravelerList::allusers.begin();
 	THREADLOOP thr[t] = thread(ConcAugThread, t, &list_mtx, augment_lists+t);
 	THREADLOOP thr[t].join();

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
 	{	size_t NumFields = 4;
 		string** fields = new string*[4];
 		fields[0] = new string;	// deleted upon construction of unordered_map element
-		fields[1] = new string;	// stays in TravelerList object
+		fields[1] = new string;	// deleted @ end of TravelerList ctor
 		fields[2] = new string;	// deleted once written to user log
 		fields[3] = new string;	// deleted once written to user log
 		split(line, fields, NumFields, ' ');

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -370,13 +370,7 @@ int main(int argc, char *argv[])
       #else
 	for (string &t : TravelerList::ids)
 	{	cout << t << ' ' << std::flush;
-		std::string** update;
-		try {	update = TravelerList::listupdates.at(t);
-		    }
-		catch (const std::out_of_range& oor)
-		    {	update = 0;
-		    }
-		TravelerList::allusers.push_back(new TravelerList(t, update, &el));
+		TravelerList::allusers.push_back(new TravelerList(t, &el));
 	}
       #endif
 	TravelerList::ids.clear();

--- a/siteupdate/cplusplus/tasks/concurrency_detection.cpp
+++ b/siteupdate/cplusplus/tasks/concurrency_detection.cpp
@@ -37,7 +37,7 @@ cout << "!\n";
 // When splitting a region, perform a sanity check on concurrencies in its systems
 if (Args::splitregionpath != "")
 {	for (HighwaySystem *h : HighwaySystem::syslist)
-	{	if (splitsystems.find(h->systemname) == splitsystems.end()) continue;
+	{	if (!splitsystems.count(h->systemname)) continue;
 		ofstream fralog(Args::splitregionpath + "/logs/" + h->systemname + "-concurrencies.log");
 		for (Route *r : h->route_list)
 		{	if (r->region->code.substr(0, Args::splitregion.size()) != Args::splitregion) continue;

--- a/siteupdate/cplusplus/tasks/subgraphs/area.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/area.cpp
@@ -12,6 +12,7 @@ while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
 	char *cline = new char[line.size()+1];
+		      // deleted @ end of this while loop after tokens are processed
 	strcpy(cline, line.data());
 	for (char *token = strtok(cline, ";"); token; token = strtok(0, ";")) fields.push_back(token);
 	if (fields.size() != 5)

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -12,6 +12,7 @@ while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
 	char *cline = new char[line.size()+1];
+		      // deleted @ end of this while loop after tokens are processed
 	strcpy(cline, line.data());
 	for (char *token = strtok(cline, ";"); token; token = strtok(0, ";")) fields.push_back(token);
 	if (fields.size() != 3)

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -11,6 +11,7 @@ while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
 	char *cline = new char[line.size()+1];
+		      // deleted @ end of this while loop after tokens are processed
 	strcpy(cline, line.data());
 	for (char *token = strtok(cline, ";"); token; token = strtok(0, ";")) fields.push_back(token);
 	if (fields.size() != 3)

--- a/siteupdate/cplusplus/templates/set_intersection.cpp
+++ b/siteupdate/cplusplus/templates/set_intersection.cpp
@@ -3,7 +3,7 @@ template <class item>
 std::unordered_set<item> operator & (const std::unordered_set<item> &a, const std::unordered_set<item> &b)
 {	std::unordered_set<item> s;
 	for (const item &i : a)
-	  if (b.find(i) != b.end())
+	  if (b.count(i))
 	    s.insert(i);
 	return s;
 }

--- a/siteupdate/cplusplus/threads/ReadListThread.cpp
+++ b/siteupdate/cplusplus/threads/ReadListThread.cpp
@@ -13,12 +13,7 @@ void ReadListThread(unsigned int id, std::mutex* tl_mtx, ErrorList* el)
 		std::cout << tl << ' ' << std::flush;
 		tl_mtx->unlock();
 		std::string** update;
-		try {	update = TravelerList::listupdates.at(tl);
-		    }
-		catch (const std::out_of_range& oor)
-		    {	update = 0;
-		    }
-		TravelerList *t = new TravelerList(tl, update, el);
+		TravelerList *t = new TravelerList(tl, el);
 				  // deleted on termination of program
 		TravelerList::mtx.lock();
 		TravelerList::allusers.push_back(t);

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3600,7 +3600,7 @@ for t in traveler_lists:
                     t.log_entries.append("System " + h.systemname + " by region:")
                 for region in sorted(h.mileage_by_region):
                     system_region_mileage = 0.0
-                    if h.systemname in t.system_region_mileages and region in t.system_region_mileages[h.systemname]:
+                    if region in t.system_region_mileages[h.systemname]:
                         system_region_mileage = t.system_region_mileages[h.systemname][region]
                         csmbr_values.append("('" + h.systemname + "','" + region + "','"
                                             + t.traveler_name + "','" +

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3475,11 +3475,11 @@ print("!", flush=True)
 print(et.et() + "Writing highway data stats log file (highwaydatastats.log).",flush=True)
 hdstatsfile = open(args.logfilepath+"/highwaydatastats.log","wt",encoding='UTF-8')
 hdstatsfile.write("Travel Mapping highway mileage as of " + str(datetime.datetime.now()) + '\n')
-active_only_miles = math.fsum(list(active_only_mileage_by_region.values()))
+active_only_miles = math.fsum(active_only_mileage_by_region.values())
 hdstatsfile.write("Active routes (active): " + "{0:.2f}".format(active_only_miles) + " mi\n")
-active_preview_miles = math.fsum(list(active_preview_mileage_by_region.values()))
+active_preview_miles = math.fsum(active_preview_mileage_by_region.values())
 hdstatsfile.write("Clinchable routes (active, preview): " + "{0:.2f}".format(active_preview_miles) + " mi\n")
-overall_miles = math.fsum(list(overall_mileage_by_region.values()))
+overall_miles = math.fsum(overall_mileage_by_region.values())
 hdstatsfile.write("All routes (active, preview, devel): " + "{0:.2f}".format(overall_miles) + " mi\n")
 hdstatsfile.write("Breakdown by region:\n")
 # let's sort alphabetically by region instead of using whatever order
@@ -3487,13 +3487,13 @@ hdstatsfile.write("Breakdown by region:\n")
 # a nice enhancement later here might break down by continent, then country,
 # then region
 region_entries = []
-for region in list(overall_mileage_by_region.keys()):
+for region in overall_mileage_by_region:
     # look up active+preview and active-only mileages if they exist
-    if region in list(active_preview_mileage_by_region.keys()):
+    if region in active_preview_mileage_by_region:
         region_active_preview_miles = active_preview_mileage_by_region[region]
     else:
         region_active_preview_miles = 0.0
-    if region in list(active_only_mileage_by_region.keys()):
+    if region in active_only_mileage_by_region:
         region_active_only_miles = active_only_mileage_by_region[region]
     else:
         region_active_only_miles = 0.0
@@ -3508,11 +3508,11 @@ for e in region_entries:
 
 for h in highway_systems:
     hdstatsfile.write("System " + h.systemname + " (" + h.level + ") total: "
-                      + "{0:.2f}".format(math.fsum(list(h.mileage_by_region.values()))) \
+                      + "{0:.2f}".format(math.fsum(h.mileage_by_region.values())) \
                              + ' mi\n')
     if len(h.mileage_by_region) > 1:
         hdstatsfile.write("System " + h.systemname + " by region:\n")
-        for region in sorted(h.mileage_by_region.keys()):
+        for region in sorted(h.mileage_by_region):
             hdstatsfile.write(region + ": " + "{0:.2f}".format(h.mileage_by_region[region]) + " mi\n")
     hdstatsfile.write("System " + h.systemname + " by route:\n")
     for cr in h.con_route_list:
@@ -3540,13 +3540,13 @@ print(et.et() + "Creating per-traveler stats log entries and augmenting data str
 for t in traveler_lists:
     print(".",end="",flush=True)
     t.log_entries.append("Clinched Highway Statistics")
-    t_active_only_miles = math.fsum(list(t.active_only_mileage_by_region.values()))
+    t_active_only_miles = math.fsum(t.active_only_mileage_by_region.values())
     t.log_entries.append("Overall in active systems: " + format_clinched_mi(t_active_only_miles,active_only_miles))
-    t_active_preview_miles = math.fsum(list(t.active_preview_mileage_by_region.values()))
+    t_active_preview_miles = math.fsum(t.active_preview_mileage_by_region.values())
     t.log_entries.append("Overall in active+preview systems: " + format_clinched_mi(t_active_preview_miles,active_preview_miles))
 
     t.log_entries.append("Overall by region: (each line reports active only then active+preview)")
-    for region in sorted(t.active_preview_mileage_by_region.keys()):
+    for region in sorted(t.active_preview_mileage_by_region):
         try:
             total_active_miles = active_only_mileage_by_region[region]
         except KeyError:
@@ -3579,13 +3579,13 @@ for t in traveler_lists:
                 preview_systems += 1
             t_system_overall = 0.0
             if h.systemname in t.system_region_mileages:
-                t_system_overall = math.fsum(list(t.system_region_mileages[h.systemname].values()))
+                t_system_overall = math.fsum(t.system_region_mileages[h.systemname].values())
             if t_system_overall > 0.0:
                 if h.active():
                     t.active_systems_traveled += 1
                 else:
                     t.preview_systems_traveled += 1
-                if t_system_overall == math.fsum(list(h.mileage_by_region.values())):
+                if t_system_overall == math.fsum(h.mileage_by_region.values()):
                     if h.active():
                         t.active_systems_clinched += 1
                     else:
@@ -3595,10 +3595,10 @@ for t in traveler_lists:
                 # the DB, but add to logs only if it's been traveled at
                 # all and it covers multiple regions
                 t.log_entries.append("System " + h.systemname + " (" + h.level + ") overall: " +
-                                     format_clinched_mi(t_system_overall, math.fsum(list(h.mileage_by_region.values()))))
+                                     format_clinched_mi(t_system_overall, math.fsum(h.mileage_by_region.values())))
                 if len(h.mileage_by_region) > 1:
                     t.log_entries.append("System " + h.systemname + " by region:")
-                for region in sorted(h.mileage_by_region.keys()):
+                for region in sorted(h.mileage_by_region):
                     system_region_mileage = 0.0
                     if h.systemname in t.system_region_mileages and region in t.system_region_mileages[h.systemname]:
                         system_region_mileage = t.system_region_mileages[h.systemname][region]
@@ -3692,19 +3692,19 @@ print(et.et() + "Writing stats csv files.",flush=True)
 # first, overall per traveler by region, both active only and active+preview
 allfile = open(args.csvstatfilepath + "/allbyregionactiveonly.csv","w",encoding='UTF-8')
 allfile.write("Traveler,Total")
-regions = sorted(active_only_mileage_by_region.keys())
+regions = sorted(active_only_mileage_by_region)
 for region in regions:
     allfile.write(',' + region)
 allfile.write('\n')
 for t in traveler_lists:
-    allfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(list(t.active_only_mileage_by_region.values()))))
+    allfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(t.active_only_mileage_by_region.values())))
     for region in regions:
-        if region in t.active_only_mileage_by_region.keys():
+        if region in t.active_only_mileage_by_region:
             allfile.write(',{0:.2f}'.format(t.active_only_mileage_by_region[region]))
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(list(active_only_mileage_by_region.values()))))
+allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_only_mileage_by_region.values())))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_only_mileage_by_region[region]))
 allfile.write('\n')
@@ -3713,19 +3713,19 @@ allfile.close()
 # active+preview
 allfile = open(args.csvstatfilepath + "/allbyregionactivepreview.csv","w",encoding='UTF-8')
 allfile.write("Traveler,Total")
-regions = sorted(active_preview_mileage_by_region.keys())
+regions = sorted(active_preview_mileage_by_region)
 for region in regions:
     allfile.write(',' + region)
 allfile.write('\n')
 for t in traveler_lists:
-    allfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(list(t.active_preview_mileage_by_region.values()))))
+    allfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(t.active_preview_mileage_by_region.values())))
     for region in regions:
-        if region in t.active_preview_mileage_by_region.keys():
+        if region in t.active_preview_mileage_by_region:
             allfile.write(',{0:.2f}'.format(t.active_preview_mileage_by_region[region]))
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(list(active_preview_mileage_by_region.values()))))
+allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_preview_mileage_by_region.values())))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_preview_mileage_by_region[region]))
 allfile.write('\n')
@@ -3737,21 +3737,21 @@ for h in highway_systems:
         continue
     sysfile = open(args.csvstatfilepath + "/" + h.systemname + '-all.csv',"w",encoding='UTF-8')
     sysfile.write('Traveler,Total')
-    regions = sorted(h.mileage_by_region.keys())
+    regions = sorted(h.mileage_by_region)
     for region in regions:
         sysfile.write(',' + region)
     sysfile.write('\n')
     for t in traveler_lists:
         # only include entries for travelers who have any mileage in system
         if h.systemname in t.system_region_mileages:
-            sysfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(list(t.system_region_mileages[h.systemname].values()))))
+            sysfile.write(t.traveler_name + ",{0:.2f}".format(math.fsum(t.system_region_mileages[h.systemname].values())))
             for region in regions:
                 if region in t.system_region_mileages[h.systemname]:
                     sysfile.write(',{0:.2f}'.format(t.system_region_mileages[h.systemname][region]))
                 else:
                     sysfile.write(',0')
             sysfile.write('\n')
-    sysfile.write('TOTAL,{0:.2f}'.format(math.fsum(list(h.mileage_by_region.values()))))
+    sysfile.write('TOTAL,{0:.2f}'.format(math.fsum(h.mileage_by_region.values())))
     for region in regions:
         sysfile.write(',{0:.2f}'.format(h.mileage_by_region[region]))
     sysfile.write('\n')
@@ -4000,7 +4000,7 @@ else:
         print(fields[1] + ' ', end="", flush=True)
         region_list = []
         selected_regions = fields[2].split(",")
-        for r in all_regions.keys():
+        for r in all_regions:
             if r in selected_regions and r in active_preview_mileage_by_region:
                 region_list.append(r)
         graph_data.write_subgraphs_tmg(graph_list, args.graphfilepath + "/", fields[1],
@@ -4517,15 +4517,15 @@ else:
                   '), activeMileage DOUBLE, activePreviewMileage DOUBLE);\n')
     sqlfile.write('INSERT INTO overallMileageByRegion VALUES\n')
     first = True
-    for region in list(active_preview_mileage_by_region.keys()):
+    for region in active_preview_mileage_by_region:
         if not first:
             sqlfile.write(",")
         first = False
         active_only_mileage = 0.0
         active_preview_mileage = 0.0
-        if region in list(active_only_mileage_by_region.keys()):
+        if region in active_only_mileage_by_region:
             active_only_mileage = active_only_mileage_by_region[region]
-        if region in list(active_preview_mileage_by_region.keys()):
+        if region in active_preview_mileage_by_region:
             active_preview_mileage = active_preview_mileage_by_region[region]
         sqlfile.write("('" + region + "','" +
                       str(active_only_mileage) + "','" +
@@ -4542,7 +4542,7 @@ else:
     first = True
     for h in highway_systems:
         if h.active_or_preview():
-            for region in list(h.mileage_by_region.keys()):
+            for region in h.mileage_by_region:
                 if not first:
                     sqlfile.write(",")
                 first = False
@@ -4558,12 +4558,12 @@ else:
     sqlfile.write('INSERT INTO clinchedOverallMileageByRegion VALUES\n')
     first = True
     for t in traveler_lists:
-        for region in list(t.active_preview_mileage_by_region.keys()):
+        for region in t.active_preview_mileage_by_region:
             if not first:
                 sqlfile.write(",")
             first = False
             active_miles = 0.0
-            if region in list(t.active_only_mileage_by_region.keys()):
+            if region in t.active_only_mileage_by_region:
                 active_miles = t.active_only_mileage_by_region[region]
             sqlfile.write("('" + region + "','" + t.traveler_name + "','" +
                           str(active_miles) + "','" +


### PR DESCRIPTION
### d2cdcaab8fab8cc73561d7870186b800d1f7acb8 set/map/dict cleanup
closes yakra#199

On the C++ side, this was mostly conceived as code-readability cleanup, but it ended up saving a little time on userlog generation, more noticeable on slower machines like lab3.

Python: In theory, saves a wee bit of time, not having to create new list objects from objects that are already iterable/searchable. In practice, it's down near the margin of error; the tiny improvements we can consistently see disappear under the larger fluctuations that happen naturally between runs in other parts of the program. Either way, the code's slightly cleaner.

---

### c8b3c9829367d40c00641ee0ad0fe8cbda47ac80 eliminates an unnecessary membership test

https://github.com/TravelMapping/DataProcessing/blob/d2cdcaab8fab8cc73561d7870186b800d1f7acb8/siteupdate/python-teresco/siteupdate.py#L3603

https://github.com/TravelMapping/DataProcessing/blob/d2cdcaab8fab8cc73561d7870186b800d1f7acb8/siteupdate/cplusplus/classes/TravelerList/userlog.cpp#L68

The first half of the check is unnecessary because to get here...
https://github.com/TravelMapping/DataProcessing/blob/d2cdcaab8fab8cc73561d7870186b800d1f7acb8/siteupdate/python-teresco/siteupdate.py#L3580-L3583

https://github.com/TravelMapping/DataProcessing/blob/d2cdcaab8fab8cc73561d7870186b800d1f7acb8/siteupdate/cplusplus/classes/TravelerList/userlog.cpp#L43-L46

...`t_system_overall` has to be non-zero. But it's just been initialized to zero, and the only way for it to be set otherwise is `if h.systemname in t.system_region_mileages`.

---

### 597682e8535f1a1f08b26e42e9b6a08c5b997182 pyfloat
closes yakra#196

C++: minor speed improvements emulating "Python-style floats", where a single ".0" is appended to integer values.
* `Waypoint::str` and `Waypoint::nmplogs` write to nearmisspoints.log & tm-master.nmp respectively.
* Rather than apply similar changes to `Route::csv_line` and optionally adding "pyfloat" support to `ConnectedRoute::csv_line` to conform, these functions were removed in favor of inserting their elements directly into the file stream in sqlfile, for a small speedup. Python-style floats were dropped in the process; the odds of a Route or ConnectedRoute's mileage being an exact integer are close to zero. I'll cross that bridge if & when I come to it.
* `TravelerList::userlog` is no-build for now, to avoid merge conflicts. I anticipate refactoring the relevant bits of code into the `sqlfile1` function.

---

### 6e0693fba6462f2ef4fca142ce87882a9171e1ad fix potential buffer overflow & a3b35e045d0e319e37bd8641614b6b14c54d3531 comments
are what they say on the tin.

---

### 3ae68f11245a867ec2677424232eabbea28b244d don't store `update` in TravelerList
saves a tiny bit of RAM.

---

### d56e5a67555922d06730363ca779c0acdc224dac update info retrieval
cleans up & consolidates the code that finds the update date & time for each .list file upon construction of its TravelerList object.