### PR TITLE
region management / remove redundant computation

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -12,6 +12,8 @@
 
 std::list<HighwaySystem*> HighwaySystem::syslist;
 std::list<HighwaySystem*>::iterator HighwaySystem::it;
+unsigned int HighwaySystem::num_active  = 0;
+unsigned int HighwaySystem::num_preview = 0;
 
 HighwaySystem::HighwaySystem(std::string &line, ErrorList &el, std::vector<std::pair<std::string,std::string>> &countries)
 {	std::ifstream file;
@@ -54,7 +56,10 @@ HighwaySystem::HighwaySystem(std::string &line, ErrorList &el, std::vector<std::
 	level = level_str[0];
 	if (level_str != "active" && level_str != "preview" && level_str != "devel")
 		el.add_error("Unrecognized level in " + Args::systemsfile + " line: " + line);
-
+	switch(level)
+	{	case 'p': num_preview++; break;
+		case 'a': num_active++;
+	}
 	std::cout << systemname << '.' << std::flush;
 
 	// read chopped routes CSV

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -44,6 +44,8 @@ class HighwaySystem
 
 	static std::list<HighwaySystem*> syslist;
 	static std::list<HighwaySystem*>::iterator it;
+	static unsigned int num_active;
+	static unsigned int num_preview;
 
 	HighwaySystem(std::string &, ErrorList &, std::vector<std::pair<std::string,std::string>> &);
 

--- a/siteupdate/cplusplus/classes/Region/Region.cpp
+++ b/siteupdate/cplusplus/classes/Region/Region.cpp
@@ -9,7 +9,7 @@ std::pair<std::string, std::string> *country_or_continent_by_code(std::string co
 	return 0;
 }
 
-std::vector<Region*> Region::allregions;
+std::list<Region> Region::allregions;
 std::unordered_map<std::string, Region*> Region::code_hash;
 
 Region::Region (const std::string &line,
@@ -26,12 +26,8 @@ Region::Region (const std::string &line,
 	split(line, fields, NumFields, ';');
 	if (NumFields != 5)
 	{	el.add_error("Could not parse regions.csv line: [" + line + "], expected 5 fields, found " + std::to_string(NumFields));
-		continent = country_or_continent_by_code("error", continents);
-		country   = country_or_continent_by_code("error", countries);
-		is_valid = 0;
-		return;
+		throw 1;
 	}
-	is_valid = 1;
 	// code
 	if (code.size() > DBFieldLength::regionCode)
 		el.add_error("Region code > " + std::to_string(DBFieldLength::regionCode)

--- a/siteupdate/cplusplus/classes/Region/Region.h
+++ b/siteupdate/cplusplus/classes/Region/Region.h
@@ -1,6 +1,7 @@
 class ErrorList;
 class HGVertex;
 class Waypoint;
+#include <list>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -46,9 +47,8 @@ class Region
 	double overall_mileage;
 	std::mutex mtx;
 	std::vector<std::pair<HGVertex*,Waypoint*>> vertices;
-	bool is_valid;
 
-	static std::vector<Region*> allregions;
+	static std::list<Region> allregions;
 	static std::unordered_map<std::string, Region*> code_hash;
 
 	Region (const std::string&,

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -29,17 +29,9 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 		    << format_clinched_mi(active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
 	}
 
-	unsigned int active_systems = 0;
-	unsigned int preview_systems = 0;
-
-	// present stats by system here, also generate entries for
-	// DB table clinchedSystemMileageByRegion as we compute and
-	// have the data handy
 	for (HighwaySystem *h : HighwaySystem::syslist)
 	  if (h->active_or_preview())
-	  {	if (h->active()) active_systems++;
-		else	preview_systems++;
-		double t_system_overall = 0;
+	  {	double t_system_overall = 0;
 		if (system_region_mileages.count(h))
 			t_system_overall = system_region_miles(h);
 		if (t_system_overall)
@@ -110,13 +102,13 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 
 	// grand summary, active only
 	sprintf(fstr,"\nTraveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) active systems",
-			active_systems_traveled, active_systems, 100*(double)active_systems_traveled/active_systems,
-			active_systems_clinched, active_systems, 100*(double)active_systems_clinched/active_systems);
+		active_systems_traveled, HighwaySystem::num_active, 100*(double)active_systems_traveled/HighwaySystem::num_active,
+		active_systems_clinched, HighwaySystem::num_active, 100*(double)active_systems_clinched/HighwaySystem::num_active);
 	log << fstr << '\n';
 	// grand summary, active+preview
 	sprintf(fstr,"Traveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) preview systems",
-			preview_systems_traveled, preview_systems, 100*(double)preview_systems_traveled/preview_systems,
-			preview_systems_clinched, preview_systems, 100*(double)preview_systems_clinched/preview_systems);
+		preview_systems_traveled, HighwaySystem::num_preview, 100*(double)preview_systems_traveled/HighwaySystem::num_preview,
+		preview_systems_clinched, HighwaySystem::num_preview, 100*(double)preview_systems_clinched/HighwaySystem::num_preview);
 	log << fstr << '\n';
 
 	// updated routes, sorted by date

--- a/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
@@ -4,18 +4,14 @@
 #include "../threads/threads.h"
 #include <fstream>
 
-void allbyregionactiveonly(std::mutex* mtx)
-{	double total_mi;
-	char fstr[112];
+void allbyregionactiveonly(std::mutex* mtx, double total_mi)
+{	char fstr[112];
 	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactiveonly.csv");
 	allfile << "Traveler,Total";
 	std::list<Region*> regions;
-	total_mi = 0;
-	for (Region* r : Region::allregions)
-	  if (r->active_only_mileage)
-	  {	regions.push_back(r);
-		total_mi += r->active_only_mileage;
-	  }
+	for (Region& r : Region::allregions)
+	  if (r.active_only_mileage)
+	    regions.push_back(&r);
 	regions.sort(sort_regions_by_code);
 	for (Region *region : regions)
 		allfile << ',' << region->code;

--- a/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
@@ -4,18 +4,14 @@
 #include "../threads/threads.h"
 #include <fstream>
 
-void allbyregionactivepreview(std::mutex* mtx)
-{	double total_mi;
-	char fstr[112];
+void allbyregionactivepreview(std::mutex* mtx, double total_mi)
+{	char fstr[112];
 	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactivepreview.csv");
 	allfile << "Traveler,Total";
 	std::list<Region*> regions;
-	total_mi = 0;
-	for (Region* r : Region::allregions)
-	  if (r->active_preview_mileage)
-	  {	regions.push_back(r);
-		total_mi += r->active_preview_mileage;
-	  }
+	for (Region& r : Region::allregions)
+	  if (r.active_preview_mileage)
+	    regions.push_back(&r);
 	regions.sort(sort_regions_by_code);
 	for (Region *region : regions)
 		allfile << ',' << region->code;

--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -86,12 +86,12 @@ void sqlfile1
 	sqlfile << "PRIMARY KEY(code), FOREIGN KEY (country) REFERENCES countries(code), FOREIGN KEY (continent) REFERENCES continents(code));\n";
 	sqlfile << "INSERT INTO regions VALUES\n";
 	first = 1;
-	for (size_t r = 0; r < Region::allregions.size()-1; r++)
+	for (auto r = Region::allregions.begin(); &*r != &*Region::allregions.rbegin(); r++)
 	{	if (!first) sqlfile << ',';
 		first = 0;
-		sqlfile << "('" << Region::allregions[r]->code << "','" << double_quotes(Region::allregions[r]->name)
-			<< "','" << Region::allregions[r]->country_code() << "','" << Region::allregions[r]->continent_code()
-			<< "','" << Region::allregions[r]->type << "')\n";
+		sqlfile << "('" << r->code << "','" << double_quotes(r->name)
+			<< "','" << r->country_code() << "','" << r->continent_code()
+			<< "','" << r->type << "')\n";
 	}
 	sqlfile << ";\n";
 
@@ -271,12 +271,12 @@ void sqlfile1
 		<< "), activeMileage DOUBLE, activePreviewMileage DOUBLE);\n";
 	sqlfile << "INSERT INTO overallMileageByRegion VALUES\n";
 	first = 1;
-	for (Region* region : Region::allregions)
-	{	if (region->active_only_mileage+region->active_preview_mileage == 0) continue;
+	for (Region& region : Region::allregions)
+	{	if (region.active_only_mileage+region.active_preview_mileage == 0) continue;
 		if (!first) sqlfile << ',';
 		first = 0;
-		sprintf(fstr, "','%.17g','%.17g')\n", region->active_only_mileage, region->active_preview_mileage);
-		sqlfile << "('" << region->code << fstr;
+		sprintf(fstr, "','%.17g','%.17g')\n", region.active_only_mileage, region.active_preview_mileage);
+		sqlfile << "('" << region.code << fstr;
 	}
 	sqlfile << ";\n";
 

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -6,10 +6,10 @@ cout << et.et() << "Creating continent graphs." << endl;
 for (size_t c = 0; c < continents.size()-1; c++)
 {	regions = new list<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
-	for (Region* r : Region::allregions)
+	for (Region& r : Region::allregions)
 	  // does it match this continent and have routes?
-	  if (&continents[c] == r->continent && r->active_preview_mileage)
-	    regions->push_back(r);
+	  if (&continents[c] == r.continent && r.active_preview_mileage)
+	    regions->push_back(&r);
 	// generate for any continent with at least 1 region with mileage
 	if (regions->size() < 1) delete regions;
 	else {	GraphListEntry::add_group(

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -7,10 +7,10 @@ cout << et.et() << "Creating country graphs." << endl;
 for (size_t c = 0; c < countries.size()-1; c++)
 {	regions = new list<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
-	for (Region* r : Region::allregions)
+	for (Region& r : Region::allregions)
 	  // does it match this country and have routes?
-	  if (&countries[c] == r->country && r->active_preview_mileage)
-	    regions->push_back(r);
+	  if (&countries[c] == r.country && r.active_preview_mileage)
+	    regions->push_back(&r);
 	// does it have at least two?  if none, no data,
 	// if 1 we already generated a graph for that one region
 	if (regions->size() < 2) delete regions;

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -28,9 +28,9 @@ while (getline(file, line))
 	regions = new list<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for(char* rg = strtok(fields[2], ","); rg; rg = strtok(0, ","))
-	  for (Region* r : Region::allregions)
-	    if (rg == r->code)
-	    {	regions->push_back(r);
+	  for (Region& r : Region::allregions)
+	    if (rg == r.code)
+	    {	regions->push_back(&r);
 		break;
 	    }
 	GraphListEntry::add_group(fields[1], fields[0], 'R', regions, nullptr, nullptr);

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -6,13 +6,13 @@ cout << et.et() << "Creating regional data graphs." << endl;
 // any active or preview systems
 
 // add entries to graph vector
-for (Region* region : Region::allregions)
-{	if (region->active_preview_mileage == 0) continue;
-	regions = new list<Region*>(1, region);
+for (Region& region : Region::allregions)
+{	if (region.active_preview_mileage == 0) continue;
+	regions = new list<Region*>(1, &region);
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	GraphListEntry::add_group(
-		region->code + "-region",
-		region->name + " (" + region->type + ")",
+		region.code + "-region",
+		region.name + " (" + region.type + ")",
 		'r', regions, nullptr, nullptr);
 }
 #ifndef threading_enabled

--- a/siteupdate/cplusplus/threads/ReadListThread.cpp
+++ b/siteupdate/cplusplus/threads/ReadListThread.cpp
@@ -12,7 +12,6 @@ void ReadListThread(unsigned int id, std::mutex* tl_mtx, ErrorList* el)
 		//printf("ReadListThread %02i (*it)++\n", id); fflush(stdout);
 		std::cout << tl << ' ' << std::flush;
 		tl_mtx->unlock();
-		std::string** update;
 		TravelerList *t = new TravelerList(tl, el);
 				  // deleted on termination of program
 		TravelerList::mtx.lock();

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1307,6 +1307,9 @@ class HighwaySystem:
     a designation within the same system crosses region boundaries,
     a connected route defines the entirety of the route.
     """
+    num_active = 0
+    num_preview = 0
+
     def __init__(self,systemname,country,fullname,color,tier,level,el,
                  path="../../../HighwayData/hwy_data/_systems"):
         self.route_list = []
@@ -2812,6 +2815,10 @@ else:
         # verify Level
         if fields[5] != "active" and fields[5] != "preview" and fields[5] != "devel":
             el.add_error("Unrecognized level in " + args.systemsfile + " line: " + line)
+        elif fields[5] == "preview":
+            HighwaySystem.num_preview += 1
+        elif fields[5] == "active":
+            HighwaySystem.num_active += 1
 
         print(fields[0] + ".",end="",flush=True)
         hs = HighwaySystem(fields[0], fields[1], fields[2],
@@ -3540,18 +3547,9 @@ for t in traveler_lists:
     t.active_systems_clinched = 0
     t.preview_systems_traveled = 0
     t.preview_systems_clinched = 0
-    active_systems = 0
-    preview_systems = 0
 
-    # present stats by system here, also generate entries for
-    # DB table clinchedSystemMileageByRegion as we compute and
-    # have the data handy
     for h in highway_systems:
         if h.active_or_preview():
-            if h.active():
-                active_systems += 1
-            else:
-                preview_systems += 1
             t_system_overall = 0.0
             if h.systemname in t.system_region_mileages:
                 t_system_overall = math.fsum(t.system_region_mileages[h.systemname].values())
@@ -3620,16 +3618,16 @@ for t in traveler_lists:
 
 
     # grand summary, active only
-    t.log_entries.append("\nTraveled " + str(t.active_systems_traveled) + " of " + str(active_systems) +
-                         " ({0:.1f}%)".format(100*t.active_systems_traveled/active_systems) +
-                         ", Clinched " + str(t.active_systems_clinched) + " of " + str(active_systems) +
-                         " ({0:.1f}%)".format(100*t.active_systems_clinched/active_systems) +
+    t.log_entries.append("\nTraveled " + str(t.active_systems_traveled) + " of " + str(HighwaySystem.num_active) +
+                         " ({0:.1f}%)".format(100*t.active_systems_traveled/HighwaySystem.num_active) +
+                         ", Clinched " + str(t.active_systems_clinched) + " of " + str(HighwaySystem.num_active) +
+                         " ({0:.1f}%)".format(100*t.active_systems_clinched/HighwaySystem.num_active) +
                          " active systems")
     # grand summary, active+preview
-    t.log_entries.append("Traveled " + str(t.preview_systems_traveled) + " of " + str(preview_systems) +
-                         " ({0:.1f}%)".format(100*t.preview_systems_traveled/preview_systems) +
-                         ", Clinched " + str(t.preview_systems_clinched) + " of " + str(preview_systems) +
-                         " ({0:.1f}%)".format(100*t.preview_systems_clinched/preview_systems) +
+    t.log_entries.append("Traveled " + str(t.preview_systems_traveled) + " of " + str(HighwaySystem.num_preview) +
+                         " ({0:.1f}%)".format(100*t.preview_systems_traveled/HighwaySystem.num_preview) +
+                         ", Clinched " + str(t.preview_systems_clinched) + " of " + str(HighwaySystem.num_preview) +
+                         " ({0:.1f}%)".format(100*t.preview_systems_clinched/HighwaySystem.num_preview) +
                          " preview systems")
     # updated routes, sorted by date
     t.log_entries.append("\nMost recent updates for listed routes:")
@@ -3668,7 +3666,7 @@ for t in traveler_lists:
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_only_mileage_by_region.values())))
+allfile.write('TOTAL,{0:.2f}'.format(active_only_miles))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_only_mileage_by_region[region]))
 allfile.write('\n')
@@ -3689,7 +3687,7 @@ for t in traveler_lists:
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_preview_mileage_by_region.values())))
+allfile.write('TOTAL,{0:.2f}'.format(active_preview_miles))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_preview_mileage_by_region[region]))
 allfile.write('\n')


### PR DESCRIPTION
Closes yakra#220. Removes an unused vestigial variable.
Closes #523.
Closes #522.

---

**C++ Region management:**
* A step toward making siteupdate "Valgrind clean". Rather than manually create `new` Region objects on the heap and store pointers in a `vector`, Regions are emplaced in a `list`. *(I'd prefer a `vector`, but can't because `Region` contains a `std::mutex`, which is immovable, making `Region`s immovable too. Went with this instead.)*
I don't have to manually delete anything, as the list destructor cleans the objects up at the end of the program when the list goes out of scope.
*Next up: TravelerLists.*
* In the process, changed the `Region` ctor to throw if the regions.csv line has the wrong # of fields. AIUI that's considered better practice than setting & checking a `valid` bit and deleting a fully constructed object, popping it from a container, etc. Cleaner code either way, and a tad less RAM.