### PR TITLE
suppress "last updated" msg for 0-byte .time files

### DIFF
--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -42,8 +42,10 @@ TravelerList::TravelerList(std::string travname, ErrorList* el)
 	std::ifstream file(Args::userlistfilepath+"/../time_files/"+traveler_name+".time");
 	if (file.is_open())
 	{	getline(file, update);
-		log << travname << " last updated: " << update << '\n';
-		update.assign(update, 0, 10);
+		if (update.size())
+		{	log << travname << " last updated: " << update << '\n';
+			update.assign(update, 0, 10);
+		}
 		file.close();
 	}
 

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1426,15 +1426,17 @@ class TravelerList:
         # strip UTF-8 byte order mark if present
         if len(lines):
             lines[0] = lines[0].encode('utf-8').decode("utf-8-sig")
+        self.log_entries = []
+        self.update = None
         try:
             file = open(path+"/../time_files/"+self.traveler_name+".time")
             line = file.readline().rstrip()
-            self.log_entries = [travelername+" last updated: "+line]
-            self.update = line[:10]
+            if len(line):
+                self.log_entries = [travelername+" last updated: "+line]
+                self.update = line[:10]
             file.close()
         except FileNotFoundError:
-            self.log_entries = []
-            self.update = None
+                pass
         self.updated_routes = set()
 
         for line in lines:


### PR DESCRIPTION
Same userlog output as before #558 when a .list file is not part of the UserData repo.
Closes #572.