### PR TITLE
graph generation speedups

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
@@ -6,15 +6,21 @@
 std::vector<GraphListEntry> GraphListEntry::entries;
 size_t GraphListEntry::num; // iterator for entries
 
-GraphListEntry::GraphListEntry(std::string r, std::string d, char f, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr)
-{	root = r;
-	descr = d;
-	form = f;
-	cat = c;
+// master graph constructor
+GraphListEntry::GraphListEntry(char f, unsigned int v, unsigned int e, unsigned int t):
+	root("tm-master"), descr("All Travel Mapping Data"),
+	vertices(v), edges(e), travelers(t),
+	form(f), cat('M') {}
 
-	regions = rg;
-	systems = sys;
-	placeradius = pr;
+// subgraph constructor
+GraphListEntry::GraphListEntry(std::string r, std::string d, char f, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr):
+	regions(rg), systems(sys), placeradius(pr),
+	root(r), descr(d), form(f), cat(c) {}
+
+void GraphListEntry::add_group(std::string&& r, std::string&& d, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr)
+{	GraphListEntry::entries.emplace_back(r, d, 's', c, rg, sys, pr);
+	GraphListEntry::entries.emplace_back(r, d, 'c', c, rg, sys, pr);
+	GraphListEntry::entries.emplace_back(r, d, 't', c, rg, sys, pr);
 }
 
 std::string GraphListEntry::filename()

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
@@ -11,11 +11,14 @@ class GraphListEntry
 	(or function names if both are on the same line)
 	match column names in the "graphs" DB table. */
 	public:
+	// Info for use in threaded subgraph generation. Not used in DB.
+	std::list<Region*> *regions;
+	std::list<HighwaySystem*> *systems;
+	PlaceRadius *placeradius;
+
+	// Info for the "graphs" DB table
 	std::string root;	std::string filename();
 	std::string descr;
-	std::list<Region*> *regions;		// C++ only, not in DB or Python
-	std::list<HighwaySystem*> *systems;	// C++ only, not in DB or Python
-	PlaceRadius *placeradius;		// C++ only, not in DB or Python
 	unsigned int vertices;
 	unsigned int edges;
 	unsigned int travelers;
@@ -26,5 +29,7 @@ class GraphListEntry
 	static size_t num; // iterator for entries
 	std::string tag();
 
+	GraphListEntry(char, unsigned int, unsigned int, unsigned int); // < master graph ctor | v----- subgraph ctor -----v 
 	GraphListEntry(std::string, std::string, char, char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
+	static void add_group(std::string&&,  std::string&&,  char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -8,7 +8,7 @@
 #include "../Waypoint/Waypoint.h"
 #include "../../templates/contains.cpp"
 
-HGEdge::HGEdge(HighwaySegment *s, HighwayGraph *graph)
+HGEdge::HGEdge(HighwaySegment *s)
 {	// initial construction is based on a HighwaySegment
 	written = new char[Args::numthreads];
 		  // deleted by HGEdge::detach
@@ -158,10 +158,10 @@ void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int th
 }
 
 // write line to tmg traveled edge file
-void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems, std::list<TravelerList*> *traveler_lists)
+void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems, std::list<TravelerList*> *traveler_lists, char* code)
 {	file << vertex1->t_vertex_num[threadnum] << ' ' << vertex2->t_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
-	file << ' ' << segment->clinchedby_code(traveler_lists, threadnum);
+	file << ' ' << segment->clinchedby_code(traveler_lists, code, threadnum);
 	for (HGVertex *intermediate : intermediate_points)
 	{	sprintf(fstr, " %.15g %.15g", intermediate->lat, intermediate->lng);
 		file << fstr;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -1,5 +1,4 @@
 class HGVertex;
-class HighwayGraph;
 class HighwaySegment;
 class HighwaySystem;
 class TravelerList;
@@ -23,13 +22,13 @@ class HGEdge
 	static const unsigned char collapsed = 2;
 	static const unsigned char traveled = 4;
 
-	HGEdge(HighwaySegment *, HighwayGraph *);
+	HGEdge(HighwaySegment *);
 	HGEdge(HGVertex *, unsigned char);
 
 	void detach();
 	void detach(unsigned char);
 	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*);
-	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, std::list<TravelerList*>*);
+	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, std::list<TravelerList*>*, char*);
 	std::string debug_tmg_line(std::list<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -23,16 +23,16 @@ HGVertex::HGVertex(Waypoint *wpt, const std::string *n)
 	    // 2: visible in both traveled & collapsed graphs
 	if (!wpt->colocated)
 	{	if (!wpt->is_hidden) visibility = 2;
-		wpt->route->region->insert_vertex(this);
-		wpt->route->system->insert_vertex(this);
+		wpt->route->region->add_vertex(this);
+		wpt->route->system->add_vertex(this);
 		return;
 	}
 	for (Waypoint *w : *(wpt->colocated))
 	{	// will consider hidden iff all colocated waypoints are hidden
 		if (!w->is_hidden) visibility = 2;
-		w->route->region->insert_vertex(this);
-		w->route->system->insert_vertex(this);
-	}
+		w->route->region->add_vertex(this);	// Yes, a region/system can get the same vertex multiple times
+		w->route->system->add_vertex(this);	// from different routes. But HighwayGraph::matching_vertices_and_edges
+	}						// gets rid of any redundancy when making the final set.
 }
 
 HGVertex::~HGVertex()

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -7,7 +7,7 @@
 #include "../Route/Route.h"
 #include "../Waypoint/Waypoint.h"
 
