### PR TITLE
NMP speed improvements

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -3,12 +3,14 @@ CXXFLAGS = -std=c++11 -Wno-comment -Wno-dangling-else -Wno-logical-op-parenthese
 
 MTObjects = siteupdateMT.o functions/sql_fileMT.o threads/threads.o \
   classes/GraphGeneration/HighwayGraphMT.o \
+  classes/Route/read_wptMT.o \
   classes/WaypointQuadtree/WaypointQuadtreeMT.o \
   functions/allbyregionactiveonlyMT.o \
   functions/allbyregionactivepreviewMT.o
 
 STObjects = siteupdateST.o functions/sql_fileST.o \
   classes/GraphGeneration/HighwayGraphST.o \
+  classes/Route/read_wptST.o \
   classes/WaypointQuadtree/WaypointQuadtreeST.o \
   functions/allbyregionactiveonlyST.o \
   functions/allbyregionactivepreviewST.o
@@ -30,7 +32,6 @@ CommonObjects = \
   classes/HighwaySystem/route_integrity.o \
   classes/Region/Region.o \
   classes/Route/Route.o \
-  classes/Route/read_wpt.o \
   classes/TravelerList/TravelerList.o \
   classes/TravelerList/userlog.o \
   classes/Waypoint/Waypoint.o \

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -65,11 +65,19 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 		if (!*lines[l]) continue;		// whitespace-only line; skip
 		Waypoint *w = new Waypoint(lines[l], this);
 			      // deleted by WaypointQuadtree::final_report, or immediately below if invalid
+		// lat & lng both equal to 0 marks a point as invalid
 		if (!w->lat && !w->lng)
 		{	delete w;
 			continue;
 		}
 		point_list.push_back(w);
+
+	      #ifndef threading_enabled
+		// look for near-miss points (before we add this one in)
+		all_waypoints->near_miss_waypoints(w, 0.0005);
+		for (Waypoint *other_w : w->near_miss_points) other_w->near_miss_points.push_front(w);
+	      #endif
+
 		all_waypoints->insert(w, 1);
 
 		// single-point Datachecks, and HighwaySegment

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -21,7 +21,7 @@ class WaypointQuadtree
 	WaypointQuadtree(double, double, double, double);
 	void refine();
 	void insert(Waypoint*, bool);
-	std::forward_list<Waypoint*> near_miss_waypoints(Waypoint*, double);
+	void near_miss_waypoints(Waypoint*, double);
 	std::string str();
 	unsigned int size();
 	std::list<Waypoint*> point_list();

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -254,8 +254,6 @@ int main(int argc, char *argv[])
 	HighwaySystem::it = HighwaySystem::syslist.begin();
 	THREADLOOP thr[t] = thread(NmpSearchThread, t, &list_mtx, &all_waypoints);
 	THREADLOOP thr[t].join();
-      #else
-	for (Waypoint *w : all_waypoints.point_list()) w->near_miss_points = all_waypoints.near_miss_waypoints(w, 0.0005);
       #endif
 
 	// Near-miss point log

--- a/siteupdate/cplusplus/threads/NmpSearchThread.cpp
+++ b/siteupdate/cplusplus/threads/NmpSearchThread.cpp
@@ -13,6 +13,6 @@ void NmpSearchThread(unsigned int id, std::mutex* hs_mtx, WaypointQuadtree* all_
 		hs_mtx->unlock();
 		for (Route *r : h->route_list)
 		  for (Waypoint *w : r->point_list)
-		    w->near_miss_points = all_waypoints->near_miss_waypoints(w, 0.0005);
+		    all_waypoints->near_miss_waypoints(w, 0.0005);
 	}
 }


### PR DESCRIPTION
## C++
Two components here:
* Close yakra#157
  Don't create a bunch of temporaries and muck about with move constructors & splicing; just push points directly to the nmp list in the `Waypoint` object itself. Saves a rather surprising amount of time for what it is.
  ![nmpdirect](https://user-images.githubusercontent.com/13720877/160157626-f7df872e-2a42-4200-9d0a-52c6e434d03c.png)
* Close #457
  When #280 were enabled, multi-threaded NMP searching came at the cost of a performance hit in single-threaded searches. Background is at #141.
  Conditioning Jim's original formula back in for single-threaded siteupdateST is easy.
  **Speed comparison** after the above component, constructing in place:
  * Time no longer spent specifically `Searching for near-miss points` via **Eric's** method should outweigh
  * the additional time `Reading waypoints for all routes`, which represents **Jim's** method.
    Box | Eric’s | Jim’s
    -- | -- | --
    BT | 1.72 | 1.437
    lab1 | 1.009 | 0.6198
    lab5 | 1.435 | 1.033
    lab2 | 1.349 | 0.966
    lab3 | 1.79 | 1.092
    lab4 | 2.16 | 1.601
    bsdlab | 2.581 | 1.752
* A third component I tried out & rejected was to
https://github.com/TravelMapping/DataProcessing/blob/de796fa866faa446f8e2d098b87ba11a959128e9/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp#L219 in `NmpSearchThread` rather than a single-threaded part of the program. Turns out this is slower.
What can I come up with for an explanation?
  * Turning cache hits into cache misses -- the single-threaded bit already deals with `root` & `label`.
  * Branch prediction effects, whether sorting is done at the same time as iterating down through the quadtree.

---

## Python?
Python OTOH has kept Jim's original "search a partially populated quadtree while reading all waypoints" NMP method the whole time. The only thing to do here is to try out building the NMP lists directly in the `Waypoint` object.
We're still creating and copying (not moving, I presume?) from a bunch of temporaries, right? I'd expect better results than:
Box | de796fa | a768800
-- | -- | --
epoch | 115.24 | 120.19
BT | 113.3 | 111.59
lab1 | 56.98 | 57.07
lab5 | 51.18 | 51
lab2 | 72.24 | 72.09
lab3 | 98.15 | 97.2
lab4 | 80.26 | 79.61
bsdlab | 126.58 | 125.06
noreaster | 93.46 | 92.53

Python is pretty mysterious under the hood. Maybe it has to check whether `w.near_miss_points` has an `append` method every time when attempting to call it, and OTOH knows that locally-declared `near_miss_points` is a list? I don't know man, I didn't do it.

I'm undecided about whether to include this. Sometimes I like to make Python changes that mirror C++ changes, just to keep the two versions structured similarly. Other times I'll leave out changes with no clear benefit, to have a smaller impact on the commit history. Is there a clear benefit here? \*Shrug.\* At least we're down 14 lines of code?
The diff is at a7688007907ebf3fe9a6a16b0b8c8825bd693cfb. @jteresco, say the word and I can push it to this branch. Or leave it out.