### PR TITLE
insert into graphs immediately upon creation

### DIFF
--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -498,6 +498,19 @@ void sqlfile2(ElapsedTime *et, std::list<std::array<std::string,3>> *graph_types
 			<< "format VARCHAR(" << DBFieldLength::graphFormat
 			<< "), category VARCHAR(" << DBFieldLength::graphCategory
 			<< "), FOREIGN KEY (category) REFERENCES graphTypes(category));\n";
+		if (GraphListEntry::entries.size())
+		{	sqlfile << "INSERT INTO graphs VALUES\n";
+			for (size_t g = 0; g < GraphListEntry::entries.size(); g++)
+			{	if (g) sqlfile << ',';
+				#define G GraphListEntry::entries[g]
+				sqlfile << "('"  << G.filename() << "','" << double_quotes(G.descr)
+					<< "','" << G.vertices   << "','" << G.edges
+					<< "','" << G.travelers  << "','" << G.format()
+					<< "','" << G.category() << "')\n";
+				#undef G
+			}
+			sqlfile << ";\n";
+		}
 		sqlfile << "CREATE TABLE graphArchiveSets (setName VARCHAR("
 			<< DBFieldLength::setName << "), descr VARCHAR("
 			<< DBFieldLength::graphDescr
@@ -519,19 +532,6 @@ void sqlfile2(ElapsedTime *et, std::list<std::array<std::string,3>> *graph_types
 			<< "), setName VARCHAR("
 			<< DBFieldLength::setName
 			<< "), maxDegree INTEGER, avgDegree FLOAT, aspectRatio FLOAT, components INTEGER, FOREIGN KEY (category) REFERENCES graphTypes(category), FOREIGN KEY (setName) REFERENCES graphArchiveSets(setName));\n";
-		if (GraphListEntry::entries.size())
-		{	sqlfile << "INSERT INTO graphs VALUES\n";
-			for (size_t g = 0; g < GraphListEntry::entries.size(); g++)
-			{	if (g) sqlfile << ',';
-				#define G GraphListEntry::entries[g]
-				sqlfile << "('"  << G.filename() << "','" << double_quotes(G.descr)
-					<< "','" << G.vertices   << "','" << G.edges
-					<< "','" << G.travelers  << "','" << G.format()
-					<< "','" << G.category() << "')\n";
-				#undef G
-			}
-			sqlfile << ";\n";
-		}
 	}
 
 	sqlfile.close();

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -4759,6 +4759,15 @@ else:
                   '), vertices INTEGER, edges INTEGER, travelers INTEGER, format VARCHAR(' + str(DBFieldLength.graphFormat) +
                   '), category VARCHAR(' + str(DBFieldLength.graphCategory) +
                   '), FOREIGN KEY (category) REFERENCES graphTypes(category));\n')
+        if len(graph_list) > 0:
+            sqlfile.write('INSERT INTO graphs VALUES\n')
+            first = True
+            for g in graph_list:
+                if not first:
+                    sqlfile.write(',')
+                first = False
+                sqlfile.write("('" + g.filename + "','" + g.descr.replace("'","''") + "','" + str(g.vertices) + "','" + str(g.edges) + "','" + str(g.travelers) + "','" + g.format + "','" + g.category + "')\n")
+            sqlfile.write(";\n")
         sqlfile.write('CREATE TABLE graphArchiveSets (setName VARCHAR(' +
                       str(DBFieldLength.setName) + '), descr VARCHAR(' +
                       str(DBFieldLength.graphDescr) +
@@ -4778,15 +4787,6 @@ else:
                       str(DBFieldLength.graphCategory) +
                       '), setName VARCHAR(' + str(DBFieldLength.setName) +
                       '), maxDegree INTEGER, avgDegree FLOAT, aspectRatio FLOAT, components INTEGER, FOREIGN KEY (category) REFERENCES graphTypes(category), FOREIGN KEY (setName) REFERENCES graphArchiveSets(setName));\n')
-        if len(graph_list) > 0:
-            sqlfile.write('INSERT INTO graphs VALUES\n')
-            first = True
-            for g in graph_list:
-                if not first:
-                    sqlfile.write(',')
-                first = False
-                sqlfile.write("('" + g.filename + "','" + g.descr.replace("'","''") + "','" + str(g.vertices) + "','" + str(g.edges) + "','" + str(g.travelers) + "','" + g.format + "','" + g.category + "')\n")
-            sqlfile.write(";\n")
 
     sqlfile.close()
 


### PR DESCRIPTION
https://github.com/TravelMapping/DataProcessing/commit/2c541b1bdf30316dae13fc8a50c8e8a6ff95a613#commitcomment-94744964
> 2. `compare_sql` still does its job, but due to the way the tables are set up misreports the number of lines in a few tables. This is because it expects a table's insertions to be made immediately after it's created. Instead, the `INSERT INTO graphs VALUES` lines appear after `graphArchiveSets` and `graphArchives` are created. Thus `graphs` is incorrectly reported as 1 line, and `graphArchives` is incorrectly reported as 1284 lines, the number of lines in `graphs`.

> 4. I would however like to move the new `graphs` insertions back to immediately follow table creation to get `compare_sql` to report the number of lines correctly, in both C++ & Python. Any objections?