-HGVertex::HGVertex(Waypoint *wpt, const std::string *n)
+void HGVertex::setup(Waypoint *wpt, const std::string *n)
 {	lat = wpt->lat;
 	lng = wpt->lng;
 	wpt->vertex = this;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -21,6 +21,6 @@ class HGVertex
 	int *t_vertex_num;
 	char visibility;
 
-	HGVertex(Waypoint*, const std::string*);
+	void setup(Waypoint*, const std::string*);
 	~HGVertex();
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -200,7 +200,7 @@ inline void HighwayGraph::matching_vertices_and_edges
 	if (g.systems) for (HighwaySystem *h : *g.systems)
 		svset.insert(h->vertices.begin(), h->vertices.end());
 	if (g.placeradius)
-		pvset = g.placeradius->vertices(qt, this);
+		g.placeradius->vertices(pvset, qt);
 
 	// determine which vertices are within our PlaceRadius, region(s) and/or system(s)
 	if (g.regions)

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -204,16 +204,16 @@ inline void HighwayGraph::matching_vertices_and_edges
 
 	// determine which vertices are within our PlaceRadius, region(s) and/or system(s)
 	if (g.regions)
-	{	mvset = rvset;
+	{	mvset = std::move(rvset);
 		if (g.placeradius)	mvset = mvset & pvset;
 		if (g.systems)		mvset = mvset & svset;
 	}
 	else if (g.systems)
-	{	mvset = svset;
+	{	mvset = std::move(svset);
 		if (g.placeradius)	mvset = mvset & pvset;
 	}
 	else if (g.placeradius)
-		mvset = pvset;
+		mvset = std::move(pvset);
 	else	// no restrictions via region, system, or placeradius, so include everything
 		mvset.insert(vertices.begin(), vertices.end());
 

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -397,25 +397,13 @@ void HighwayGraph::write_subgraphs_tmg
 	unsigned int sv = 0;
 	unsigned int cv = 0;
 	unsigned int tv = 0;
+	char fstr[57];
 	for (HGVertex *v : mv)
-	{	char fstr[57];
-		sprintf(fstr, " %.15g %.15g", v->lat, v->lng);
-		// all vertices for simple graph
-		simplefile << *(v->unique_name) << fstr << '\n';
-		v->s_vertex_num[threadnum] = sv;
-		sv++;
-		// visible vertices...
-		if (v->visibility >= 1)
-		{	// for traveled graph,
-			travelfile << *(v->unique_name) << fstr << '\n';
-			v->t_vertex_num[threadnum] = tv;
-			tv++;
-			if (v->visibility == 2)
-			{	// and for collapsed graph
-				collapfile << *(v->unique_name) << fstr << '\n';
-				v->c_vertex_num[threadnum] = cv;
-				cv++;
-			}
+	{	sprintf(fstr, " %.15g %.15g", v->lat, v->lng);
+		switch(v->visibility) // fall-thru is a Good Thing!
+		{ case 2:  collapfile << *(v->unique_name) << fstr << '\n'; v->c_vertex_num[threadnum] = cv++;
+		  case 1:  travelfile << *(v->unique_name) << fstr << '\n'; v->t_vertex_num[threadnum] = tv++;
+		  default: simplefile << *(v->unique_name) << fstr << '\n'; v->s_vertex_num[threadnum] = sv++;
 		}
 	}
 	// write edges
@@ -425,7 +413,6 @@ void HighwayGraph::write_subgraphs_tmg
 		e->segment->write_label(simplefile, GRAPH(0).systems);
 		simplefile << '\n';
 	}
-	char fstr[57];
 	for (HGEdge *e : mce)
 		e->collapsed_tmg_line(collapfile, fstr, threadnum, GRAPH(0).systems);
 	for (HGEdge *e : mte)

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -28,14 +28,15 @@ class HighwayGraph
 	public:
 	std::unordered_set<std::string> vertex_names[256];	// unique vertex labels
 	std::list<std::string> waypoint_naming_log;		// to track waypoint name compressions
-	std::vector<HGVertex*> vertices;
 	std::mutex set_mtx[256], log_mtx;
+	std::vector<HGVertex> vertices;
+	unsigned int cv, tv, se, ce, te;			// vertex & edge counts
 
 	HighwayGraph(WaypointQuadtree&, ElapsedTime&);
 
 	void clear();
 	void namelog(std::string&&);
-	void simplify(int, std::vector<Waypoint*>*, unsigned int*, std::vector<HGVertex*>*);
+	void simplify(int, std::vector<Waypoint*>*, unsigned int*, const size_t);
 	inline std::pair<std::unordered_set<std::string>::iterator,bool> vertex_name(std::string&);
 
 	inline void matching_vertices_and_edges

--- a/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
@@ -21,6 +21,6 @@ class PlaceRadius
 
 	bool contains_vertex(HGVertex *);
 	bool contains_vertex(double, double);
-	std::unordered_set<HGVertex*> vertices(WaypointQuadtree *, HighwayGraph *);
-	std::unordered_set<HGVertex*> v_search(WaypointQuadtree *, HighwayGraph *, double, double);
+	void vertices(std::unordered_set<HGVertex*>&, WaypointQuadtree *);
+	void v_search(std::unordered_set<HGVertex*>&, WaypointQuadtree *, double, double);
 };

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -65,29 +65,18 @@ std::string HighwaySegment::segment_name()
 	return "";
 }//*/
 
-std::string HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_lists, unsigned int threadnum)
-{	// Return a hexadecimal string encoding which travelers have clinched this segment, for use in "traveled" graph files
-	// Each character stores info for traveler #n thru traveler #n+3
+const char* HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_lists, char* code, unsigned int threadnum)
+{	// Compute a hexadecimal string encoding which travelers
+	// have clinched this segment, for use in "traveled" graph files.
+	// Each character stores info for traveler #n thru traveler #n+3.
 	// The first character stores traveler 0 thru traveler 3,
 	// The second character stores traveler 4 thru traveler 7, etc.
 	// For each character, the low-order bit stores traveler n, and the high bit traveler n+3.
 
 	if (traveler_lists->empty()) return "0";
-	std::string code(ceil(double(traveler_lists->size())/4), '0');
-	//std::cout << str() << " code string initialized (" << clinched_by.size() << '/' << traveler_lists->size() << ')' << std::endl;
-	//unsigned int num = 0;
 	for (TravelerList* t : clinched_by)
-	{	//std::cout << "\t" << num << ": TravNum = " << t->traveler_num[threadnum] << ": " << t->traveler_name << std::endl;
-		//std::cout << "\t" << num << ": TravNum/4 = " << t->traveler_num[threadnum]/4 << std::endl;
-		//std::cout << "\t" << num << ": TravNum%4 = " << TravNum%4 << std::endl;
-		//std::cout << "\t" << num << ": 2 ^ TravNum%4 = " << pow(2, TravNum%4) << std::endl;
-		//std::cout << "\t" << num << ": code[" << TravNum/4 << "] += int(" << pow(2, TravNum%4) << ")" << std::endl;
 		code[t->traveler_num[threadnum]/4] += 1 << t->traveler_num[threadnum]%4;
-		//num++;
-	}
-	//std::cout << "travelers written to array" << std::endl;
-	for (char &nibble : code) if (nibble > '9') nibble += 7;
-	//std::cout << "nibbles >9 -> letters" << std::endl;
+	for (char* nibble = code; *nibble; ++nibble) if (*nibble > '9') *nibble += 7;
 	return code;
 }
 

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -29,7 +29,7 @@ class HighwaySegment
 	std::string csv_line(unsigned int);
 	std::string segment_name();
 	//std::string concurrent_travelers_sanity_check();
-	std::string clinchedby_code(std::list<TravelerList*> *, unsigned int);
+	const char* clinchedby_code(std::list<TravelerList*>*, char*, unsigned int);
 	bool system_match(std::list<HighwaySystem*>*);
 	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
 	void compute_stats_t(TravelerList*);

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -141,9 +141,9 @@ size_t HighwaySystem::con_route_index(ConnectedRoute* cr)
 	return -1; // error, ConnectedRoute not found
 }
 
