### PR TITLE
use clang optimization flag

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CXXFLAGS = -std=c++11 -Wno-comment -Wno-dangling-else -Wno-logical-op-parentheses
+CXXFLAGS = -O3 -std=c++11 -Wno-comment -Wno-dangling-else -Wno-logical-op-parentheses
 
 MTObjects = siteupdateMT.o functions/sql_fileMT.o threads/threads.o \
   classes/GraphGeneration/HighwayGraphMT.o \

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -9,7 +9,7 @@
 #ifdef threading_enabled
 #include <thread>
 #endif
-inline bool WaypointQuadtree::WaypointQuadtree::refined()
+bool WaypointQuadtree::WaypointQuadtree::refined()
 {	return nw_child;
 }
 

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -247,9 +247,9 @@ int main(int argc, char *argv[])
 	}
 	else	cout << "All .wpt files in " << Args::highwaydatapath << "/hwy_data processed." << endl;
 
+      #ifdef threading_enabled
 	// create NMP lists
 	cout << et.et() << "Searching for near-miss points." << endl;
-      #ifdef threading_enabled
 	HighwaySystem::it = HighwaySystem::syslist.begin();
 	THREADLOOP thr[t] = thread(NmpSearchThread, t, &list_mtx, &all_waypoints);
 	THREADLOOP thr[t].join();


### PR DESCRIPTION
Be sure to `make clean` before you `make` again (or `gmake` as the case may be).

Re the change to WaypointQuadtree.cpp, I'm surprised I never got linking errors before.

