### PR TITLE
nmpbyregion 2.0

### DIFF
--- a/nmpfilter/.gitignore
+++ b/nmpfilter/.gitignore
@@ -1,0 +1,1 @@
+nmpbyregion

--- a/nmpfilter/README.md
+++ b/nmpfilter/README.md
@@ -22,6 +22,10 @@ The output directory should be empty before running *nmpbycountry*. Files for co
 **Purpose:**<br>
 Splits *tm-master.nmp* into smaller .nmp files filtered by region.
 
+**Compiling:**<br>
+C++11 support is required.<br>
+With GCC, I use the commandline `g++ nmpbyregion.cpp -std=c++11 -o nmpbyregion`
+
 **Usage:**<br>
 `nmpbyregion HwyDataDir MasterNMP OutputDir`, where
 * `HwyDataDir` is the path of the *hwy_data* directory in the HighwayData repository, or equivalent

--- a/nmpfilter/nmpbyregion.cpp
+++ b/nmpfilter/nmpbyregion.cpp
@@ -1,93 +1,94 @@
-// Travel Mapping Project, Eric Bryant, 2018
-#include <ctime>
-#include <dirent.h>
+// Travel Mapping Project, Eric Bryant, 2018-2022
+#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <string>
+#include <list>
+#include <map>
 #include <vector>
 using namespace std;
 