-void HighwaySystem::insert_vertex(HGVertex* v)
+void HighwaySystem::add_vertex(HGVertex* v)
 {	lniu_mtx.lock();	// re-use an existing mutex...
-	vertices.insert(v);
+	vertices.push_back(v);
 	lniu_mtx.unlock();	// ...rather than make a new one
 }
 

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -36,8 +36,8 @@ class HighwaySystem
 
 	std::vector<Route*> route_list;
 	std::vector<ConnectedRoute*> con_route_list;
+	std::vector<HGVertex*> vertices;
 	std::unordered_map<Region*, double> mileage_by_region;
-	std::unordered_set<HGVertex*> vertices;
 	std::unordered_set<std::string>listnamesinuse, unusedaltroutenames;
 	std::mutex lniu_mtx, uarn_mtx;
 	bool is_valid;
@@ -56,6 +56,6 @@ class HighwaySystem
 	size_t route_index(Route*);	// Return index of a specified Route* within route_list
 	size_t con_route_index(ConnectedRoute*); // same thing for ConnectedRoutes
 	void route_integrity(ErrorList& el);
-	void insert_vertex(HGVertex*);
+	void add_vertex(HGVertex*);
 	void stats_csv();
 };

--- a/siteupdate/cplusplus/classes/Region/Region.cpp
+++ b/siteupdate/cplusplus/classes/Region/Region.cpp
@@ -66,9 +66,9 @@ std::string& Region::continent_code()
 {	return continent->first;
 }
 
