### PR TITLE
minor concurrency augment speedup

### DIFF
--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -437,7 +437,7 @@ int main(int argc, char *argv[])
 	// now augment any traveler clinched segments for concurrencies
 	cout << et.et() << "Augmenting travelers for detected concurrent segments." << flush;
       #ifdef threading_enabled
-	list<string>* augment_lists = new list<string>[Args::numthreads];
+	auto augment_lists = new vector<string>[Args::numthreads];
 				      // deleted once written to concurrencies.log
 	TravelerList::tl_it = TravelerList::allusers.begin();
 	THREADLOOP thr[t] = thread(ConcAugThread, t, &list_mtx, augment_lists+t);

--- a/siteupdate/cplusplus/threads/ConcAugThread.cpp
+++ b/siteupdate/cplusplus/threads/ConcAugThread.cpp
@@ -1,4 +1,4 @@
-void ConcAugThread(unsigned int id, std::mutex* tl_mtx, std::list<std::string>* augment_list)
+void ConcAugThread(unsigned int id, std::mutex* tl_mtx, std::vector<std::string>* augment_list)
 {	//printf("Starting ConcAugThread %02i\n", id); fflush(stdout);
 	while (TravelerList::tl_it != TravelerList::allusers.end())
 	{	tl_mtx->lock();

--- a/siteupdate/cplusplus/threads/threads.h
+++ b/siteupdate/cplusplus/threads/threads.h
@@ -2,12 +2,12 @@ class ElapsedTime;
 class ErrorList;
 class HighwayGraph;
 class WaypointQuadtree;
-#include <list>
 #include <mutex>
+#include <vector>
 
 void CompStatsRThread(unsigned int, std::mutex*);
 void CompStatsTThread(unsigned int, std::mutex*);
-void ConcAugThread   (unsigned int, std::mutex*, std::list<std::string>*);
+void ConcAugThread   (unsigned int, std::mutex*, std::vector<std::string>*);
 void MasterTmgThread(HighwayGraph*, std::mutex*, std::mutex*, WaypointQuadtree*, ElapsedTime*);
 void NmpMergedThread (unsigned int, std::mutex*);
 void NmpSearchThread (unsigned int, std::mutex*, WaypointQuadtree*);


### PR DESCRIPTION
`list` -> `vector` conversion helps cache coherency & iteration.
What's neato here is that reduced cache misses cause subsequent tasks to run faster even though their code is unchanged, kind of the reverse of https://github.com/TravelMapping/DataProcessing/pull/311#issuecomment-620943860. Proportionally, their speedup is even bigger.

![Conc](https://user-images.githubusercontent.com/13720877/219262913-8bc9288e-a246-4370-9b63-239f2c920597.png)

**Writing to concurrencies.log** (single-threaded):
|  | 616425b | 525c2b6 |
| -- | -- | -- |
| **BT** | 0.3715 | 0.1863 |
| **lab1** | 0.2040 | 0.1030 |
| **lab5** | 0.1491 | 0.0722 |
| **lab2** | 0.2100 | 0.1114 |
| **lab3** | 0.3143 | 0.1807 |
| **lab4** | 0.2525 | 0.1300 |
| **bsdlab** | 0.1834 | 0.1187 |

![csr](https://user-images.githubusercontent.com/13720877/219263209-93748f62-14d1-41e8-a481-ed23f6058e94.png)
![cst](https://user-images.githubusercontent.com/13720877/219263220-5c8d7ec1-fc89-45f4-b542-6710850d6c0a.png)
Worth noting again that soon, after the region.php ranking bugfix is implemented, CompStatsRThread & CompStatsTThread will cease to be separate tasks.
![all4](https://user-images.githubusercontent.com/13720877/219263646-29b8d571-30ee-4efc-b47a-8f830fe6beb4.png)
Subsequent tasks (highwaydatastats.log, Creating per-traveler stats logs and augmenting data structure, etc.) were not measured; I had siteupdate terminate early to finish the speed tests in a reasonable amount of time. Though surely as the program marches onward & more stuff is read out of main memory into cache, the effect will be less & less.