-bool LwrCaseValid(string &RgStr)
-// Check whether a string is a valid region; convert to lower case
-{	if (RgStr == ".")		return 0;
-	if (RgStr == "..")		return 0;
-	if (RgStr == "_systems")	return 0;
-	if (RgStr == "_boundaries")	return 0;
-	for (unsigned int i = 0; i < RgStr.size(); i++)
-	  if (RgStr[i] >= 'A' && RgStr[i] <= 'Z')
-	    RgStr[i] += 32;
-	return 1;
-}
+struct Region
+{	vector<string> lines;
+	unsigned int unmarked;
+	unsigned int fps;
 
-void GetRegions(char *HwyDataDir, vector<string> &RgList)
-// Get a list of regions by scanning subdirectories of HwyData/
-{	DIR *dir;
-	dirent *ent;
-	if ((dir = opendir (HwyDataDir)) != NULL)
-	{	while ((ent = readdir (dir)) != NULL)
-		{	string RgStr = ent->d_name;
-			if (LwrCaseValid(RgStr)) RgList.push_back(RgStr);
-		}
-		closedir(dir);
+	static unsigned int master_unmarked;
+	static unsigned int master_fps;
+
+	Region(): unmarked(0), fps(0) {}
+
+	bool operator != (const Region& other)
+	{	return this != &other;
 	}
-	else cout << "Error opening directory " << HwyDataDir << ". (Not found?)\n";
-}
 
-string GetRootRg(string RgStr)
-// Remove dashes from region codes, to match region strings as found in Roots
-{	for (int dash = RgStr.find('-'); dash > 0; dash = RgStr.find('-'))
-		RgStr.erase(dash, 1);
-	return RgStr;
-}
-
-void filter(vector<string> &RgList, char *MasterNMP, char *OutputDir)
-// Write .nmp files for each region
-{	for (unsigned int i = 0; i < RgList.size(); i++)
-	{	ifstream master(MasterNMP);
-		if (!master)
-		{	std::cout << MasterNMP << " not found\n";
-			return;
-		}
-		string pt1, pt2;
-		string outfile = OutputDir+RgList[i]+".nmp";
-		ofstream nmp(outfile.data());
-		while (getline(master, pt1) && getline(master, pt2))
-		{	string RootRg = GetRootRg(RgList[i]);
-			if (pt1.substr(0, pt1.find('.')) == RootRg || pt2.substr(0, pt2.find('.')) == RootRg)
-			nmp << pt1 << '\n' << pt2 << '\n';
-		}
+	void add_info(string& w1, string& w2, bool count_master)
+	{	lines.push_back(w1);
+		lines.push_back(w2);
+		if (strcmp(w1.data()+w1.size()-2, "FP") && strcmp(w1.data()+w1.size()-4, "FPLI"))
+		     {	unmarked++;
+			if (count_master) master_unmarked++;
+		     }
+		else {	fps++;
+			if (count_master) master_fps++;
+		     }
 	}
+};
+unsigned int Region::master_unmarked = 0;
+unsigned int Region::master_fps = 0;
+
+bool descending_by_unmarked_count(pair<const string,Region>* a, pair<const string,Region>* b)
+{	return a->second.unmarked > b->second.unmarked;
 }
 
 int main(int argc, char *argv[])
-{	if (argc != 4)
-	{	cout << "usage: nmpbyregion HwyDataDir MasterNMP OutputDir\n";
+{	if (argc != 3)
+	{	cout << "usage: nmpbyregion MasterNMP OutputDir\n";
 		return 0;
 	}
 
-	// Record execution start time
-	time_t StartTime = time(0);
-	char* LocalTime = ctime(&StartTime);
+	ifstream master(argv[1]);
+	if (!master)
+	{	std::cout << argv[1] << " not found\n";
+		return 1;
+	}
 
-	// Attempt to find most recent commit info
-	string MasterInfo;
-	string MasterPath = argv[1];
-	if (MasterPath.back() != '/') MasterPath += '/';
-	MasterPath += "../.git/refs/heads/master";
-	ifstream MasterFile(MasterPath.data());
-	if (MasterFile)
-		MasterFile >> MasterInfo;
-	else	MasterInfo = "unknown.";
+	// read tm-master.nmp and populate region data
+	map<string, Region> region_map;
+	string w1, w2;
+	while (getline(master, w1) && getline(master, w2))
+	{	Region& r1 = region_map[w1.substr(0, w1.find('.'))];
+		Region& r2 = region_map[w2.substr(0, w2.find('.'))];
+		r1.add_info(w1, w2, 1);
+		if (r1 != r2) r2.add_info(w1, w2, 0);
+	}
 
-	// nmpbyregion.log
-	string LogPath = argv[3];
-	LogPath += "nmpbyregion.log";
-	ofstream LogFile(LogPath.data());
-	LogFile << "nmpbyregion executed " << LocalTime;
-	LogFile << "Most recent commit is " << MasterInfo << '\n';
+	// sort regions by number of unmarked NMP pairs
+	list<pair<const string,Region>*> region_list;
+	for (auto& r : region_map) region_list.push_back(&r);
+	region_list.sort(descending_by_unmarked_count);
 
-	// The actual filtering
-	vector<string> RgList;
-	GetRegions(argv[1], RgList);
-	filter(RgList, argv[2], argv[3]);
+	// index.html table header & tm-master entry
+	ofstream html(string(argv[2])+"/index.html");
+	html << "<h1>NMP by Region</h1>\n";
+	html << "<table border=1 cellpadding=2 cellspacing=0>";
+	html << "<tr><td><b>file</b></td><td><b>unmarked pairs</b></td><td><b>pairs marked FP</b></td><td><b>total NMP pairs</b></td><td><b>links</b></td></tr>\n";
+	html << "<tr><td>tm-master.nmp</td><td>"
+	     << Region::master_unmarked << "</td><td>"
+	     << Region::master_fps << "</td><td>"
+	     << Region::master_unmarked + Region::master_fps << "</td><td>"
+	     << "<a href='../tm-master.nmp'>file</a> "
+	     << "<a href='https://courses.teresco.org/metal/hdx?load=tm-master.nmp'>HDX</a></td></tr>\n";
+
+	// write .nmp files & table entries
+	for (auto& r : region_list)
+	{	ofstream nmp(argv[2]+('/'+r->first)+".nmp");
+		for (string& line : r->second.lines) nmp << line << '\n';
+		html << "<tr><td>" << r->first << ".nmp</td>";
+		html << "<td>" << r->second.unmarked << "</td>";
+		html << "<td>" << r->second.fps << "</td>";
+		html << "<td>" << r->second.fps + r->second.unmarked << "</td><td>";
+		html << "<a href='" << r->first << ".nmp'>file</a> ";
+		html << "<a href='https://courses.teresco.org/metal/hdx?load=" << r->first << ".nmp'>HDX</a></td></tr>\n";
+	}
+	html << "</table>";
 }

--- a/siteupdate/cplusplus/localupdate.sh
+++ b/siteupdate/cplusplus/localupdate.sh
@@ -68,7 +68,7 @@ echo DataProcessing '@' `git show -s | head -n 1 | cut -f2 -d' '` | tee -a $date
 
 echo "$0: creating listupdates.txt"
 cd $tmbase/UserData/list_files
-for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done > $execdir/listupdates.txt
+for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done | tee $execdir/listupdates.txt
 cd -
 
 echo "$0: launching siteupdateST"
@@ -80,18 +80,7 @@ rm $execdir/listupdates.txt
 
 if [ -x ../../nmpfilter/nmpbyregion ]; then
     echo "$0: running nmpbyregion"
-    ../../nmpfilter/nmpbyregion $tmbase/HighwayData/hwy_data  $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
-    echo "$0: creating zip archive of all nmp files created by nmpbyregion"
-    cd $datestr/$logdir/nmpbyregion
-    zip -q nmpbyregion.zip *.nmp
-    echo "<h1>NMP by Region</h1>" > index.html
-    echo "<ul>" >> index.html
-    echo "<li>tm-master.nmp <a href='https://travelmapping.net/logs/tm-master.nmp'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=tm-master.nmp'>HDX</a></li>" >> index.html
-    for file in *.nmp; do
-	echo "<li>${file} <a href='https://travelmapping.net/logs/nmpbyregion/${file}'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=${file}'>HDX</a></li>" >> index.html
-    done
-    echo "</ul>" >> index.html
-    cd -
+    ../../nmpfilter/nmpbyregion $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
 else
     echo "$0: SKIPPING nmpbyregion (../../nmpfilter/nmpbyregion not executable)"
 fi

--- a/siteupdate/cplusplus/localupdate_centos.sh
+++ b/siteupdate/cplusplus/localupdate_centos.sh
@@ -68,7 +68,7 @@ echo DataProcessing '@' `git show -s | head -n 1 | cut -f2 -d' '` | tee -a $date
 
 echo "$0: creating listupdates.txt"
 cd $tmbase/UserData/list_files
-for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done > $execdir/listupdates.txt
+for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done | tee $execdir/listupdates.txt
 cd -
 
 echo "$0: launching siteupdate"
@@ -80,18 +80,7 @@ rm $execdir/listupdates.txt
 
 if [ -x ../../nmpfilter/nmpbyregion ]; then
     echo "$0: running nmpbyregion"
-    ../../nmpfilter/nmpbyregion $tmbase/HighwayData/hwy_data  $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
-    echo "$0: creating zip archive of all nmp files created by nmpbyregion"
-    cd $datestr/$logdir/nmpbyregion
-    zip -q nmpbyregion.zip *.nmp
-    echo "<h1>NMP by Region</h1>" > index.html
-    echo "<ul>" >> index.html
-    echo "<li>tm-master.nmp <a href='https://travelmapping.net/logs/tm-master.nmp'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=tm-master.nmp'>HDX</a></li>" >> index.html
-    for file in *.nmp; do
-	echo "<li>${file} <a href='https://travelmapping.net/logs/nmpbyregion/${file}'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=${file}'>HDX</a></li>" >> index.html
-    done
-    echo "</ul>" >> index.html
-    cd -
+    ../../nmpfilter/nmpbyregion $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
 else
     echo "$0: SKIPPING nmpbyregion (../../nmpfilter/nmpbyregion not executable)"
 fi

--- a/siteupdate/python-teresco/localupdate.sh
+++ b/siteupdate/python-teresco/localupdate.sh
@@ -68,7 +68,7 @@ echo DataProcessing '@' `git show -s | head -n 1 | cut -f2 -d' '` | tee -a $date
 
 echo "$0: creating listupdates.txt"
 cd $tmbase/UserData/list_files
-for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done > $execdir/listupdates.txt
+for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done | tee $execdir/listupdates.txt
 cd -
 
 echo "$0: launching siteupdate.py"
@@ -80,18 +80,7 @@ rm $execdir/listupdates.txt
 
 if [ -x ../../nmpfilter/nmpbyregion ]; then
     echo "$0: running nmpbyregion"
-    ../../nmpfilter/nmpbyregion $tmbase/HighwayData/hwy_data  $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
-    echo "$0: creating zip archive of all nmp files created by nmpbyregion"
-    cd $datestr/$logdir/nmpbyregion
-    zip -q nmpbyregion.zip *.nmp
-    echo "<h1>NMP by Region</h1>" > index.html
-    echo "<ul>" >> index.html
-    echo "<li>tm-master.nmp <a href='https://travelmapping.net/logs/tm-master.nmp'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=tm-master.nmp'>HDX</a></li>" >> index.html
-    for file in *.nmp; do
-	echo "<li>${file} <a href='https://travelmapping.net/logs/nmpbyregion/${file}'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=${file}'>HDX</a></li>" >> index.html
-    done
-    echo "</ul>" >> index.html
-    cd -
+    ../../nmpfilter/nmpbyregion $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
 else
     echo "$0: SKIPPING nmpbyregion (../../nmpfilter/nmpbyregion not executable)"
 fi

--- a/siteupdate/python-teresco/localupdate_centos.sh
+++ b/siteupdate/python-teresco/localupdate_centos.sh
@@ -68,7 +68,7 @@ echo DataProcessing '@' `git show -s | head -n 1 | cut -f2 -d' '` | tee -a $date
 
 echo "$0: creating listupdates.txt"
 cd $tmbase/UserData/list_files
-for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done > $execdir/listupdates.txt
+for u in *; do echo $u `git log -n 1 --pretty=%ci $u`; done | tee $execdir/listupdates.txt
 cd -
 
 echo "$0: launching siteupdate.py"
@@ -80,18 +80,7 @@ rm $execdir/listupdates.txt
 
 if [ -x ../../nmpfilter/nmpbyregion ]; then
     echo "$0: running nmpbyregion"
-    ../../nmpfilter/nmpbyregion $tmbase/HighwayData/hwy_data  $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
-    echo "$0: creating zip archive of all nmp files created by nmpbyregion"
-    cd $datestr/$logdir/nmpbyregion
-    zip -q nmpbyregion.zip *.nmp
-    echo "<h1>NMP by Region</h1>" > index.html
-    echo "<ul>" >> index.html
-    echo "<li>tm-master.nmp <a href='https://travelmapping.net/logs/tm-master.nmp'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=tm-master.nmp'>HDX</a></li>" >> index.html
-    for file in *.nmp; do
-	echo "<li>${file} <a href='https://travelmapping.net/logs/nmpbyregion/${file}'>file</a> <a href='https://courses.teresco.org/metal/hdx?load=${file}'>HDX</a></li>" >> index.html
-    done
-    echo "</ul>" >> index.html
-    cd -
+    ../../nmpfilter/nmpbyregion $datestr/$logdir/tm-master.nmp $datestr/$logdir/nmpbyregion/
 else
     echo "$0: SKIPPING nmpbyregion (../../nmpfilter/nmpbyregion not executable)"
 fi


### PR DESCRIPTION
closes #533

I decided to order the entries by descending number of unmarked entries, as it was simplest to code.

There are no longer any hyphens in filenames -- `nmpbyregion` only uses info from tm-master.nmp itself now, so we only have lower-case regions with no hyphens, as used in .wpt file roots, available.
The old way of searching `hwy_data/` for region codes & converting them was bloaty overkill that contributed to all the 0-byte files. I figure converting `deurp` to `DEU-RP` etc. is more trouble than it's worth.