-void Region::insert_vertex(HGVertex* v)
+void Region::add_vertex(HGVertex* v)
 {	mtx.lock();
-	vertices.insert(v);
+	vertices.push_back(v);
 	mtx.unlock();
 }
 

--- a/siteupdate/cplusplus/classes/Region/Region.h
+++ b/siteupdate/cplusplus/classes/Region/Region.h
@@ -3,7 +3,6 @@ class HGVertex;
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -45,7 +44,7 @@ class Region
 	double active_preview_mileage;
 	double overall_mileage;
 	std::mutex mtx;
-	std::unordered_set<HGVertex*> vertices;
+	std::vector<HGVertex*> vertices;
 	bool is_valid;
 
 	static std::vector<Region*> allregions;
@@ -58,7 +57,7 @@ class Region
 
 	std::string &country_code();
 	std::string &continent_code();
-	void insert_vertex(HGVertex*);
+	void add_vertex(HGVertex*);
 };
 
 bool sort_regions_by_code(const Region*, const Region*);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -329,35 +329,6 @@ int main(int argc, char *argv[])
 
 	#include "tasks/read_updates.cpp"
 
-	// Read most recent update dates/times for .list files
-	// one line for each traveler, containing 4 space-separated fields:
-	// 0: username with .list extension
-	// 1-3: date, time, and time zone as written by "git log -n 1 --pretty=%ci"
-	file.open("listupdates.txt");
-	if (file.is_open()) cout << et.et() << "Reading .list updates file." << endl;
-	while(getline(file, line))
-	{	size_t NumFields = 4;
-		string** fields = new string*[4];
-		fields[0] = new string;	// deleted upon construction of unordered_map element
-		fields[1] = new string;	// deleted @ end of TravelerList ctor
-		fields[2] = new string;	// deleted once written to user log
-		fields[3] = new string;	// deleted once written to user log
-		split(line, fields, NumFields, ' ');
-		if (NumFields != 4)
-		{	cout << "WARNING: Could not parse listupdates.txt line: [" << line
-			     << "], expected 4 fields, found " << std::to_string(NumFields) << endl;
-			delete fields[0];
-			delete fields[1];
-			delete fields[2];
-			delete fields[3];
-			delete[] fields;
-			continue;
-		}
-		TravelerList::listupdates[*fields[0]] = fields;
-		delete fields[0];
-	}
-	file.close();
-
 	// Create a list of TravelerList objects, one per person
 	cout << et.et() << "Processing traveler list files:" << endl;
       #ifdef threading_enabled

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -1,5 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	"tm-master", "All Travel Mapping Data", F, 'M', (list<Region*>*)0, (list<HighwaySystem*>*)0, (PlaceRadius*)0)
 // Build a graph structure out of all highway data in active and
 // preview systems
 cout << et.et() << "Setting up for graphs of highway data." << endl;