---
![RWpt](https://user-images.githubusercontent.com/13720877/163825283-629a6716-3159-4313-a44b-ffd8bbaa5534.gif)
![Sort](https://user-images.githubusercontent.com/13720877/163825410-6973055f-86fd-477d-acea-537f5a11f980.gif)
Wow, FreeBSD is a top performer here. Note the small bump in processing time when we run out of physical cores & start using hyperthreaded virtual cores.
Less apparent on lab3 & especially lab4.
![NmpS](https://user-images.githubusercontent.com/13720877/163825539-97e18241-91e8-4626-b457-0213e23d5905.gif)
The "default" line for FreeBSD was thrown off by a couple big outliers.
![NmpM](https://user-images.githubusercontent.com/13720877/163826765-8330408a-36fb-4594-b97e-401eeb3717a5.gif)
Ouch, [another horrible performer under FreeBSD](https://github.com/TravelMapping/DataProcessing/issues/519).
![NmpM_Linux](https://user-images.githubusercontent.com/13720877/163827534-aa1155e8-5344-49d9-a9c3-9cfe3e2f764d.gif)
Same thing, zoomed in to just the Linux machines.
![Intg](https://user-images.githubusercontent.com/13720877/163827710-5c1141f0-29be-4274-9914-dcc8786dd0fb.gif)
Another win for FreeBSD.
![List](https://user-images.githubusercontent.com/13720877/163827914-2c0ccb9a-ebc8-4567-a260-e22fc960618b.gif)
![Conc](https://user-images.githubusercontent.com/13720877/163828233-107f3e7c-8213-4f2c-99b9-ee950bf359d0.gif)
A couple outliers in FreeBSD's "default" line again.
![csr](https://user-images.githubusercontent.com/13720877/163828305-3ca3b583-1cf1-4bfb-baba-f8b80290b180.gif)
For the 24-thread machines, the results of 5 passes were averaged together instead of the usual 10, because I wanted to do these tests in a finite amount of time. :) With this task being so fast, the noise is a much larger piece of the pie, resulting in fairly jagged lines.
![cst](https://user-images.githubusercontent.com/13720877/163829177-8a73e5b2-60c0-4313-92c7-cd78d175221e.gif)
![User](https://user-images.githubusercontent.com/13720877/163829580-9c9b2d2c-0299-45a2-a023-d4093a3c67bf.gif)
Another case where FreeBSD has trouble scaling beyond just a few threads, though this isn't as bad as the others.
There are several potential changes that could maybe help out, and as we saw in https://github.com/TravelMapping/DataProcessing/pull/517, sometimes a little tweak goes a long way.
Good news is, noreaster scales up to 8 threads. This looks like a memory bandwidth issue, and shouldn't be as tough to tackle as nmp_merged or subgraphs.
![Vert](https://user-images.githubusercontent.com/13720877/163837124-6381bb12-44c1-408b-abaf-3c2be7255268.gif)
The somewhat jagged lines could be a result of small sample size again.
Why does BiggaTomato stay flat between 3 & 4 threads? The DB file is being written in the background. So for a little while, siteupdate actually runs `numthreads`+1 threads. It's just easiest to do this way. It usually finishes up at some point during subgraph generation.
Well, that _would_ be the case, except that it already stays flat between 2 & 3 threads. Running out of memory bandwidth I guess.
![Subg](https://user-images.githubusercontent.com/13720877/163838925-b4d1b093-640b-459c-920f-2610f2930773.gif)
This is just painful. :( A nice bump at 1 thread, and then... nothing. [This may take a lot of work to see an improvement...](https://github.com/TravelMapping/DataProcessing/issues/519)
![Subg_Linux](https://user-images.githubusercontent.com/13720877/163840452-a46eb6fe-39ea-4d12-98b7-1110c374c225.gif)
Same thing, zoomed in to just the Linux machines.
At 4 threads on BT & 8 on lab1 & lab5, that's probably the DB file slowing down graph generation again.
![mtsub](https://user-images.githubusercontent.com/13720877/163840586-5955142c-d7e9-4d48-9e5d-5d7a5aca0bb3.gif)
![Total](https://user-images.githubusercontent.com/13720877/163840594-1cc9d00d-999d-45cf-a5d6-8707332abd27.gif)

---

### single-threaded tasks in multi-threaded `siteupdate`
**top:** default / `-O0`
**bottom:** `-O3`

|BT|lab1|lab5|lab2|lab3|lab4|bsdlab|
|-|-|-|-|-|-|-|
|Reading region, country, and continent descriptions|.0040<br>.0011|.0030<br>.0010|.0020<br>.0005|.0025<br>.0009|.0035<br>.0012|.0041<br>.0014|.0174<br>.0024|
|Reading systems list|.6388<br>.3934|.4503<br>.2826|.3640<br>.1867|.5357<br>.3225|.7169<br>.4374|.6730<br>.3402|1.7155<br>.6082|
|Finding all .wpt files...* files found|.4979<br>.4396|.2295<br>.2011|.2554<br>.2184|.2889<br>.2574|.3922<br>.3455|.3910<br>.4357|.6397<br>.5667|
|Finding unprocessed wpt files|.0142<br>.0083|.0106<br>.0062|.0130<br>.0055|.0133<br>.0073|.0123<br>.0074|.0165<br>.0094|.0342<br>.0099|
|Near-miss point log and tm-master.nmp file|.7112<br>.4870|.4151<br>.3019|.4220<br>.2427|.5105<br>.3579|.6826<br>.4707|.8405<br>.5181|1.3232<br>.7681|
|Concurrent segment detection|.7570<br>.3647|.5378<br>.3069|.4489<br>.1751|.6300<br>.3385|.9040<br>.5067|.8745<br>.3218|1.2316<br>.3505|
|Reading updates file|.0396<br>.0389|.0285<br>.0281|.0258<br>.0254|.0329<br>.0331|.0454<br>.0404|.0288<br>.0276|.1693<br>.1495|
|Reading systemupdates file|.0006<br>.0005|.0007<br>.0006|.0004<br>.0003|.0006<br>.0005|.0009<br>.0007|.0005<br>.0003|.0105<br>.0040|
|Processed .* traveler list files. Sorting and numbering|.0004<br>.0002|.0002<br>.0001|.0004<br>.0001|.0002<br>.0002|.0008<br>.0003|.0008<br>.0002|.0007<br>.0001|
|Clearing route & label hash tables|.2294<br>.1442|.1344<br>.1124|.1085<br>.0546|.1528<br>.1254|.2949<br>.2118|.2064<br>.0877|.2258<br>.1055|
|Writing route and label logs|.4222<br>.1759|.2305<br>.1294|.2367<br>.0626|.2755<br>.1440|.4296<br>.2428|.4933<br>.1117|.4630<br>.1003|
|Writing to concurrencies.log|.3050<br>.2727|.1868<br>.1702|.1423<br>.1130|.1901<br>.1699|.3045<br>.2853|.2629<br>.1984|.2538<br>.1504|
|Writing highway data stats log file|.1931<br>.1519|.1890<br>.1623|.1097<br>.0863|.2021<br>.1777|.2686<br>.2245|.1911<br>.1336|.3681<br>.2649|
|Writing stats csv files|1.7749<br>1.1743|.6701<br>.4540|.6512<br>.4462|.9172<br>.6325|1.9110<br>1.2893|1.6824<br>1.1524|7.9618<br>6.8389|
|Reading datacheckfps.csv|.0101<br>.0075|.0133<br>.0107|.0361<br>.0342|.0118<br>.0104|.0473<br>.0321|.0318<br>.0243|.0881<br>.0167|
|Setting up for graphs of highway data|.8726<br>.4447|.5071<br>.2352|.6122<br>.2345|.6084<br>.2732|1.2327<br>.6286|1.1912<br>.5611|1.4650<br>.4606|
|Creating edges|1.9794<br>1.1674|.9023<br>.6282|1.0598<br>.5988|1.1242<br>.7827|2.1535<br>1.4456|2.0437<br>1.2360|2.7588<br>.9418|
|Compressing collapsed edges|1.3646<br>.6540|.6600<br>.2882|.7712<br>.2588|.7981<br>.3424|1.8995<br>1.0588|1.7339<br>1.1830|1.4325<br>.4142|
|Writing graph waypoint simplification log|.1299<br>.1224|.1049<br>.0983|.0774<br>.0611|.1303<br>.1220|.3482<br>.3014|.2775<br>.2297|.1277<br>.0790|
|Setting up subgraphs|1.3351<br>1.1321|.4590<br>.3721|.4671<br>.3752|.3070<br>.2353|.3702<br>.2936|.3194<br>.2444|.4713<br>.6122|
|Clearing HighwayGraph contents from memory|1.4703<br>.9588|.7784<br>.4951|.7830<br>.3693|.9857<br>.6038|1.8046<br>1.3576|1.0112<br>.7988|2.1953<br>.9430|
|Marking datacheck false positives|1.8045<br>.5343|1.7090<br>.9466|1.2997<br>.4812|2.2242<br>1.3515|2.2488<br>1.7582|2.0259<br>.5065|5.1414<br>.4211|
|Found .* datacheck errors and matched .* FP entries|0<br>0|.0010<br>.0010|0<br>0|.0010<br>.0011|.0038<br>.0047|0<br>0|0<br>0|
|Writing log of unmatched datacheck FP entries|.0001<br>.0001|.0002<br>.0002|.0001<br>.0001|.0002<br>.0002|.0004<br>.0004|.0001<br>.0001|.0003<br>.0001|
|Writing datacheck.log|.0070<br>.0055|.1155<br>.3964|.0034<br>.2120|.1442<br>.6740|.0103<br>.3064|.0074<br>.1270|.0071<br>.0206|
|Resume writing database file|.0096<br>.0076|.0093<br>.0096|.0060<br>.0065|.0110<br>.0125|.0120<br>.0267|.0097<br>.0118|.0153<br>.0059|
|Processed .* highway systems|.0149<br>.0070|.0731<br>.0663|.0073<br>.0034|.0834<br>.0756|.2571<br>.2821|.0554<br>.0415|.0107<br>.0048|
|WaypointQuadtree contains .* total nodes|.0031<br>.0026|.0020<br>.0011|.0009<br>.0005|.0020<br>.0012|.0035<br>.0025|.0016<br>.0008|.0009<br>.0005|
|Computing waypoint colocation stats, reporting all with .* or more colocations:|.7188<br>.5349|.4668<br>.3135|.4378<br>.2668|.5654<br>.3715|.8830<br>.6405|.8500<br>.6161|1.1657<br>.5514|


---

### `siteupdateST`
**top:** default / `-O0`
**bottom:** `-O3`

|BT|lab1|lab5|lab2|lab3|lab4|bsdlab|
|-|-|-|-|-|-|-|
|Reading region, country, and continent descriptions|.0036<br>.0013|.0040<br>.0012|.0029<br>.0012|.0027<br>.0010|.0039<br>.0015|.0031<br>.0009|.0174<br>.0020|
|Reading systems list|.6397<br>.3909|.4737<br>.2852|.3530<br>.1856|.5383<br>.3127|.7112<br>.4353|.6564<br>.3072|1.6962<br>.5206|
|Finding all .wpt files\. .* files found|.4961<br>.4385|.2337<br>.2036|.2552<br>.2217|.2928<br>.2605|.3907<br>.3362|.3948<br>.4494|.6262<br>.5473|
|Reading waypoints for all routes|11.9922<br>6.8816|6.9573<br>3.7160|6.9757<br>3.2935|9.2052<br>4.9499|11.7993<br>6.4641|10.9858<br>5.2846|16.0367<br>7.1586|
|Sorting waypoints in Quadtree|3.7683<br>1.2658|2.1093<br>1.1123|2.2986<br>.6838|2.5753<br>1.3455|3.4226<br>1.9014|3.5320<br>1.0321|3.5300<br>.7939|
|Finding unprocessed wpt files|.0125<br>.0065|.0052<br>.0029|.0083<br>.0034|.0069<br>.0038|.0086<br>.0049|.0126<br>.0055|.0235<br>.0063|
|Near-miss point log and tm-master.nmp file|.6412<br>.4123|.3592<br>.2466|.4130<br>.2276|.4491<br>.3044|.6321<br>.4230|.6227<br>.3447|.9362<br>.3660|
|Writing near-miss point merged wpt files|3.0926<br>2.8874|1.7041<br>1.5618|1.6677<br>1.5484|2.1109<br>1.9298|2.7429<br>2.5422|2.5316<br>2.3818|1.9217<br>1.4800|
|Concurrent segment detection|.6867<br>.3152|.5042<br>.2661|.4466<br>.1698|.5980<br>.3108|.7718<br>.4466|.6731<br>.2637|1.0096<br>.2424|
|Creating label hashes and checking route integrity|1.1644<br>.5300|.6740<br>.3712|.6442<br>.2768|.8472<br>.4538|1.1056<br>.5828|.9839<br>.4165|1.6490<br>.3383|
|Reading updates file|.0275<br>.0260|.0172<br>.0171|.0153<br>.0141|.0216<br>.0212|.0282<br>.0276|.0233<br>.0218|.1187<br>.0449|
|Reading systemupdates file|.0007<br>.0005|.0004<br>.0004|.0003<br>.0002|.0005<br>.0005|.0008<br>.0007|.0005<br>.0004|.0069<br>.0015|
|Processing traveler list files:|13.6179<br>6.3435|7.7015<br>3.9958|8.3551<br>3.6810|9.1902<br>4.6261|11.6469<br>6.0119|12.4801<br>5.2961|16.8212<br>5.6122|
|Processed .* traveler list files. Sorting and numbering|.0004<br>.0002|.0002<br>.0001|.0003<br>.0001|.0002<br>.0001|.0003<br>.0001|.0004<br>.0001|.0006<br>.0001|
|Clearing route & label hash tables|.1888<br>.1021|.1163<br>.0831|.0994<br>.0467|.1227<br>.0948|.1763<br>.1263|.1464<br>.0646|.1755<br>.0746|
|Writing route and label logs|.3466<br>.0973|.2894<br>.1868|.2360<br>.0575|.3332<br>.2024|.4273<br>.2578|.3565<br>.0862|.3327<br>.0646|
|Augmenting travelers for detected concurrent segments|5.2394<br>3.2560|3.6148<br>2.2776|3.2230<br>1.7555|3.8917<br>2.4635|4.9246<br>3.1934|4.5379<br>2.4245|5.6145<br>2.4007|
|Performing per-route data checks and computing stats|6.3980<br>2.1974|3.3031<br>1.4002|3.8125<br>1.2916|4.0901<br>1.6904|5.2259<br>2.1860|5.7971<br>1.9178|8.3406<br>2.0268|
|Writing highway data stats log file|.1821<br>.1441|.1383<br>.1176|.1062<br>.0789|.1641<br>.1419|.2205<br>.1810|.1587<br>.1211|.2404<br>.1165|
|Creating per-traveler stats logs and augmenting data structure|33.0327<br>17.6778|22.0984<br>9.1960|22.8136<br>8.8497|25.5185<br>10.8630|31.0281<br>13.3940|32.5740<br>12.3124|32.9422<br>13.7009|
|Writing allbyregionactiveonly.csv|.5265<br>.3999|.2662<br>.2005|.2447<br>.1808|.3266<br>.2459|.4264<br>.3194|.3739<br>.2817|.8706<br>.7102|
|Writing allbyregionactivepreview.csv|.7377<br>.5503|.3683<br>.2768|.3391<br>.2477|.4527<br>.3389|.5878<br>.4419|.5149<br>.3764|1.2099<br>.9887|
|Writing per-system stats csv files|.5858<br>.4284|.3042<br>.2198|.2875<br>.1998|.3793<br>.2707|.4877<br>.3503|.4395<br>.3032|.8879<br>.6947|
|Reading datacheckfps.csv|.0105<br>.0082|.0076<br>.0060|.0062<br>.0044|.0093<br>.0073|.0140<br>.0112|.0117<br>.0081|.0566<br>.0137|
|Setting up for graphs of highway data|.8156<br>.3793|.4780<br>.2131|.5889<br>.2225|.5792<br>.2507|.7701<br>.3280|.9136<br>.3393|1.1541<br>.3041|
|Creating unique names and vertices|2.4403<br>1.4896|1.8919<br>1.2981|1.5840<br>.8554|2.2505<br>1.5051|2.9548<br>2.0886|2.4563<br>1.3441|4.0264<br>1.2961|
|Creating edges|1.4579<br>.8779|.8655<br>.5821|.9989<br>.5205|1.0688<br>.7136|1.3600<br>.9372|1.5436<br>.8290|2.4347<br>.6780|
|Compressing collapsed edges|1.0787<br>.4365|.6181<br>.2622|.7423<br>.2459|.7520<br>.3064|.9315<br>.3788|1.1292<br>.3642|1.3077<br>.3567|
|Writing graph waypoint simplification log|.0825<br>.0754|.0581<br>.0532|.0483<br>.0360|.0675<br>.0598|.0908<br>.0798|.0748<br>.0549|.0788<br>.0368|
|Writing master TM graph files|4.8957<br>4.0317|3.1352<br>2.6169|3.0301<br>2.5080|3.7402<br>3.1063|4.7022<br>3.9244|4.5410<br>3.7398|5.2170<br>3.5506|
|Creating continent graphs|10.2184<br>7.3478|7.0612<br>5.5430|7.3678<br>4.9343|8.2043<br>6.1743|10.2388<br>7.6388|10.8380<br>7.0800|12.6697<br>6.4112|
|Creating multisystem graphs|2.1258<br>1.6187|1.5534<br>1.3049|1.5238<br>1.1716|1.7180<br>1.4066|2.0785<br>1.6995|2.1780<br>1.6317|2.3161<br>1.4475|
|Creating system data graphs|2.3439<br>1.8517|1.7230<br>1.4693|1.6274<br>1.3050|1.8858<br>1.5847|2.2696<br>1.8999|2.3144<br>1.8196|2.4338<br>1.6033|
|Creating country graphs|7.1299<br>5.5012|5.1263<br>4.2029|4.9214<br>3.6760|5.6060<br>4.4994|7.0072<br>5.6147|7.0674<br>5.1529|8.1340<br>4.6180|
|Creating multiregion graphs|2.4047<br>1.9080|1.7733<br>1.4371|1.6478<br>1.2322|1.8688<br>1.4885|2.3483<br>1.8703|2.3331<br>1.6975|2.7443<br>1.4524|
|Creating regional data graphs|8.1909<br>6.5444|5.1538<br>4.1925|4.9798<br>3.8385|5.2359<br>4.1994|6.8920<br>5.4836|6.9225<br>5.1910|7.6064<br>4.2535|
|Creating area data graphs|.4980<br>.3532|.3075<br>.2414|.3101<br>.2271|.3401<br>.2599|.4312<br>.3278|.4553<br>.3193|.4497<br>.2636|
|Clearing HighwayGraph contents from memory|1.0810<br>.5862|.6474<br>.3921|.7220<br>.2973|.7885<br>.4555|1.0236<br>.5783|1.1198<br>.4625|1.6870<br>.7053|
|Marking datacheck false positives|2.3850<br>.9341|1.6721<br>.8743|1.8886<br>.8538|2.3581<br>1.2464|3.0368<br>1.6190|3.3338<br>1.5672|6.2501<br>1.0552|
|Found .* datacheck errors and matched .* FP entries|0<br>0|.0009<br>.0008|0<br>0|.0004<br>.0004|.0006<br>.0007|0<br>0|0<br>0|
|Writing log of unmatched datacheck FP entries|.0001<br>.0001|.0001<br>.0001|.0001<br>.0001|.0002<br>.0001|.0002<br>.0002|.0002<br>.0002|.0002<br>.0001|
|Writing datacheck.log|.0055<br>.0043|.0041<br>.0032|.0036<br>.0025|.0041<br>.0030|.0055<br>.0044|.0051<br>.0035|.0071<br>.0023|
|\.\.\.continents, countries, regions|.0003<br>.0001|.0002<br>.0001|.0002<br>.0001|.0002<br>.0002|.0003<br>.0003|.0003<br>.0002|.0008<br>.0001|
|\.\.\.systems|.0005<br>.0003|.0004<br>.0003|.0003<br>.0002|.0005<br>.0004|.0006<br>.0006|.0005<br>.0003|.0011<br>.0003|
|\.\.\.routes|.1487<br>.1259|.0988<br>.0924|.0949<br>.0864|.1206<br>.1117|.1526<br>.1496|.1422<br>.1289|.2169<br>.1328|
|\.\.\.connectedRoutes|.1245<br>.1049|.0832<br>.0754|.0767<br>.0677|.0996<br>.0909|.1253<br>.1165|.1164<br>.1013|.1845<br>.1237|
|\.\.\.connectedRouteRoots|.0064<br>.0025|.0030<br>.0013|.0027<br>.0014|.0034<br>.0014|.0048<br>.0020|.0041<br>.0018|.0040<br>.0012|
|\.\.\.waypoints|2.9989<br>2.8391|1.7540<br>1.7053|1.6367<br>1.5768|2.1351<br>2.0774|2.8348<br>2.7818|2.5627<br>2.4527|2.9167<br>2.4236|
|\.\.\.segments|7.1758<br>4.8770|5.7852<br>3.9942|4.5624<br>2.9252|6.8010<br>4.6551|8.6883<br>6.0985|6.8235<br>4.4124|5.9052<br>2.3766|
|\.\.\.clinched$|.6012<br>.4295|.3699<br>.2406|.4440<br>.4050|.4548<br>.2971|.5945<br>.3825|.6760<br>.6096|1.3881<br>.4144|
|\.\.\.overallMileageByRegion|.0010<br>.0010|.0006<br>.0006|.0005<br>.0005|.0007<br>.0007|.0009<br>.0009|.0009<br>.0008|.0007<br>.0007|
|\.\.\.systemMileageByRegion|.0024<br>.0022|.0014<br>.0014|.0014<br>.0013|.0017<br>.0017|.0022<br>.0021|.0025<br>.0020|.0020<br>.0016|
|\.\.\.clinchedOverallMileageByRegion|.0393<br>.0358|.0228<br>.0213|.0227<br>.0211|.0279<br>.0260|.0356<br>.0331|.0343<br>.0318|.0316<br>.0260|
|\.\.\.clinchedSystemMileageByRegion|.0750<br>.0690|.0445<br>.0430|.0441<br>.0425|.0538<br>.0518|.0691<br>.0659|.0680<br>.0642|.0760<br>.0569|
|\.\.\.clinchedConnectedRoutes|.4465<br>.4123|.2657<br>.2507|.2624<br>.2546|.3266<br>.3048|.4095<br>.3907|.3995<br>.3831|.5587<br>.4285|
|\.\.\.clinchedRoutes|.5297<br>.4961|.3104<br>.3073|.3025<br>.2957|.3802<br>.3715|.4887<br>.4683|.4547<br>.4427|.6579<br>.5078|
|\.\.\.updates|.0088<br>.0037|.0066<br>.0035|.0054<br>.0020|.0083<br>.0047|.0107<br>.0062|.0082<br>.0031|.0280<br>.0066|
|\.\.\.systemUpdates|.2458<br>.2145|.1511<br>.0997|.1342<br>.0855|.1910<br>.1307|.2484<br>.1715|.2016<br>.1261|.2118<br>.0654|
|\.\.\.datacheckErrors|.0089<br>.0073|.0096<br>.0083|.0068<br>.0069|.0106<br>.0094|.0130<br>.0118|.0099<br>.0114|.0163<br>.0064|
|\.\.\.graphs|.0013<br>.0007|.0010<br>.0007|.0009<br>.0005|.0012<br>.0008|.0015<br>.0011|.0014<br>.0008|.0028<br>.0005|
|Processed .* highway systems|.0149<br>.0070|.0690<br>.0614|.0073<br>.0033|.0780<br>.0687|.0913<br>.0974|.0105<br>.0046|.0100<br>.0036|
|WaypointQuadtree contains .* total nodes|.0031<br>.0027|.0019<br>.0011|.0009<br>.0005|.0020<br>.0012|.0025<br>.0015|.0009<br>.0005|.0008<br>.0004|
|Computing waypoint colocation stats, reporting all with .* or more colocations:|.5647<br>.3766|.4279<br>.2671|.4094<br>.2311|.5119<br>.3075|.6299<br>.3902|.5973<br>.3392|.9483<br>.3939|