### PR TITLE
pointsinuse fixes

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -192,3 +192,23 @@ void HighwaySystem::stats_csv()
 	sysfile << '\n';
 	sysfile.close();
 }
+
+void HighwaySystem::mark_route_in_use(std::string& lookup)
+{	uarn_mtx.lock();
+	unusedaltroutenames.erase(lookup);
+	uarn_mtx.unlock();
+	lniu_mtx.lock();
+	listnamesinuse.insert(std::move(lookup));
+	lniu_mtx.unlock();
+}
+
+void HighwaySystem::mark_routes_in_use(std::string& lookup1, std::string& lookup2)
+{	uarn_mtx.lock();
+	unusedaltroutenames.erase(lookup1);
+	unusedaltroutenames.erase(lookup2);
+	uarn_mtx.unlock();
+	lniu_mtx.lock();
+	listnamesinuse.insert(std::move(lookup1));
+	listnamesinuse.insert(std::move(lookup2));
+	lniu_mtx.unlock();
+}

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -60,4 +60,6 @@ class HighwaySystem
 	void route_integrity(ErrorList& el);
 	void add_vertex(HGVertex*);
 	void stats_csv();
+	void mark_route_in_use(std::string&);
+	void mark_routes_in_use(std::string&, std::string&);
 };

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -265,6 +265,26 @@ void Route::con_mismatch()
 			       (con_route->banner.size() ? con_route->banner : "(blank)"));
 }
 
+void Route::mark_label_in_use(char* label)
+{	ual_mtx.lock();
+	unused_alt_labels.erase(label);
+	ual_mtx.unlock();
+	liu_mtx.lock();
+	labels_in_use.insert(label);
+	liu_mtx.unlock();
+}
+
+void Route::mark_labels_in_use(char* label1, char* label2)
+{	ual_mtx.lock();
+	unused_alt_labels.erase(label1);
+	unused_alt_labels.erase(label2);
+	ual_mtx.unlock();
+	liu_mtx.lock();
+	labels_in_use.insert(label1);
+	labels_in_use.insert(label2);
+	liu_mtx.unlock();
+}
+
 // sort routes by most recent update for use at end of user logs
 // all should have a valid updates entry pointer before being passed here
 bool sort_route_updates_oldest(const Route *r1, const Route *r2)

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -95,6 +95,8 @@ class Route
 	//std::string list_line(int, int);
 	void write_nmp_merged();
 	void store_traveled_segments(TravelerList*, std::ofstream&, std::string&, unsigned int, unsigned int);
+	void mark_label_in_use(char*);
+	void mark_labels_in_use(char*, char*);
 	void compute_stats_r();
 	void con_mismatch();
 	Waypoint* con_beg();

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -87,20 +87,8 @@ if (lit1->second == lit2->second)
 	UPDATE_NOTE(r)
 }
 // otherwise both labels are valid; mark in use & proceed