@@ -20,39 +18,18 @@ if (Args::skipgraphs || Args::errorcheck)
 	cout << et.et() << "SKIPPING generation of subgraphs." << endl;
 else {	list<Region*> *regions;
 	list<HighwaySystem*> *systems;
-	ADDGRAPH('s');
-	ADDGRAPH('c');
-	ADDGRAPH('t');
-	#undef ADDGRAPH
+	GraphListEntry::entries.emplace_back('s', graph_data.vertices.size(), graph_data.se, 0);
+	GraphListEntry::entries.emplace_back('c', graph_data.cv, graph_data.ce, 0);
+	GraphListEntry::entries.emplace_back('t', graph_data.tv, graph_data.te, TravelerList::allusers.size());
 	graph_types.push_back({"master", "All Travel Mapping Data",
 				"These graphs contain all routes currently plotted in the Travel Mapping project."});
 	GraphListEntry::num = 3;
 
 	cout << et.et() << "Writing master TM graph files." << endl;
-	#define GRAPH(G) GraphListEntry::entries[G]
-	GRAPH(0).edges = 0;	GRAPH(0).vertices = graph_data.vertices.size();
-	GRAPH(1).edges = 0;	GRAPH(1).vertices = 0;
-	GRAPH(2).edges = 0;	GRAPH(2).vertices = 0;
-	// get master graph vertex & edge counts for terminal output before writing files
-	for (HGVertex* v : graph_data.vertices)
-	{	GRAPH(0).edges += v->incident_s_edges.size();
-		if (v->visibility >= 1)
-		{	GRAPH(2).vertices++;
-			GRAPH(2).edges += v->incident_t_edges.size();
-			if (v->visibility == 2)
-			{	GRAPH(1).vertices++;
-				GRAPH(1).edges += v->incident_c_edges.size();
-			}
-		}
-	}
-	GRAPH(0).edges /= 2;
-	GRAPH(1).edges /= 2;
-	GRAPH(2).edges /= 2;
 	// print summary info
-	std::cout << "   Simple graph has " << GRAPH(0).vertices << " vertices, " << GRAPH(0).edges << " edges." << std::endl;
-	std::cout << "Collapsed graph has " << GRAPH(1).vertices << " vertices, " << GRAPH(1).edges << " edges." << std::endl;
-	std::cout << " Traveled graph has " << GRAPH(2).vertices << " vertices, " << GRAPH(2).edges << " edges." << std::endl;
-	#undef GRAPH
+	std::cout << "   Simple graph has " << graph_data.vertices.size() << " vertices, " << graph_data.se << " edges." << std::endl;
+	std::cout << "Collapsed graph has " << graph_data.cv << " vertices, " << graph_data.ce << " edges." << std::endl;
+	std::cout << " Traveled graph has " << graph_data.tv << " vertices, " << graph_data.te << " edges." << std::endl;
 
       #ifndef threading_enabled
 	graph_data.write_master_graphs_tmg();

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -64,8 +64,8 @@ else {	list<Region*> *regions;
 	#include "subgraphs/system.cpp"
 	#include "subgraphs/country.cpp"
 	#include "subgraphs/multiregion.cpp"
-	#include "subgraphs/area.cpp"
 	#include "subgraphs/region.cpp"
+	#include "subgraphs/area.cpp"
       #ifdef threading_enabled
 	// write graph vector entries to disk
 	thr[0] = thread(MasterTmgThread, &graph_data, &list_mtx, &term_mtx, &all_waypoints, &et);

--- a/siteupdate/cplusplus/tasks/read_updates.cpp
+++ b/siteupdate/cplusplus/tasks/read_updates.cpp
@@ -105,3 +105,32 @@ while (getline(file, line))
 	systemupdates.push_back(fields);
 }
 file.close();
+
+// Read most recent update dates/times for .list files
+// one line for each traveler, containing 4 space-separated fields:
+// 0: username with .list extension
+// 1-3: date, time, and time zone as written by "git log -n 1 --pretty=%ci"
+file.open("listupdates.txt");
+if (file.is_open()) cout << et.et() << "Reading .list updates file." << endl;
+while(getline(file, line))
+{	size_t NumFields = 4;
+	string** fields = new string*[4];
+	fields[0] = new string;	// deleted upon construction of unordered_map element
+	fields[1] = new string;	// deleted @ end of TravelerList ctor
+	fields[2] = new string;	// deleted once written to user log
+	fields[3] = new string;	// deleted once written to user log
+	split(line, fields, NumFields, ' ');
+	if (NumFields != 4)
+	{	cout << "WARNING: Could not parse listupdates.txt line: [" << line
+		     << "], expected 4 fields, found " << std::to_string(NumFields) << endl;
+		delete fields[0];
+		delete fields[1];
+		delete fields[2];
+		delete fields[3];
+		delete[] fields;
+		continue;
+	}
+	TravelerList::listupdates[*fields[0]] = fields;
+	delete fields[0];
+}
+file.close();

--- a/siteupdate/cplusplus/tasks/subgraphs/area.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/area.cpp
@@ -1,13 +1,11 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	a.title + to_string(a.r) + "-area", a.descr + " (" + to_string(a.r) + " mi radius)",\
-	F, 'a', (list<Region*>*)0, (list<HighwaySystem*>*)0, &a)
 // graphs restricted by place/area - from areagraphs.csv file
 #ifndef threading_enabled
 cout << et.et() << "Creating area data graphs." << endl;
 #endif
 file.open(Args::highwaydatapath+"/graphs/areagraphs.csv");
 getline(file, line);  // ignore header line
