### PR TITLE
convert to double before calling ceil

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -28,7 +28,7 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 
 	// allocate vertices, and a bit field to track their inclusion in subgraphs
 	vertices.resize(hi_priority_points.size()+lo_priority_points.size());
-	vbytes = double(ceil(vertices.size())/8);
+	vbytes = ceil(double(vertices.size())/8);
 	vbits = new unsigned char[vbytes*Args::numthreads];
 		// deleted by HighwayGraph::clear
 	for (size_t i = 0; i < vbytes*Args::numthreads; ++i) vbits[i] = 0;


### PR DESCRIPTION
I love it when I randomly find a bug just by looking at my code, rather then by observing a symptom and having to track it down.

1 byte per thread less than necessary was allocated for `HighwayGraph::vbits`.
I've somehow never observed problems, but this fixes:
* Collisions where the highest vertices in thread `n` & the lowest vertices in thread `n+1` map to the same bits. If both threads access these bytes at the same time, we have problems.
* Reading/writing past the end of the array. In theory, the fewer threads there were, the more likely the highest numbered thread was to access the highest vertices & cause this problem, with 100% likelihood @ 1 thread, although valgrind doesn't report an error.