### PR TITLE
subgraph vertex bit field / full custom graphs

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
@@ -51,6 +51,7 @@ std::string GraphListEntry::category()
 		case 'R': return "multiregion";
 		case 'c': return "country";
 		case 'C': return "continent";
+		case 'f': return "fullcustom";
 		default : return std::string("ERROR: GraphListEntry::category() unexpected category token ('")+cat+"')";
 	}
 }
@@ -61,6 +62,7 @@ std::string GraphListEntry::tag()
 		case 'r': return regions->front()->code + ' ';			// must have valid pointer
 		case 's': return systems->front()->systemname + ' ';		// must have valid pointer
 		case 'S':
+		case 'f':
 		case 'R': return root + ' ';
 		case 'c': return regions->front()->country_code() + ' ';	// must have valid pointer
 		case 'C': return regions->front()->continent_code() + ' ';	// must have valid pointer

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.cpp
@@ -23,14 +23,14 @@ void HGVertex::setup(Waypoint *wpt, const std::string *n)
 	    // 2: visible in both traveled & collapsed graphs
 	if (!wpt->colocated)
 	{	if (!wpt->is_hidden) visibility = 2;
-		wpt->route->region->add_vertex(this);
+		wpt->route->region->add_vertex(this, wpt);
 		wpt->route->system->add_vertex(this);
 		return;
 	}
 	for (Waypoint *w : *(wpt->colocated))
 	{	// will consider hidden iff all colocated waypoints are hidden
 		if (!w->is_hidden) visibility = 2;
-		w->route->region->add_vertex(this);	// Yes, a region/system can get the same vertex multiple times
+		w->route->region->add_vertex(this, wpt);// Yes, a region/system can get the same vertex multiple times
 		w->route->system->add_vertex(this);	// from different routes. But HighwayGraph::matching_vertices_and_edges
 	}						// gets rid of any redundancy when making the final set.
 }

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -26,10 +26,12 @@ class HighwayGraph
     */
 
 	public:
+	size_t vbytes;		// number of bytes allocated to each thread in the vbits array
+	unsigned char* vbits;	// bit field to track whether each vertex is included in a given subgraph
 	std::unordered_set<std::string> vertex_names[256];	// unique vertex labels
 	std::list<std::string> waypoint_naming_log;		// to track waypoint name compressions
 	std::mutex set_mtx[256], log_mtx;
-	std::vector<HGVertex> vertices;
+	std::vector<HGVertex> vertices;				// MUST be stored sequentially!
 	unsigned int cv, tv, se, ce, te;			// vertex & edge counts
 
 	HighwayGraph(WaypointQuadtree&, ElapsedTime&);
@@ -38,14 +40,17 @@ class HighwayGraph
 	void namelog(std::string&&);
 	void simplify(int, std::vector<Waypoint*>*, unsigned int*, const size_t);
 	inline std::pair<std::unordered_set<std::string>::iterator,bool> vertex_name(std::string&);
+	bool subgraph_contains(HGVertex*, const int);
+	void add_to_subgraph(HGVertex*, const int);
+	void clear_vbit(HGVertex*, const int);
 
 	inline void matching_vertices_and_edges
 	(	GraphListEntry&, WaypointQuadtree*,
 		std::list<TravelerList*> &,
-		std::unordered_set<HGVertex*>&,	// final set of vertices matching all criteria
-		std::list<HGEdge*>&,		// matching    simple edges
-		std::list<HGEdge*>&,		// matching collapsed edges
-		std::list<HGEdge*>&,		// matching  traveled edges
+		std::vector<HGVertex*>&,	// final set of vertices matching all criteria
+		std::vector<HGEdge*>&,		// matching    simple edges
+		std::vector<HGEdge*>&,		// matching collapsed edges
+		std::vector<HGEdge*>&,		// matching  traveled edges
 		int, unsigned int&, unsigned int&
 	);
 

--- a/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
@@ -1,9 +1,10 @@
+class GraphListEntry;
 class HGEdge;
 class HGVertex;
 class HighwayGraph;
 class WaypointQuadtree;
 #include <iostream>