-else {	r->system->lniu_mtx.lock();
-	r->system->listnamesinuse.insert(lookup);
-	r->system->lniu_mtx.unlock();
-	r->system->uarn_mtx.lock();
-	r->system->unusedaltroutenames.erase(lookup);
-	r->system->uarn_mtx.unlock();
-	r->liu_mtx.lock();
-	r->labels_in_use.insert(fields[2]);
-	r->labels_in_use.insert(fields[3]);
-	r->liu_mtx.unlock();
-	r->ual_mtx.lock();
-	r->unused_alt_labels.erase(fields[2]);
-	r->unused_alt_labels.erase(fields[3]);
-	r->ual_mtx.unlock();
+else {	r->system->mark_route_in_use(lookup);
+	r->mark_labels_in_use(fields[2], fields[3]);
 
 	list_entries++;
 	bool reverse = 0;

--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -78,6 +78,8 @@ if (duplicate)
 {	splist << orig_line << endlines[l];
 	log << "  Please report this error in the Travel Mapping forum.\n  Unable to parse line: "
 	    << trim_line << '\n';
+	r->system->mark_route_in_use(lookup);
+	r->mark_labels_in_use(fields[2], fields[3]);
 	continue;
 }
 // if both labels reference the same waypoint...

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -104,6 +104,9 @@ if (duplicate)
 {	splist << orig_line << endlines[l];
 	log << "  Please report this error in the Travel Mapping forum.\n"
 	    << "  Unable to parse line: " << trim_line << '\n';
+	r1->system->mark_routes_in_use(lookup1, lookup2);
+	r1->mark_label_in_use(fields[2]);
+	r2->mark_label_in_use(fields[5]);
 	continue;
 }
 bool reverse = 0;

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1525,6 +1525,12 @@ class TravelerList:
                     duplicate = True
                 if duplicate:
                     self.log_entries.append("  Please report this error in the Travel Mapping forum.\n  Unable to parse line: " + line)
+                    r.system.listnamesinuse.add(lookup)
+                    r.system.unusedaltroutenames.discard(lookup)
+                    r.labels_in_use.add(list_label_1)
+                    r.labels_in_use.add(list_label_2)
+                    r.unused_alt_labels.discard(list_label_1)
+                    r.unused_alt_labels.discard(list_label_2)
                     continue
                 # if both labels reference the same waypoint...
                 if index1 == index2:
@@ -1671,6 +1677,14 @@ class TravelerList:
                     duplicate = True
                 if duplicate:
                     self.log_entries.append("  Please report this error in the Travel Mapping forum.\n  Unable to parse line: " + line)
+                    r1.system.listnamesinuse.add(lookup1)
+                    r1.system.unusedaltroutenames.discard(lookup1)
+                    r2.system.listnamesinuse.add(lookup2)
+                    r2.system.unusedaltroutenames.discard(lookup2)
+                    r1.labels_in_use.add(list_label_1)
+                    r1.unused_alt_labels.discard(list_label_1)
+                    r2.labels_in_use.add(list_label_2)
+                    r2.unused_alt_labels.discard(list_label_2)
                     continue
                 # if both region/route combos point to the same chopped route...
                 if r1 == r2:

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1685,6 +1685,10 @@ class TravelerList:
                         r1.store_traveled_segments(self, index1, index2)
                     else:
                         r1.store_traveled_segments(self, index2, index1)
+                    r1.labels_in_use.add(list_label_1)
+                    r1.unused_alt_labels.discard(list_label_1)
+                    r2.labels_in_use.add(list_label_2)
+                    r2.unused_alt_labels.discard(list_label_2)
                 else:
                     # user log warning for DISCONNECTED_ROUTE errors
                     if r1.con_route.disconnected:
@@ -1704,6 +1708,15 @@ class TravelerList:
                     if r1.rootOrder > r2.rootOrder:
                         (r1, r2) = (r2, r1)
                         (index1, index2) = (index2, index1)
+                        r1.labels_in_use.add(list_label_2)
+                        r1.unused_alt_labels.discard(list_label_2)
+                        r2.labels_in_use.add(list_label_1)
+                        r2.unused_alt_labels.discard(list_label_1)
+                    else:
+                        r1.labels_in_use.add(list_label_1)
+                        r1.unused_alt_labels.discard(list_label_1)
+                        r2.labels_in_use.add(list_label_2)
+                        r2.unused_alt_labels.discard(list_label_2)
                     # mark the beginning chopped route from index1 to its end
                     if r1.is_reversed():
                         r1.store_traveled_segments(self, 0, index1)
@@ -1720,12 +1733,8 @@ class TravelerList:
                 # both labels are valid; mark in use & proceed
                 r1.system.listnamesinuse.add(lookup1)
                 r1.system.unusedaltroutenames.discard(lookup1)
-                r1.labels_in_use.add(list_label_1)
-                r1.unused_alt_labels.discard(list_label_1)
                 r2.system.listnamesinuse.add(lookup2)
                 r2.system.unusedaltroutenames.discard(lookup2)
-                r2.labels_in_use.add(list_label_2)
-                r2.unused_alt_labels.discard(list_label_2)
                 list_entries += 1
             else:
                 self.log_entries.append("Incorrect format line (4 or 6 fields expected, found " + \


### PR DESCRIPTION
**What's new:**
* Closes #564.
* Flags duplicate labels in-use per [topic=5045.msg30255](https://forum.travelmapping.net/index.php?topic=5045.msg30255#msg30255).
* Ticks off a few boxes in [yakra#210](https://github.com/yakra/DataProcessing/issues/210) without closing the issue.

**Efficiency:**
* **C++** will have a tiny little speedup *(like, barely measurable)* from decreasing:
  * pointer-chasing
  * mutex lock & unlock operations
  * memory copies & allocations
* **Python** should in theory have no change in speed whatsoever (as currently there are no in-use duplicate labels).

**In the future:**
* [more helpful info for DUPLICATE_LABEL errors](https://github.com/TravelMapping/DataProcessing/issues/412)
* [further memory bandwidth improvements for `TravelerList` ctor (Processing traveler list files)](https://github.com/TravelMapping/DataProcessing/issues/466)