### PR TITLE
TravelerList::clinched_segments -> vector, etc.

### DIFF
--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -219,8 +219,8 @@ void Route::store_traveled_segments(TravelerList* t, std::ofstream& log, std::st
 {	// store clinched segments with traveler and traveler with segments
 	for (unsigned int pos = beg; pos < end; pos++)
 	{	HighwaySegment *hs = segment_list[pos];
-		hs->add_clinched_by(t);
-		t->clinched_segments.insert(hs);
+		if (hs->add_clinched_by(t))
+		  t->clinched_segments.push_back(hs);
 	}
 	if (last_update && t->updated_routes.insert(this).second && update.size() && last_update[0] >= update)
 		log << "Route updated " << last_update[0] << ": " << readable_name() << '\n';

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -6,7 +6,6 @@ class Region;
 class TravelerList;
 class Waypoint;
 class WaypointQuadtree;
-#include <deque>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -59,7 +58,7 @@ class Route
 	std::string abbrev;
 	std::string city;
 	std::string root;
-	std::deque<std::string> alt_route_names;
+	std::vector<std::string> alt_route_names;
 	ConnectedRoute *con_route;
 
 	std::vector<Waypoint*> point_list;

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -31,7 +31,7 @@ class TravelerList
     start_region start_route start_point end_region end_route end_point
     */
 	public:
-	std::unordered_set<HighwaySegment*> clinched_segments;
+	std::vector<HighwaySegment*> clinched_segments;
 	std::string traveler_name;
 	std::unordered_map<Region*, double> active_preview_mileage_by_region;				// total mileage per region, active+preview only
 	std::unordered_map<Region*, double> active_only_mileage_by_region;				// total mileage per region, active only

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -1,10 +1,10 @@
 // Tab Width = 8
 
-// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2022
+// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2023
 /* Code to read .csv and .wpt files and prepare for
 adding to the Travel Mapping Project database.
 
-(c) 2015-2022, Jim Teresco and Eric Bryant
+(c) 2015-2023, Jim Teresco and Eric Bryant
 Original Python version by Jim Teresco, with contributions from Eric Bryant and the TravelMapping team
 C++ translation by Eric Bryant
 

--- a/siteupdate/cplusplus/threads/ConcAugThread.cpp
+++ b/siteupdate/cplusplus/threads/ConcAugThread.cpp
@@ -20,6 +20,6 @@ void ConcAugThread(unsigned int id, std::mutex* tl_mtx, std::list<std::string>* 
 		      {	augment_list->push_back("Concurrency augment for traveler " + t->traveler_name + ": [" + hs->str() + "] based on [" + s->str() + ']');
 			to_add.push_back(hs);
 		      }
-		t->clinched_segments.insert(to_add.begin(), to_add.end());
+		t->clinched_segments.insert(t->clinched_segments.end(), to_add.begin(), to_add.end());
 	}
 }

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Travel Mapping Project, Jim Teresco, 2015-2022
+# Travel Mapping Project, Jim Teresco, 2015-2023
 """Python code to read .csv and .wpt files and prepare for
 adding to the Travel Mapping Project database.
 
-(c) 2015-2022, Jim Teresco, Eric Bryant, and Travel Mapping Project contributors
+(c) 2015-2023, Jim Teresco, Eric Bryant, and Travel Mapping Project contributors
 
 This module defines classes to represent the contents of a
 .csv file that lists the highways within a system, and a

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1173,8 +1173,8 @@ class Route:
         # store clinched segments with traveler and traveler with segments
         for pos in range(beg, end):
             hs = self.segment_list[pos]
-            hs.add_clinched_by(t)
-            t.clinched_segments.add(hs)
+            if hs.add_clinched_by(t):
+                t.clinched_segments.append(hs)
         if self.last_update and self not in t.updated_routes:
             t.updated_routes.add(self)
             if t.update and self.last_update[0] >= t.update:
@@ -1417,7 +1417,7 @@ class TravelerList:
 
     def __init__(self,travelername,el,path="../../../UserData/list_files"):
         list_entries = 0
-        self.clinched_segments = set()
+        self.clinched_segments = []
         self.traveler_name = travelername[:-5]
         if len(self.traveler_name.encode('utf-8')) > DBFieldLength.traveler:
             el.add_error("Traveler name " + self.traveler_name + " > " + str(DBFieldLength.traveler) + "bytes")

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -4097,6 +4097,7 @@ else:
                     if h.systemname in fields[6].split(","):
                         systems.append(h)
 
+            print(fields[1] + ' ', end="", flush=True)
             graph_data.write_subgraphs_tmg(graph_list, args.graphfilepath + "/", fields[1],
                                            fields[0], "fullcustom", region_list,
                                            systems, placeradius, all_waypoints)


### PR DESCRIPTION
Minor bits & bobs:
* 1cc2b9570cdfbe6a8cd501c3149712c074de8f4b is what it says on the tin.
* 780a65bb456f4755e719dd127308de9f9dcc042c fixes an omission from the original Python implementation of full custom graphs, where only the vertex and edge counts were printed, without the filename. Originally a bit too straightforward a translation from the C++ version apparently; forgot to take into account that this should happen here, and isn't handled by `write_subgraphs_tmg`.

---

616425bc2fb5df01778f43c2d06ccbe15ae94816 closes yakra#230. C++ only.
Saves a bit of RAM in `Route` objects and speeds up *Reading systems list*.
Same idea as in #468, just much lower impact due to far fewer routes than waypoints, fewer AltRouteNames than AltLabels, and the task being so fast to begin with. That and we're not getting rid of any memory copies. All that considered, not too bad though:

machine | OS | before | after | time<br>ratio | % speed<br>increase
-- | -- | -- | -- | -- | --
BT | Ubuntu 16.04 | 0.4318 | 0.3543 | 0.821 | 21.87
lab5 | Ubuntu 18.04 | 0.2058 | 0.1753 | 0.852 | 17.40
lab4 | Ubuntu 18.04 | 0.3694 | 0.3141 | 0.850 | 17.61
lab1 | CentOS 7 | 0.3087 | 0.2846 | 0.922 | 8.47
lab2 | CentOS 7 | 0.3875 | 0.3487 | 0.900 | 11.13
lab3 | CentOS 7 | 0.4946 | 0.4404 | 0.890 | 12.31
bsdlab | FreeBSD 13.0 | 0.6941 | 0.6939 | 1.000 | 0.03

---

And now, saving the best for last, as mentioned in https://github.com/TravelMapping/DataProcessing/issues/151#issuecomment-1413899998...
a90d66477911bdc60f5cedd62f8c315450b9ee34 converts `TravelerList::clinched_segments` from an unordered_set to a vector, that we only add to if `HighwaySegment::add_clinched_by` returns True.
* RAM savings per `TravelerList` of 16 B on FreeBSD, 32 B on Ubuntu 16.04 (DK about Ubuntu 18.04 or CentOS) plus whatever the "hidden" costs of `std::unordered_set` allocated on the heap are.
* Speeds up 3 separate tasks:

### Processing traveler list files
![List](https://user-images.githubusercontent.com/13720877/218014900-b01a0bbe-d0db-49b3-892f-d2f26cd03bd7.png)
We lose a bunch of set insertions in `Route::store_traveled_segments`, instead conditionally appending to a vector.

**Python:**
machine | before | after
| -- | -- | -- |
lab1 | 10.71 | 10.36 | 
lab5 | 8.99 | 8.58 | 
lab2 | 13.01 | 12.44

Underwhelming results in Python. I blame its type system.

### Augmenting travelers for detected concurrent segments
![Conc](https://user-images.githubusercontent.com/13720877/218016506-277a088f-b0ac-43d7-9f10-a68a20147158.png)
Two components to the speedup here:
* Iterating through a vector will be less expensive than iterating through an unordered_set. Python benefits from this too. This particular speedup is here to stay. But OTOH...
* Inserting the `TravelerList::clinched_segments` into a vector instead of an unordered_set, for later use when *Computing stats per traveler*. Multi-threaded C++ only. SiteupdateST & Python don't have the extra insertions, because I never changed the way *Computing stats* iterated, because single threaded.
This component will eventually become moot when other branches of the code catch up. Fixing [the region.php rankings bug](https://forum.travelmapping.net/index.php?topic=5379) means changing the way *Computing stats* iterates, means no longer needing to insert the additional elements into `clinched_segments`. So that'll be removed completely, making this task even faster still.

**Python:**
machine | before | after
| -- | -- | -- |
lab1 | 9.81 | 8.46
lab5 | 8.36 | 7.04
lab2 | 11.44 | 10.32

A little more substantial improvement this time, but still not approaching the gains for C++.

### Computing stats per traveler
![cst](https://user-images.githubusercontent.com/13720877/218022420-66bc2ea3-280a-48c6-9f80-9ca578a37310.png)
Multi-threaded C++ only. This is a good example of the benefits of iterating through a vector rather than an unordered_set. [Not much else is going on](https://github.com/TravelMapping/DataProcessing/blob/76589583c4da970b867655e8ca70bb73999201b4/siteupdate/cplusplus/classes/HighwaySegment/compute_stats_t.cpp) in `CompStatsTThread` other than some hash table lookups and arithmetic. The code itself is unchanged for this task; just the container we're iterating through.
This improvement will also be short-lived though. With the upcoming region.php rankings bugfix, *Computing stats per traveler* will cease to exist as its own discrete task.
There are a few different roads I can take here.
* Before I hit the pause button on the bugfix Feb 1, I had 9 different build alternatives to evaluate, and was about to introduce 3 more. Some significantly slower, some about the same speed, some a little faster.
* Meanwhile, working on #151 again has led me to [dust off an old idea and develop it further](https://github.com/yakra/DataProcessing/issues/221#issuecomment-1416854847).
**A new `TMBitset` class would save some RAM and speed up:**
• Processing traveler list files (Route::store_traveled_segments)
• Augmenting travelers for detected concurrent segments
• userlogs (Route::clinched_by_traveler)
• graph generation (edge compression)
• graph generation (traveled graph traveler lists and `clinchedby_code`s)
**The trade-off is slower:**
• computing stats
• writing the `segments` SQL table
...due to increased costs of iterating through this new class.
  * There are a couple potential optimizations I've yet to try out that could lessen the impact on iteration. Where it would ultimately stand relative to iterating through an `unordered_set` remains to be seen.
  * For writing the SQL tables, we can work around this if desired by iterating through `TravelerList::clinched_segments` to write the `clinched` table.
  (Unless we *really* wanna save about 64 MB RAM by clearing these vectors once computing stats (or augmenting concurrencies, after the rankings bugfix is implemented) is finished.)
  We could do this now, in fact.
    * With the conversion of `clinched_segments` to a vector, that's about as efficient as iteration gets! Way faster than an unordered_set or a TMBitset with whatever optimizations it eventually includes.
    * A side benefit of this is not having to create the big `std::vector<std::string> clinched_list` while writing the `segments` table, and all the allocations, re-allocations, and moves that entails. It would play a lot nicer with memory bandwidth. A Good Thing considering the .sql file is written concurrent with graph file generation, which is pretty bandwidth-hungry. Especially in [FreeBSD](https://github.com/TravelMapping/DataProcessing/issues/518), which usually suffers sooner & more greatly from RAM bottlenecks.