-list<PlaceRadius> area_list;
+
+// add entries to graph vector
 while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
@@ -37,18 +35,15 @@ while (getline(file, line))
 	if (*endptr)		el.add_error("invalid lng in areagraphs.csv line: " + line);
 	int r = strtol(fields[4], &endptr, 10);
 	if (*endptr || r <= 0) {el.add_error("invalid radius in areagraphs.csv line: " + line); r=1;}
-	area_list.emplace_back(fields[0], fields[1], lat, lng, r);
+	PlaceRadius *a = new PlaceRadius(fields[0], fields[1], lat, lng, r);
+			 // deleted @ end of HighwayGraph::write_subgraphs_tmg
+	GraphListEntry::add_group(
+		fields[1] + to_string(r) + "-area",
+		fields[0] + (" (" + to_string(r) + " mi radius)"),
+		'a', nullptr, nullptr, a);
 	delete[] cline;
 }
 file.close();
-
-// add entries to graph vector
-for (PlaceRadius &a : area_list)
-{	ADDGRAPH('s');
-	ADDGRAPH('c');
-	ADDGRAPH('t');
-	#undef ADDGRAPH
-}
 #ifndef threading_enabled
 // write new graph vector entries to disk
 while (GraphListEntry::num < GraphListEntry::entries.size())

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -1,6 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	continents[c].first + "-continent", continents[c].second + " All Routes on Continent", \
-	F, 'C', regions, (list<HighwaySystem*>*)0, (PlaceRadius*)0)
 // continent graphs -- any continent with data will be created
 #ifndef threading_enabled
 cout << et.et() << "Creating continent graphs." << endl;
@@ -15,10 +12,10 @@ for (size_t c = 0; c < continents.size()-1; c++)
 	    regions->push_back(r);
 	// generate for any continent with at least 1 region with mileage
 	if (regions->size() < 1) delete regions;
-	else {	ADDGRAPH('s');
-		ADDGRAPH('c');
-		ADDGRAPH('t');
-		#undef ADDGRAPH
+	else {	GraphListEntry::add_group(
+			continents[c].first + "-continent",
+			continents[c].second + " All Routes on Continent",
+			'C', regions, nullptr, nullptr);
 	     }
 }
 #ifndef threading_enabled

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -1,5 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	countries[c].first + "-country", countries[c].second + " All Routes in Country", F, 'c', regions, (list<HighwaySystem*>*)0, (PlaceRadius*)0)
 // country graphs - we find countries that have regions
 // that have routes with active or preview mileage
 #ifndef threading_enabled
@@ -16,10 +14,10 @@ for (size_t c = 0; c < countries.size()-1; c++)
 	// does it have at least two?  if none, no data,
 	// if 1 we already generated a graph for that one region
 	if (regions->size() < 2) delete regions;
-	else {	ADDGRAPH('s');
-		ADDGRAPH('c');
-		ADDGRAPH('t');
-		#undef ADDGRAPH
+	else {	GraphListEntry::add_group(
+			countries[c].first + "-country",
+			countries[c].second + " All Routes in Country",
+			'c', regions, nullptr, nullptr);
 	     }
 }
 #ifndef threading_enabled

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -1,5 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	fields[1], fields[0], F, 'R', regions, (list<HighwaySystem*>*)0, (PlaceRadius*)0)
 // Some additional interesting graphs, the "multiregion" graphs
 #ifndef threading_enabled
 cout << et.et() << "Creating multiregion graphs." << endl;
@@ -35,10 +33,7 @@ while (getline(file, line))
 	    {	regions->push_back(r);
 		break;
 	    }
-	ADDGRAPH('s');
-	ADDGRAPH('c');
-	ADDGRAPH('t');
-	#undef ADDGRAPH
+	GraphListEntry::add_group(fields[1], fields[0], 'R', regions, nullptr, nullptr);
 	delete[] cline;
 }
 file.close();

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -1,4 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(fields[1], fields[0], F, 'S', (list<Region*>*)0, systems, (PlaceRadius*)0)
 // Some additional interesting graphs, the "multisystem" graphs
 #ifndef threading_enabled
 cout << et.et() << "Creating multisystem graphs." << endl;
@@ -34,10 +33,7 @@ while (getline(file, line))
 	    {	systems->push_back(h);
 		break;
 	    }
-	ADDGRAPH('s');
-	ADDGRAPH('c');
-	ADDGRAPH('t');
-	#undef ADDGRAPH
+	GraphListEntry::add_group(fields[1], fields[0], 'S', nullptr, systems, nullptr);
 	delete[] cline;
 }
 file.close();

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -1,5 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	region->code + "-region", region->name + " (" + region->type + ")", F, 'r', regions, (list<HighwaySystem*>*)0, (PlaceRadius*)0)
 // Graphs restricted by region
 #ifndef threading_enabled
 cout << et.et() << "Creating regional data graphs." << endl;
