### PR TITLE
fix quadtree memory leak / speed up per-traveler regional stats

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySegment/compute_stats_t.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/compute_stats_t.cpp
@@ -1,25 +1,12 @@
 void HighwaySegment::compute_stats_t(TravelerList* t)
 {	// credit active+preview for this region, which it must be
 	// if this segment is clinched by anyone
-	try {	t->active_preview_mileage_by_region.at(route->region) += length/active_preview_concurrency_count;
-	    }
-	catch (const std::out_of_range& oor)
-	    {	t->active_preview_mileage_by_region[route->region] = length/active_preview_concurrency_count;
-	    }
+	t->active_preview_mileage_by_region[route->region] += length/active_preview_concurrency_count;
 
 	// credit active only for this region
 	if (route->system->active())
-	{	try {	t->active_only_mileage_by_region.at(route->region) += length/active_only_concurrency_count;
-		    }
-		catch (const std::out_of_range& oor)
-		    {	t->active_only_mileage_by_region[route->region] = length/active_only_concurrency_count;
-		    }
-	}
+		t->active_only_mileage_by_region[route->region] += length/active_only_concurrency_count;
 
 	// credit this system in this region in the messy unordered_map of unordered_maps
-	try {	t->system_region_mileages[route->system].at(route->region) += length/system_concurrency_count;
-	    }
-	catch (const std::out_of_range& oor)
-	    {	t->system_region_mileages[route->system][route->region] = length/system_concurrency_count;
-	    }
+	t->system_region_mileages[route->system][route->region] += length/system_concurrency_count;
 }

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -262,7 +262,7 @@ void WaypointQuadtree::final_report(std::vector<unsigned int>& colocate_counts)
 		else if (w == w->colocated->front())
 		{   while (w->colocated->size() >= colocate_counts.size()) colocate_counts.push_back(0);
 		    colocate_counts[w->colocated->size()] += 1;
-		    if (w->colocated->size() >= 9)
+		    if (w->colocated->size() >= 9 && !Args::errorcheck)
 		    {	printf("(%.15g, %.15g) is occupied by %i waypoints: ['", w->lat, w->lng, (unsigned int)w->colocated->size());
 			std::list<Waypoint*>::iterator p = w->colocated->begin();
 			std::cout << (*p)->route->root << ' ' << (*p)->label << '\'';

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -660,10 +660,10 @@ int main(int argc, char *argv[])
 	  cout << "MISMATCH: all_waypoints contains " << all_waypoints.size() << " waypoints!" << endl;
 	cout << et.et() << "WaypointQuadtree contains " << all_waypoints.total_nodes() << " total nodes." << endl;
 
+	vector<unsigned int> colocate_counts(2,0);
 	if (!Args::errorcheck)
 	{	// compute colocation of waypoints stats
 		cout << et.et() << "Computing waypoint colocation stats, reporting all with 9 or more colocations:" << endl;
-		vector<unsigned int> colocate_counts(2,0);
 		all_waypoints.final_report(colocate_counts);
 		cout << "Waypoint colocation counts:" << endl;
 		unsigned int unique_locations = 0;
@@ -672,7 +672,7 @@ int main(int argc, char *argv[])
 			printf("%6i are each occupied by %2i waypoints.\n", colocate_counts[c], c);
 		}
 		cout << "Unique locations: " << unique_locations << endl;
-	}
+	} else	all_waypoints.final_report(colocate_counts);
 
 	/* EDB
 	cout << endl;


### PR DESCRIPTION
### Fix WaypointQuadtree memory leak
675886566bb49353d277f3c73696245c98ca4a0b closes #481.

---

### Computing stats per traveler
d5d8c030f11c8ff2520dd199c10d04680adc061e: https://www.youtube.com/watch?v=lkgszkPnV8g&t=8m43s
Neato. [I'd noticed the behavior the presenter describes, but avoided it due to the same "newbie" expectations he cites, of uninitialized rather than value-initialized doubles.](https://github.com/yakra/DataProcessing/issues/87#issuecomment-846150960) Thought it was possible that not every C++ compiler would gimme the results I was seeing. Great news.
![cst517](https://user-images.githubusercontent.com/13720877/163686573-8d2d87bf-2af1-494a-baf1-7acde38b35ea.gif)
Looks like this removes a memory bottleneck.
A surprisingly big improvement under **FreeBSD**. That's what I like to see!
**Linux**: Time is down ~5% on the low end (lab4 @ 1-5 threads), improving as thread count increases, all the way up to **60%** savings on lab3 @ 26 threads.
Lab3 smoothly scales all the way up to 24 threads now, whereas before the graph gently turned upward after 11-12 threads (see also [this chart](https://user-images.githubusercontent.com/13720877/136426177-55a421d5-ad5e-4a43-b066-1281ef77491d.png) @ yakra#188).
Lab4 doesn't scale quite as smoothly; there are a couple brief bumps upward, topping out @ 15 threads. Ubuntu seems a little less hampered by memory bottlenecks, meaning there's less gains to be seen.

---

### No-Build: Performing per-route data checks and computing stats
An interesting oddity:
I'm leaving this similar block alone:
https://github.com/TravelMapping/DataProcessing/blob/487b0423a0ec23b32f4e79c46f9bec96fe86dbdb/siteupdate/cplusplus/classes/Route/compute_stats_r.cpp#L41-L45
Here's a chart with a logarithmic Y axis, to make the diffs easier to see:
![csr517log](https://user-images.githubusercontent.com/13720877/163689176-7fc896ae-2c24-47aa-9884-275679a9ad70.gif)
We can see that, primarily on the CentOS machines @ 4+ threads, what should be faster becomes slower.
[The `std::unordered_map::at` function](https://www.cplusplus.com/reference/unordered_map/unordered_map/at/) must be more efficient under the hood than [the [] operator](https://www.cplusplus.com/reference/unordered_map/unordered_map/operator[]/), enough to make up for constructing & throwing a `std::out_of_range` object and hashing the region address a second time.
Which makes no sense; I'd think that they'd work the same -- hash the key etc., then check whether it exist in the map -- only differing in what happens next: throw an exception vs. create a new key/value pair.
Maybe `at` got improved at some point and the maintainers forgot to update `[]` the same way? I wonder what I'd see if I updated clang...
For giggles, I'm testing out the same commits compiled with g++, seeing if I observe the same thing.