### PR TITLE
minor userlog tweaks

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -171,7 +171,7 @@ void HighwaySystem::stats_csv()
 	{	// only include entries for travelers who have any mileage in system
 		auto it = t->system_region_mileages.find(this);
 		if (it != t->system_region_mileages.end())
-		{	sprintf(fstr, ",%.2f", t->system_region_miles(this));
+		{	sprintf(fstr, ",%.2f", t->system_miles(this));
 			sysfile << t->traveler_name << fstr;
 			for (Region *region : regions)
 			  try {	sprintf(fstr, ",%.2f", it->second.at(region));

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -157,7 +157,7 @@ double TravelerList::active_preview_miles()
 }
 
 /* Return mileage across all regions for a specified system */
-double TravelerList::system_region_miles(HighwaySystem *h)
+double TravelerList::system_miles(HighwaySystem *h)
 {	double mi = 0;
 	for (std::pair<Region* const, double>& rm : system_region_mileages.at(h)) mi += rm.second;
 	return mi;

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -56,7 +56,7 @@ class TravelerList
 	TravelerList(std::string, ErrorList*);
 	double active_only_miles();
 	double active_preview_miles();
-	double system_region_miles(HighwaySystem *);
+	double system_miles(HighwaySystem *);
 	void userlog(const double, const double);
 };
 

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -32,11 +32,9 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 	// stats by system
 	for (HighwaySystem *h : HighwaySystem::syslist)
 	  if (h->active_or_preview())
-	  {	double t_system_overall = 0;
-		if (system_region_mileages.count(h))
-			t_system_overall = system_region_miles(h);
-		if (t_system_overall)
-		{	if (h->active())
+	  {	if (system_region_mileages.count(h))
+		{	double t_system_overall = system_miles(h);
+			if (h->active())
 				active_systems_traveled++;
 			else	preview_systems_traveled++;
 			if (float(t_system_overall) == float(h->total_mileage()))
@@ -118,8 +116,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 
 	// updated routes, sorted by date
 	log << "\nMost recent updates for listed routes:\n";
-	std::list<Route*> route_list;
-	for (Route* r : updated_routes) if (r->last_update) route_list.push_back(r);
+	std::list<Route*> route_list(updated_routes.begin(), updated_routes.end());
 	updated_routes.clear();
 	route_list.sort(sort_route_updates_oldest);
 	for (Route* r : route_list)

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -3538,10 +3538,8 @@ for t in traveler_lists:
     # stats by system
     for h in highway_systems:
         if h.active_or_preview():
-            t_system_overall = 0.0
             if h.systemname in t.system_region_mileages:
                 t_system_overall = math.fsum(t.system_region_mileages[h.systemname].values())
-            if t_system_overall > 0.0:
                 if h.active():
                     t.active_systems_traveled += 1
                 else:
@@ -3619,15 +3617,10 @@ for t in traveler_lists:
                          " preview systems")
     # updated routes, sorted by date
     t.log_entries.append("\nMost recent updates for listed routes:")
-    route_list = []
-    for r in t.updated_routes:
-        if r.last_update:
-            route_list.append(r)
-    del t.updated_routes
-    route_list.sort(key=lambda r: r.last_update[0]+r.last_update[3])
-    for r in route_list:
+    for r in sorted(t.updated_routes, key=lambda r: r.last_update[0]+r.last_update[3]):
         t.log_entries.append(r.last_update[0] + " | " + r.last_update[1] + " | " + \
                              r.last_update[2] + " | " + r.last_update[3] + " | " + r.last_update[4])
+    del t.updated_routes
 
 print("!", flush=True)
 


### PR DESCRIPTION
* **`system_region_miles` -> `system_miles`**
  This function was created in the early "translate from Python" days (in place of a math.fsum) and hastily named without a clear understanding of what it was doing. There's nothing *regional* about it; it's the total across *all* regions. The new name is a more accurate description.
* **Remove extraneous conditional at beginning of stats by system**
  If the system is in `system_region_mileages`, it's a virtual guarantee mileage is >0.
  To have zero mileage, we'd have to have a zero-length segment, via a BAD_ANGLE error (which we've not seen in a long time, and those are a `Datacheck::always_error` & should in theory be fixed quickly), *and* a user would have to mark only zero-length segment(s) -- using consecutive same-coords points -- in their .list file. In the unlikely event this does happen, the worst that happens is some extraneous info (a load of 0s) in that user's .log file.
* **Remove extraneous condition from updated routes list population.**
  We know `r->last_update` is true; this was a condition of items' original insertion.
  * While at it, I made the Python version more Pythonic.
  * In C++, the new list is populated during construction.

---

In other news, I've been trying out various tweaks to increase [userlog efficiency](https://forum.travelmapping.net/index.php?topic=5349.msg30150#msg30150) and hopefully help out its poor scaling under FreeBSD. Individually, each one fails to pan out except for maybe producing the tiniest little differences on BiggaTomato. Maybe if I:
* throw [everything I can think of](https://github.com/yakra/DataProcessing/issues/234) together at once, or
* find the machine with the right combo of most cores & least cache _(lab1, lab5, BiggaTomato?)_ and cripple it with a single channel of the slowest RAM I can find,

... I might see some results?