@@ -12,10 +10,10 @@ for (Region* region : Region::allregions)
 {	if (region->active_preview_mileage == 0) continue;
 	regions = new list<Region*>(1, region);
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
-	ADDGRAPH('s');
-	ADDGRAPH('c');
-	ADDGRAPH('t');
-	#undef ADDGRAPH
+	GraphListEntry::add_group(
+		region->code + "-region",
+		region->name + " (" + region->type + ")",
+		'r', regions, nullptr, nullptr);
 }
 #ifndef threading_enabled
 // write new graph vector entries to disk

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -1,5 +1,3 @@
-#define ADDGRAPH(F) GraphListEntry::entries.emplace_back(\
-	h->systemname + "-system", h->systemname + " (" + h->fullname + ")", F, 's', (list<Region*>*)0, systems, (PlaceRadius*)0)
 // Graphs restricted by system - from systemgraphs.csv file
 #ifndef threading_enabled
 cout << et.et() << "Creating system data graphs." << endl;
@@ -21,10 +19,10 @@ while (getline(file, line))
 	if (h)
 	{	systems = new list<HighwaySystem*>(1, h);
 			  // deleted @ end of HighwayGraph::write_subgraphs_tmg
-		ADDGRAPH('s');
-		ADDGRAPH('c');
-		ADDGRAPH('t');
-		#undef ADDGRAPH
+		GraphListEntry::add_group(
+			h->systemname + "-system",
+			h->systemname + " (" + h->fullname + ")",
+			's', nullptr, systems, nullptr);
 	}
 }
 file.close();


### PR DESCRIPTION
@jteresco, this doesn't make any of the changes I PMed you about on the forum.
What *is* here is mostly C++, various graph generation optimizations. The ones that I could also do in Python I did there too, though the results were underwhelming.

---

6c97b69059ba49775080f367416d501251e3e282 closes yakra#195.
Area graph vertex sets are populated in place instead of dealing with a bunch of temporaries, same idea as what #508 did with NMPs.
* C++: cuts area graph time by ~28%. Though area graphs _already_ took only 0.49-0.79 s depending on machine.
* Python: saves about 1.5%.

---

33183f2d8bb2f85617b30ad147fce252fb389305 takes advantage of memory locality (and probably also faster iteration?) and speeds up:
* initial vertex creation
* getting matching sets for subgraphs

