### PR TITLE
user log speedup / remove redundant computation

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -12,6 +12,8 @@
 
 std::list<HighwaySystem*> HighwaySystem::syslist;
 std::list<HighwaySystem*>::iterator HighwaySystem::it;
+unsigned int HighwaySystem::num_active  = 0;
+unsigned int HighwaySystem::num_preview = 0;
 
 HighwaySystem::HighwaySystem(std::string &line, ErrorList &el, std::vector<std::pair<std::string,std::string>> &countries)
 {	std::ifstream file;
@@ -54,7 +56,10 @@ HighwaySystem::HighwaySystem(std::string &line, ErrorList &el, std::vector<std::
 	level = level_str[0];
 	if (level_str != "active" && level_str != "preview" && level_str != "devel")
 		el.add_error("Unrecognized level in " + Args::systemsfile + " line: " + line);
-
+	switch(level)
+	{	case 'a': num_active++; break;
+		case 'p': num_preview++;
+	}
 	std::cout << systemname << '.' << std::flush;
 
 	// read chopped routes CSV

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -44,6 +44,8 @@ class HighwaySystem
 
 	static std::list<HighwaySystem*> syslist;
 	static std::list<HighwaySystem*>::iterator it;
+	static unsigned int num_active;
+	static unsigned int num_preview;
 
 	HighwaySystem(std::string &, ErrorList &, std::vector<std::pair<std::string,std::string>> &);
 

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -29,17 +29,10 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 		    << format_clinched_mi(active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
 	}
 
-	unsigned int active_systems = 0;
-	unsigned int preview_systems = 0;
-
-	// present stats by system here, also generate entries for
-	// DB table clinchedSystemMileageByRegion as we compute and
-	// have the data handy
+	// stats by system
 	for (HighwaySystem *h : HighwaySystem::syslist)
 	  if (h->active_or_preview())
-	  {	if (h->active()) active_systems++;
-		else	preview_systems++;
-		double t_system_overall = 0;
+	  {	double t_system_overall = 0;
 		if (system_region_mileages.count(h))
 			t_system_overall = system_region_miles(h);
 		if (t_system_overall)
@@ -110,13 +103,13 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 
 	// grand summary, active only
 	sprintf(fstr,"\nTraveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) active systems",
-			active_systems_traveled, active_systems, 100*(double)active_systems_traveled/active_systems,
-			active_systems_clinched, active_systems, 100*(double)active_systems_clinched/active_systems);
+		active_systems_traveled, HighwaySystem::num_active, 100*(double)active_systems_traveled/HighwaySystem::num_active,
+		active_systems_clinched, HighwaySystem::num_active, 100*(double)active_systems_clinched/HighwaySystem::num_active);
 	log << fstr << '\n';
 	// grand summary, active+preview
 	sprintf(fstr,"Traveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) preview systems",
-			preview_systems_traveled, preview_systems, 100*(double)preview_systems_traveled/preview_systems,
-			preview_systems_clinched, preview_systems, 100*(double)preview_systems_clinched/preview_systems);
+		preview_systems_traveled, HighwaySystem::num_preview, 100*(double)preview_systems_traveled/HighwaySystem::num_preview,
+		preview_systems_clinched, HighwaySystem::num_preview, 100*(double)preview_systems_clinched/HighwaySystem::num_preview);
 	log << fstr << '\n';
 
 	// updated routes, sorted by date

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -13,8 +13,8 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 	std::cout << "." << std::flush;
 	std::ofstream log(Args::logfilepath+"/users/"+traveler_name+".log", std::ios::app);
 	log << "Clinched Highway Statistics\n";
-	log << "Overall in active systems: " << format_clinched_mi(active_only_miles(), total_active_only_miles) << '\n';
-	log << "Overall in active+preview systems: " << format_clinched_mi(active_preview_miles(), total_active_preview_miles) << '\n';
+	log << "Overall in active systems: " << format_clinched_mi(fstr, active_only_miles(), total_active_only_miles) << '\n';
+	log << "Overall in active+preview systems: " << format_clinched_mi(fstr, active_preview_miles(), total_active_preview_miles) << '\n';
 
 	log << "Overall by region: (each line reports active only then active+preview)\n";
 	std::list<Region*> travregions;
@@ -25,8 +25,8 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 	{	double t_active_miles = 0;
 		if (active_only_mileage_by_region.count(region))
 			t_active_miles = active_only_mileage_by_region.at(region);
-		log << region->code << ": " << format_clinched_mi(t_active_miles, region->active_only_mileage) << ", "
-		    << format_clinched_mi(active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
+		log << region->code << ": " << format_clinched_mi(fstr, t_active_miles, region->active_only_mileage) << ", "
+		    << format_clinched_mi(fstr, active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
 	}
 
 	// stats by system
@@ -50,7 +50,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 			auto& systemname = h->systemname;
 			auto& sysmbr = h->mileage_by_region;
 			log << "System " << systemname << " (" << h->level_name() << ") overall: "
-			    << format_clinched_mi(t_system_overall, h->total_mileage()) << '\n';
+			    << format_clinched_mi(fstr, t_system_overall, h->total_mileage()) << '\n';
 			if (sysmbr.size() > 1)
 			{	log << "System " << systemname << " by region:\n";
 				std::list<Region*> sysregions;
@@ -62,7 +62,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 					auto it = system_region_mileages.at(h).find(region);
 					if (it != system_region_mileages.at(h).end())
 						system_region_mileage = it->second;
-					log << "  " << region->code << ": " << format_clinched_mi(system_region_mileage, sysmbr.at(region)) << '\n';
+					log << "  " << region->code << ": " << format_clinched_mi(fstr, system_region_mileage, sysmbr.at(region)) << '\n';
 				}
 			}
 
@@ -73,7 +73,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 			log << "System " << systemname << " by route (traveled routes only):\n";
 			for (ConnectedRoute *cr : h->con_route_list)
 			{	double con_clinched_miles = 0;
-				std::string to_write = "";
+				std::vector<std::pair<Route*, double>> chop_mi;
 				auto& roots = cr->roots;
 				for (Route *r : roots)
 				{	// find traveled mileage on this by this user
@@ -81,17 +81,21 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 					if (miles)
 					{	cr_values.emplace_back(r, miles);
 						con_clinched_miles += miles;
-						to_write += "  " + r->readable_name() + ": " + format_clinched_mi(miles,r->mileage) + "\n";
+						chop_mi.emplace_back(r, miles);
 					}
 				}
 				if (con_clinched_miles)
 				{	num_con_rtes_traveled += 1;
 					num_con_rtes_clinched += (con_clinched_miles == cr->mileage);
 					ccr_values.emplace_back(cr, con_clinched_miles);
-					log << cr->readable_name() << ": " << format_clinched_mi(con_clinched_miles, cr->mileage) << '\n';
+					log << cr->readable_name() << ": " << format_clinched_mi(fstr, con_clinched_miles, cr->mileage) << '\n';
 					if (roots.size() == 1)
 						log << " (" << roots[0]->readable_name() << " only)\n";
-					else	log << to_write << '\n';
+					else {	for (auto& rm : chop_mi)
+						    log << "  " << rm.first->readable_name() << ": "
+							<< format_clinched_mi(fstr, rm.second,rm.first->mileage) << "\n";
+						log << '\n';
+					     }
 				}
 			}
 			sprintf(fstr, " connected routes traveled: %i of %i (%.1f%%), clinched: %i of %i (%.1f%%).",

--- a/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
@@ -4,18 +4,14 @@
 #include "../threads/threads.h"
 #include <fstream>
 
-void allbyregionactiveonly(std::mutex* mtx)
-{	double total_mi;
-	char fstr[112];
+void allbyregionactiveonly(std::mutex* mtx, double total_mi)
+{	char fstr[112];
 	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactiveonly.csv");
 	allfile << "Traveler,Total";
 	std::list<Region*> regions;
-	total_mi = 0;
 	for (Region* r : Region::allregions)
 	  if (r->active_only_mileage)
-	  {	regions.push_back(r);
-		total_mi += r->active_only_mileage;
-	  }
+	    regions.push_back(r);
 	regions.sort(sort_regions_by_code);
 	for (Region *region : regions)
 		allfile << ',' << region->code;

--- a/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
@@ -4,18 +4,14 @@
 #include "../threads/threads.h"
 #include <fstream>
 
-void allbyregionactivepreview(std::mutex* mtx)
-{	double total_mi;
-	char fstr[112];
+void allbyregionactivepreview(std::mutex* mtx, double total_mi)
+{	char fstr[112];
 	std::ofstream allfile(Args::csvstatfilepath + "/allbyregionactivepreview.csv");
 	allfile << "Traveler,Total";
 	std::list<Region*> regions;
-	total_mi = 0;
 	for (Region* r : Region::allregions)
 	  if (r->active_preview_mileage)
-	  {	regions.push_back(r);
-		total_mi += r->active_preview_mileage;
-	  }
+	    regions.push_back(r);
 	regions.sort(sort_regions_by_code);
 	for (Region *region : regions)
 		allfile << ',' << region->code;

--- a/siteupdate/cplusplus/functions/format_clinched_mi.cpp
+++ b/siteupdate/cplusplus/functions/format_clinched_mi.cpp
@@ -1,14 +1,11 @@
 #include "format_clinched_mi.h"
+#include <cstdio>
 
-std::string format_clinched_mi(double clinched, double total)
+char* format_clinched_mi(char* str, double clinched, double total)
 {	/* return a nicely-formatted string for a given number of miles
 	clinched and total miles, including percentage */
-	char str[37];
-	std::string percentage = "-.--%";
 	if (total)
-	{	sprintf(str, "(%0.2f%%)", 100*clinched/total);
-		percentage = str;
-	}
-	sprintf(str, "%0.2f of %0.2f mi ", clinched, total);
-	return str + percentage;
+		sprintf(str, "%0.2f of %0.2f mi (%0.2f%%)", clinched, total, 100*clinched/total);
+	else	sprintf(str, "%0.2f of %0.2f mi -.--%%", clinched, total);
+	return str;
 }

--- a/siteupdate/cplusplus/functions/format_clinched_mi.h
+++ b/siteupdate/cplusplus/functions/format_clinched_mi.h
@@ -1,2 +1,1 @@
-#include <string>
-std::string format_clinched_mi(double, double);
+char* format_clinched_mi(char*, double, double);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -41,8 +41,8 @@ This module defines classes to represent the contents of a
 #include <thread>
 #include "threads/threads.h"
 #endif
-void allbyregionactiveonly(std::mutex*);
-void allbyregionactivepreview(std::mutex*);
+void allbyregionactiveonly(std::mutex*, double);
+void allbyregionactivepreview(std::mutex*, double);
 using namespace std;
 
 int main(int argc, char *argv[])
@@ -579,22 +579,22 @@ int main(int argc, char *argv[])
 	{   case 1:
       #endif
 		cout << et.et() << "Writing allbyregionactiveonly.csv." << endl;
-		allbyregionactiveonly(0);
+		allbyregionactiveonly(0, active_only_miles);
 		cout << et.et() << "Writing allbyregionactivepreview.csv." << endl;
-		allbyregionactivepreview(0);
+		allbyregionactivepreview(0, active_preview_miles);
 		cout << et.et() << "Writing per-system stats csv files." << endl;
 		for (HighwaySystem* h : HighwaySystem::syslist) h->stats_csv();
       #ifdef threading_enabled
 		break;
 	   case 2:
-		thr[0] = thread(allbyregionactiveonly, &list_mtx);
-		thr[1] = thread(allbyregionactivepreview, &list_mtx);
+		thr[0] = thread(allbyregionactiveonly,    &list_mtx, active_only_miles);
+		thr[1] = thread(allbyregionactivepreview, &list_mtx, active_preview_miles);
 		thr[0].join();
 		thr[1].join();
 		break;
 	   default:
-		thr[0] = thread(allbyregionactiveonly, (std::mutex*)0);
-		thr[1] = thread(allbyregionactivepreview, (std::mutex*)0);
+		thr[0] = thread(allbyregionactiveonly,    nullptr, active_only_miles);
+		thr[1] = thread(allbyregionactivepreview, nullptr, active_preview_miles);
 		thr[2] = thread(StatsCsvThread, 2, &list_mtx);
 		thr[0].join();
 		thr[1].join();

--- a/siteupdate/cplusplus/threads/ReadListThread.cpp
+++ b/siteupdate/cplusplus/threads/ReadListThread.cpp
@@ -12,7 +12,6 @@ void ReadListThread(unsigned int id, std::mutex* tl_mtx, ErrorList* el)
 		//printf("ReadListThread %02i (*it)++\n", id); fflush(stdout);
 		std::cout << tl << ' ' << std::flush;
 		tl_mtx->unlock();
-		std::string** update;
 		TravelerList *t = new TravelerList(tl, el);
 				  // deleted on termination of program
 		TravelerList::mtx.lock();

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1307,6 +1307,9 @@ class HighwaySystem:
     a designation within the same system crosses region boundaries,
     a connected route defines the entirety of the route.
     """
+    num_active = 0
+    num_preview = 0
+
     def __init__(self,systemname,country,fullname,color,tier,level,el,
                  path="../../../HighwayData/hwy_data/_systems"):
         self.route_list = []
@@ -2812,6 +2815,10 @@ else:
         # verify Level
         if fields[5] != "active" and fields[5] != "preview" and fields[5] != "devel":
             el.add_error("Unrecognized level in " + args.systemsfile + " line: " + line)
+        elif fields[5] == "preview":
+            HighwaySystem.num_preview += 1
+        elif fields[5] == "active":
+            HighwaySystem.num_active += 1
 
         print(fields[0] + ".",end="",flush=True)
         hs = HighwaySystem(fields[0], fields[1], fields[2],
@@ -3540,18 +3547,10 @@ for t in traveler_lists:
     t.active_systems_clinched = 0
     t.preview_systems_traveled = 0
     t.preview_systems_clinched = 0
-    active_systems = 0
-    preview_systems = 0
 
-    # present stats by system here, also generate entries for
-    # DB table clinchedSystemMileageByRegion as we compute and
-    # have the data handy
+    # stats by system
     for h in highway_systems:
         if h.active_or_preview():
-            if h.active():
-                active_systems += 1
-            else:
-                preview_systems += 1
             t_system_overall = 0.0
             if h.systemname in t.system_region_mileages:
                 t_system_overall = math.fsum(t.system_region_mileages[h.systemname].values())
@@ -3620,16 +3619,16 @@ for t in traveler_lists:
 
 
     # grand summary, active only
-    t.log_entries.append("\nTraveled " + str(t.active_systems_traveled) + " of " + str(active_systems) +
-                         " ({0:.1f}%)".format(100*t.active_systems_traveled/active_systems) +
-                         ", Clinched " + str(t.active_systems_clinched) + " of " + str(active_systems) +
-                         " ({0:.1f}%)".format(100*t.active_systems_clinched/active_systems) +
+    t.log_entries.append("\nTraveled " + str(t.active_systems_traveled) + " of " + str(HighwaySystem.num_active) +
+                         " ({0:.1f}%)".format(100*t.active_systems_traveled/HighwaySystem.num_active) +
+                         ", Clinched " + str(t.active_systems_clinched) + " of " + str(HighwaySystem.num_active) +
+                         " ({0:.1f}%)".format(100*t.active_systems_clinched/HighwaySystem.num_active) +
                          " active systems")
     # grand summary, active+preview
-    t.log_entries.append("Traveled " + str(t.preview_systems_traveled) + " of " + str(preview_systems) +
-                         " ({0:.1f}%)".format(100*t.preview_systems_traveled/preview_systems) +
-                         ", Clinched " + str(t.preview_systems_clinched) + " of " + str(preview_systems) +
-                         " ({0:.1f}%)".format(100*t.preview_systems_clinched/preview_systems) +
+    t.log_entries.append("Traveled " + str(t.preview_systems_traveled) + " of " + str(HighwaySystem.num_preview) +
+                         " ({0:.1f}%)".format(100*t.preview_systems_traveled/HighwaySystem.num_preview) +
+                         ", Clinched " + str(t.preview_systems_clinched) + " of " + str(HighwaySystem.num_preview) +
+                         " ({0:.1f}%)".format(100*t.preview_systems_clinched/HighwaySystem.num_preview) +
                          " preview systems")
     # updated routes, sorted by date
     t.log_entries.append("\nMost recent updates for listed routes:")

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3668,7 +3668,7 @@ for t in traveler_lists:
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_only_mileage_by_region.values())))
+allfile.write('TOTAL,{0:.2f}'.format(active_only_miles))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_only_mileage_by_region[region]))
 allfile.write('\n')
@@ -3689,7 +3689,7 @@ for t in traveler_lists:
         else:
             allfile.write(',0')
     allfile.write('\n')
-allfile.write('TOTAL,{0:.2f}'.format(math.fsum(active_preview_mileage_by_region.values())))
+allfile.write('TOTAL,{0:.2f}'.format(active_preview_miles))
 for region in regions:
     allfile.write(',{0:.2f}'.format(active_preview_mileage_by_region[region]))
 allfile.write('\n')


### PR DESCRIPTION
This is a do-over of #524.

Closes https://github.com/yakra/DataProcessing/issues/220.
Closes https://github.com/TravelMapping/DataProcessing/issues/523.
Closes https://github.com/TravelMapping/DataProcessing/issues/522.

---

**C++ Region management** is on the backburner.
There are a couple different paths forward here, and I'm not 100% sold on either. Kicking that can down the road.

---

### User log speedup
Small improvement on Linux; big one for FreeBSD.
For just FreeBSD, the chart below includes an intermediate step:
the initial conversion of `std::string to_write` to `std::vector<std::pair<Route*, double>> chop_mi`
(not included for Linux, as the lines are already so close together it'd just add clutter).
After that, the next step was to have `format_clinched_mi` format & return a `char*`. Same idea as what #515 did with `clinchedby_code` in traveled graphs.
![User526-18](https://user-images.githubusercontent.com/13720877/165643936-b3864515-3d0b-4893-9d4e-7b09db8cd170.png)
[Alternate version](https://user-images.githubusercontent.com/13720877/165646041-ab69964b-91fb-4382-a1b9-0c9aa07014c6.png) with 2x the vertical scale, to compare against [this one](https://user-images.githubusercontent.com/13720877/163829580-9c9b2d2c-0299-45a2-a023-d4093a3c67bf.gif) from #520. And before that, there was #513.

**Future?**
There may be more improvements to be had by playing around with the `std::unordered_map`s or converting to `std::map`s.
Sometimes small changes make big results (see #517). But OTOH, we could be approaching the point of diminishing returns.
Call me cautiously optimistic.