-#include <unordered_set>
+#include <vector>
 
 class PlaceRadius
 {	/* This class encapsulates a place name, file base name, latitude,
@@ -21,6 +22,6 @@ class PlaceRadius
 
 	bool contains_vertex(HGVertex *);
 	bool contains_vertex(double, double);
-	void vertices(std::unordered_set<HGVertex*>&, WaypointQuadtree *);
-	void v_search(std::unordered_set<HGVertex*>&, WaypointQuadtree *, double, double);
+	void vertices(std::vector<HGVertex*>&, WaypointQuadtree *, HighwayGraph *, GraphListEntry&, const int);
+	void v_search(std::vector<HGVertex*>&, WaypointQuadtree *, HighwayGraph *, GraphListEntry&, const int, double, double);
 };

--- a/siteupdate/cplusplus/classes/Region/Region.cpp
+++ b/siteupdate/cplusplus/classes/Region/Region.cpp
@@ -66,9 +66,9 @@ std::string& Region::continent_code()
 {	return continent->first;
 }
 
-void Region::add_vertex(HGVertex* v)
+void Region::add_vertex(HGVertex* v, Waypoint* w)
 {	mtx.lock();
-	vertices.push_back(v);
+	vertices.emplace_back(v,w);
 	mtx.unlock();
 }
 

--- a/siteupdate/cplusplus/classes/Region/Region.h
+++ b/siteupdate/cplusplus/classes/Region/Region.h
@@ -1,5 +1,6 @@
 class ErrorList;
 class HGVertex;
+class Waypoint;
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -44,7 +45,7 @@ class Region
 	double active_preview_mileage;
 	double overall_mileage;
 	std::mutex mtx;
-	std::vector<HGVertex*> vertices;
+	std::vector<std::pair<HGVertex*,Waypoint*>> vertices;
 	bool is_valid;
 
 	static std::vector<Region*> allregions;
@@ -57,7 +58,7 @@ class Region
 
 	std::string &country_code();
 	std::string &continent_code();
-	void add_vertex(HGVertex*);
+	void add_vertex(HGVertex*, Waypoint*);
 };
 
 bool sort_regions_by_code(const Region*, const Region*);

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -5,6 +5,7 @@
 #include "../Route/Route.h"
 #include "../../functions/strd.h"
 #include "../../functions/valid_num_str.h"
+#include "../../templates/contains.cpp"
 #include <cmath>
 #include <cstring>
 #define pi 3.141592653589793238
@@ -274,6 +275,22 @@ Waypoint* Waypoint::hashpoint()
 	return colocated->front();
 }
 
+bool Waypoint::region_match(std::list<Region*>* regions)
+{	if (!regions) return 1;
+	if (!colocated) return contains(*regions, route->region);
+	for (Waypoint* w : *colocated)
+	  if (w->route->system->active_or_preview() && contains(*regions, w->route->region)) return 1;
+	return 0;
+}
+
+bool Waypoint::system_match(std::list<HighwaySystem*>* systems)
+{	if (!systems) return 1;
+	if (!colocated) return contains(*systems, route->system);
+	for (Waypoint* w : *colocated)
+	  if (contains(*systems, w->route->system)) return 1;
+	return 0;
+}
+
 bool Waypoint::label_references_route(Route *r)
 {	std::string no_abbrev = r->name_no_abbrev();
 	if ( strncmp(label.data(), no_abbrev.data(), no_abbrev.size()) )
@@ -291,6 +308,8 @@ bool Waypoint::label_references_route(Route *r)
 		Datacheck::add(route, label, "", "", "UNEXPECTED_DESIGNATION", label.data()+no_abbrev.size()+r->abbrev.size()+1);//*/
 	return 0;
 }