[Some harmless redundancy is involved.](https://forum.travelmapping.net/index.php?topic=2926.msg27248#msg27248)
Writing subgraphs, saves ~5-7% depending on machine @ 1 thread, tapering off as thread count increases. Hm. Wonder why that is. *Cache line bouncing?*

---

f0d618ae25fd60c6ca598907eaf8c4ab7ca37f9a is a step toward the long-term goal of moving as much code as practical out of the main siteupdate.cpp file, whether by function calls or simple `#include`s.

---

12beccd5c04b56d12bc11ba88da0930d35d9212b uses a `switch` when writing subgraph vertices. Much more concise. Will help with readability when https://github.com/TravelMapping/EduTools/issues/156 happens.

---

f699eba4c9f92eaccd01c120141e50c0a134de50 is 5 commits squashed together. Now we're getting into the good stuff!
* **V1a:** store vertices in contiguous memory
  Writing subgraphs, saves 5-9% @ 1 thread on the various Linux machines, tapering off as thread count increases.
  This sets the stage for [the bit field I mentioned on the forum](https://forum.travelmapping.net/index.php?topic=2926.msg27239#msg27239), but doesn't implement it just yet.
* **V1b:** `switch`es when writing master graph vertices & edges
* **T:** allocate `clinchedby_code` once per graph; modify in place
  This avoids having to allocate a string for every edge, instead reusing one `char*` for each edge in a graph.
  * Ubuntu: Saves ~9.5% on subgraphs, looking fairly flat WRT thread count.
  * CentOS: Much bigger impact here. At worst, lab1 is down 11.6% @ 1 thread. Savings increase with thread count up to ~10-12 threads, and then the time ratio relative to "V1b" starts inching back up a bit.
    My CentOS machines have older compilers without [small string optimization](https://www.youtube.com/watch?v=kPR8h4-qZdk). Across all traveled graphs, 34% of `clinchedby_code`s are < 16 bytes long. Meaning, this improvement saves us only ~1.5x the mallocs on CentOS as on Ubuntu. The mallocs alone can't explain the performance boost; there has to be something else going on.
* **V1c:** master vertex & edge counts in HighwayGraph object
  This is what should have happened in [#258](https://github.com/TravelMapping/DataProcessing/pull/258). Keeps tracks of these numbers during initial construction instead of needlessly making a 2nd pass thru the structure afterward to grab this data. Saves a bit of time *Writing master TM graph files*; cleans up the code a bit.
* **V1d:** nix GRAPH & ADDGRAPH macros
  I always felt a little yucky about them. Plus, it's all done in a way that uses fewer lines of code.

---

All together, subgraph time is down 11.4% (lab5 @ 5 threads) to 44% (lab2 @ 8 threads).
Before, the record for subgraph processing was 6.3 s, set by lab5 @ 8 threads. Now, lab2 takes 4.4 s at 8 threads, despite its considerably slower clock. Must be its larger L3 cache.
Implementing the bit field will break the 4 second barrier. Other improvements in the pipeline additionally looked quite promising, but haven't been formally tested yet.
![Subg515a](https://user-images.githubusercontent.com/13720877/163054953-ee5d9e74-e541-4579-8a55-60f0027f9602.gif)
Hey, wait a sec -- where's bsdlab?
![Subg515b](https://user-images.githubusercontent.com/13720877/163054980-b7f641aa-3d7d-4825-83ff-cc40977036f2.gif)
...Oh. It's up here. :(
Maybe some upcoming speedups or Clang's optimization flags (currently being tested) may put a dent in that processing time, but at this point I'm not holding my breath...

Finally, performance of several single-threaded tasks has also changed. Top = before; bottom = after:

### C++:
task | Bigga<br>Tomato | lab1 | lab5 | lab2 | lab3 | lab4 | bsdlab
| - | - | - | - | - | - | - | - |
Setting up for graphs of highway data | .656<br>.817 | .437<br>.48 | .513<br>.587 | .542<br>.589 | .692<br>.762 | .774<br>.904 | .96<br>1.1540
Creating unique names and vertices | 4.086<br>2.458 | 2.64<br>1.894 | 2.464<br>1.576 | 3.222<br>2.257 | 4.128<br>2.962 | 3.692<br>2.422 | 5.642<br>3.9840
Creating edges | 1.476<br>1.455 | .928<br>.843 | .995<br>.967 | 1.165<br>1.067 | 1.422<br>1.382 | 1.55<br>1.482 | 2.488<br>2.4460
Compressing collapsed edges | 1.107<br>1.079 | .661<br>.616 | .77<br>.743 | .798<br>.758 | .968<br>.952 | 1.154<br>1.122 | 1.34<br>1.3240
Writing master TM graph files | 5.55<br>4.804 | 4.917<br>3.111 | 3.461<br>3.033 | 6.352<br>3.777 | 7.868<br>4.658 | 5.196<br>4.526 | 6.454<br>5.2480
Setting up subgraphs | .199<br>.168 | .109<br>.084 | .128<br>.091 | .121<br>.089 | .164<br>.13 | .182<br>.126 | .166<br>.1100
**combined** | **13.074<br>10.781** | **9.692<br>7.028** | **8.331<br>6.997** | **12.2<br>8.537** | **15.242<br>10.846** | **12.548<br>10.582** | **17.05<br>14.266**

### Python:
task | Bigga<br>Tomato | lab1 | lab5 | lab2 | lab3 | lab4 | bsdlab
| - | - | - | - | - | - | - | - |
Creating unique names and vertices | 22.86<br>22.66 | 11.68<br>11.56 | 10.51<br>10.42 | 13.77<br>13.67 | 19.24<br>19.14 | 15.36<br>15.34 | 23.98<br>23.4600
Creating edges | 15.82<br>16.12 | 7.74<br>7.88 | 7.19<br>7.22 | 9.39<br>9.49 | 13.08<br>13.28 | 10.54<br>10.66 | 16.3<br>16.3600
Compressing collapsed edges | 4.02<br>4.26 | 2.18<br>2.26 | 1.87<br>1.93 | 2.69<br>2.79 | 3.36<br>3.52 | 2.8<br>2.86 | 4.4<br>4.5600
Writing master TM graph files | 29.66<br>28.8 | 17.64<br>17.31 | 14.12<br>13.76 | 22.17<br>21.65 | 28.26<br>27.74 | 21.5<br>21.0 | 36.3<br>35.2400
subgraphs | 106.02<br>103.8 | 65.7<br>65.02 | 53.91<br>53.55 | 79.96<br>79.35 | 103.24<br>102.48 | 79.82<br>78.76 | 133.02<br>133.0800
**combined** | **178.38<br>175.64** | **104.94<br>104.03** | **87.6<br>86.88** | **127.98<br>126.95** | **167.18<br>166.16** | **130.02<br>128.62** | **214<br>212.7**