+
+/* Datacheck helper functions */
 
 Route* Waypoint::coloc_same_number(const char* digits)
 {	if (colocated)

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -1,5 +1,7 @@
 class HGVertex;
 class HighwayGraph;
+class HighwaySystem;
+class Region;
 class Route;
 #include <forward_list>
 #include <fstream>
@@ -42,6 +44,8 @@ class Waypoint
 	std::string root_at_label();
 	void nmplogs(std::unordered_set<std::string> &, std::ofstream &, std::list<std::string> &);
 	Waypoint* hashpoint();
+	bool region_match(std::list<Region*>*);
+	bool system_match(std::list<HighwaySystem*>*);
 	bool label_references_route(Route *);
 	Route* coloc_same_number(const char*);
 	Route* coloc_same_designation(const std::string&);

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -41,6 +41,7 @@ else {	list<Region*> *regions;
 	#include "subgraphs/system.cpp"
 	#include "subgraphs/country.cpp"
 	#include "subgraphs/multiregion.cpp"
+	#include "subgraphs/fullcustom.cpp"
 	#include "subgraphs/region.cpp"
 	#include "subgraphs/area.cpp"
       #ifdef threading_enabled

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -1,0 +1,100 @@
+// fully customizable graphs using any combination of PlaceRadius, region(s) & system(s)
+file.open(Args::highwaydatapath+"/graphs/fullcustom.csv");
+if (file.is_open())
+{	getline(file, line);  // ignore header line
+	#ifndef threading_enabled
+	cout << et.et() << "Creating full custom graphs." << endl;
+	#endif
+	// add entries to graph vector
+	while (getline(file, line))
+	{	// parse fullcustom.csv line
+		if (line.empty()) continue;
+		size_t NumFields = 7;
+		std::string descr, root, lat_s, lng_s, radius, regionlist, systemlist;
+		std::string* fields[7] = {&descr, &root, &lat_s, &lng_s, &radius, &regionlist, &systemlist};
+		split(line, fields, NumFields, ';');
+		if (NumFields != 7)
+		{	el.add_error("Could not parse fullcustom.csv line: [" + line
+				   + "], expected 7 fields, found " + std::to_string(NumFields));
+			continue;
+		}
+		if (descr.size() > DBFieldLength::graphDescr)
+		  el.add_error("description > " + std::to_string(DBFieldLength::graphDescr)
+			     + " bytes in fullcustom.csv line: " + line);
+		if (root.size() > DBFieldLength::graphFilename-14)
+		  el.add_error("title > " + std::to_string(DBFieldLength::graphFilename-14)
+			     + " bytes in fullcustom.csv line: " + line);
+
+		// 3 columns of PlaceRadius data
+		PlaceRadius* a = 0;
+		char blanks = lat_s.empty() + lng_s.empty() + radius.empty();
+		if (!blanks)
+		{	// convert numeric fields
+			char* endptr;
+			double lat = strtod(lat_s.data(), &endptr);
+			if (*endptr)		el.add_error("invalid lat in fullcustom.csv line: " + line);
+			double lng = strtod(lng_s.data(), &endptr);
+			if (*endptr)		el.add_error("invalid lng in fullcustom.csv line: " + line);
+			int r = strtol(radius.data(), &endptr, 10);
+			if (*endptr || r <= 0) {el.add_error("invalid radius in fullcustom.csv line: " + line); r=1;}
+			a = new PlaceRadius(descr.data(), root.data(), lat, lng, r);
+		}	    // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		else if (blanks != 3)
+		{	el.add_error("lat/lng/radius error in fullcustom.csv line: [" + line
+				   + "], either all or none must be populated");
+			continue;
+		}
+		else if (regionlist.empty() && systemlist.empty())
+		{	el.add_error("Disallowed full custom graph in line: [" + line
+				   + "], functionally identical to tm-master");
+			continue;
+		}
+
+		// regionlist
+		if (regionlist.empty()) regions = 0;
+		else {	regions = new list<Region*>;
+				  // deleted @ end of HighwayGraph::write_subgraphs_tmg or if a token is unrecognized
+			char* field = new char[regionlist.size()+1];
+				      // deleted once region tokens are processed or if a token is unrecognized
+			strcpy(field, regionlist.data());
+			for(char* rg = strtok(field, ","); rg; rg = strtok(0, ","))
+			  try {	regions->push_back(Region::code_hash.at(rg));
+			      }
+			  catch (const std::out_of_range& oor)
+			      {	el.add_error("unrecognized region code "+std::string(rg)+" in fullcustom.csv line: ["+line+"], skipping this entry");
+				delete[] field;
+				delete regions;
+				continue;
+			      }
+			delete[] field;
+		     }
+
+		// systemlist
+		if (systemlist.empty()) systems = 0;
+		else {	systems = new list<HighwaySystem*>;
+				  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+			char* field = new char[systemlist.size()+1];
+				      // deleted once system tokens are processed
+			strcpy(field, systemlist.data());
+			for(char* s = strtok(field, ","); s; s = strtok(0, ","))
+			  for (HighwaySystem *h : HighwaySystem::syslist)
+			    if (s == h->systemname)
+			    {	systems->push_back(h);
+				break;
+			    }
+			delete[] field;
+		     }
+		GraphListEntry::add_group(std::move(root), std::move(descr), 'f', regions, systems, a);
+	}
+	file.close();
+	#ifndef threading_enabled
+	// write new graph vector entries to disk
+	while (GraphListEntry::num < GraphListEntry::entries.size())
+	{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
+		GraphListEntry::num += 3;
+	}
+	cout << "!" << endl;
+	#endif
+	graph_types.push_back({"fullcustom", "Full Custom Graphs",
+	"These graphs can be restricted by any combination of one more more regions and one or more highway systems, and optionally within the given distance radius of a given place."});
+}

--- a/siteupdate/cplusplus/threads/SubgraphThread.cpp
+++ b/siteupdate/cplusplus/threads/SubgraphThread.cpp
@@ -10,7 +10,7 @@ void SubgraphThread
 			return;
 		}
 		//std::cout << "Thread " << id << " with graph_vector.size()=" << graph_vector->size() << " & index=" << GraphListEntry::num << std::endl;
-		//std::cout << "Thread " << id << " assigned " << graph_vector->at(GraphListEntry::num).tag() << std::endl;
+		//std::cout << "Thread " << id << " assigned " << GraphListEntry::entries.at(GraphListEntry::num).tag() << std::endl;
 		size_t i = GraphListEntry::num;
 		GraphListEntry::num += 3;
 		l->unlock();


### PR DESCRIPTION
**Full custom graph** functionality *"is and is not"* implemented, sort of a hidden feature. If fullcustom.csv is not found, siteupdate skips right past that bit without complaining.
I decided it's easier to just merge this to master now than to keep rebasing a local branch or updating stashes as I change other related parts of the code moving forward. Hope this is OK, Jim. :)
Closes #401.

---

The **Subgraph vertex bit field** provides another good speed boost in Linux, but sadly doesn't do much for FreeBSD.
At 1 thread, subgraph time is down almost 15%, but FreeBSD is right back to its old tricks @ 2 threads, taking 45.9 s.
<!--![Subg521-88](https://user-images.githubusercontent.com/13720877/164784790-2fb83206-79ce-4f1e-bc08-6d153f8024ea.png)-->
<!--![Subg521-88](https://user-images.githubusercontent.com/13720877/164787015-1076f916-7694-4443-aa8b-88cf1f92c2d7.png)-->
![Subg521-88V4A](https://user-images.githubusercontent.com/13720877/164800062-5de7fbd5-41a4-470b-9ae3-7fcd4ed1d94a.png)
Same Y axis scale as [this chart](https://user-images.githubusercontent.com/13720877/163838925-b4d1b093-640b-459c-920f-2610f2930773.gif) from #520 & [this chart](https://user-images.githubusercontent.com/13720877/163054980-b7f641aa-3d7d-4825-83ff-cc40977036f2.gif) from #515 for easy comparison.

Zoomed in to just Linux:
<!--![Subg521-34](https://user-images.githubusercontent.com/13720877/164785171-a4fcf4fb-2468-4f7b-b9ca-982b010b1d22.png)-->
![Subg521-34](https://user-images.githubusercontent.com/13720877/164787049-7a80315a-3cd2-4c4a-aa80-f6e01ad48203.png)
Same Y axis scale as [this chart](https://user-images.githubusercontent.com/13720877/163840452-a46eb6fe-39ea-4d12-98b7-1110c374c225.gif) from #520 for easy comparison.