### PR TITLE
TMArray, TMBitset, etc.

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -158,10 +158,10 @@ void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int th
 }
 
 // write line to tmg traveled edge file
-void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems, std::list<TravelerList*> *traveler_lists, char* code)
+void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems, bool trav, char* code)
 {	file << vertex1->t_vertex_num[threadnum] << ' ' << vertex2->t_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
-	file << ' ' << segment->clinchedby_code(traveler_lists, code, threadnum);
+	file << ' ' << (trav ? segment->clinchedby_code(code, threadnum) : "0");
 	for (HGVertex *intermediate : intermediate_points)
 	{	sprintf(fstr, " %.15g %.15g", intermediate->lat, intermediate->lng);
 		file << fstr;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -1,7 +1,6 @@
 class HGVertex;
 class HighwaySegment;
 class HighwaySystem;
-class TravelerList;
 #include <iostream>
 #include <list>
 
@@ -28,7 +27,7 @@ class HGEdge
 	void detach();
 	void detach(unsigned char);
 	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*);
-	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, std::list<TravelerList*>*, char*);
+	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, bool, char*);
 	std::string debug_tmg_line(std::list<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -18,9 +18,9 @@ class HGEdge
 	unsigned char format;
 
 	// constants for more human-readable format masks
-	static const unsigned char simple = 1;
-	static const unsigned char collapsed = 2;
-	static const unsigned char traveled = 4;
+	static constexpr unsigned char simple = 1;
+	static constexpr unsigned char collapsed = 2;
+	static constexpr unsigned char traveled = 4;
 
 	HGEdge(HighwaySegment *);
 	HGEdge(HGVertex *, unsigned char);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -4,7 +4,6 @@ class Region;
 class Waypoint;
 #include <list>
 #include <string>
-#include <unordered_set>
 
 class HGVertex
 {   /* This class encapsulates information needed for a highway graph

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -109,11 +109,11 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 			{	new HGEdge(w->vertex, HGEdge::collapsed);
 				continue;
 			}
-			else if ((w->vertex->incident_c_edges.front() == w->vertex->incident_t_edges.front()
+			if   (	 (w->vertex->incident_c_edges.front() == w->vertex->incident_t_edges.front()
 			       && w->vertex->incident_c_edges.back()  == w->vertex->incident_t_edges.back())
 			      || (w->vertex->incident_c_edges.front() == w->vertex->incident_t_edges.back()
-			       && w->vertex->incident_c_edges.back()  == w->vertex->incident_t_edges.front()))
-				new HGEdge(w->vertex, HGEdge::collapsed | HGEdge::traveled);
+			       && w->vertex->incident_c_edges.back()  == w->vertex->incident_t_edges.front())
+			     )	new HGEdge(w->vertex, HGEdge::collapsed | HGEdge::traveled);
 			else {	new HGEdge(w->vertex, HGEdge::collapsed);
 				new HGEdge(w->vertex, HGEdge::traveled);
 				// Final collapsed edges are deleted by HGEdge::detach via ~HGVertex via HighwayGraph::clear.

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -91,22 +91,14 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 				w->vertex->visibility = 2;
 				continue;
 			}
-			// if edge clinched_by sets mismatch, set visibility to 1
-			// (visible in traveled graph; hidden in collapsed graph)
-			// first, the easy check, for whether set sizes mismatch
-			if (w->vertex->incident_t_edges.front()->segment->clinched_by.size()
-			 != w->vertex->incident_t_edges.back()->segment->clinched_by.size())
-				w->vertex->visibility = 1;
-			// next, compare clinched_by sets; look for any element in the 1st not in the 2nd
-			else for (TravelerList *t : w->vertex->incident_t_edges.front()->segment->clinched_by)
-				if (!w->vertex->incident_t_edges.back()->segment->clinched_by.count(t))
-				{	w->vertex->visibility = 1;
-					break;
-				}
 			// construct from vertex this time
 			--ce; --cv;
-			if (w->vertex->visibility == 1)
-			{	new HGEdge(w->vertex, HGEdge::collapsed);
+			// if edge clinched_by sets mismatch, set visibility to 1
+			// (visible in traveled graph; hidden in collapsed graph)
+			if (w->vertex->incident_t_edges.front()->segment->clinched_by
+			 != w->vertex->incident_t_edges.back()->segment->clinched_by)
+			{	w->vertex->visibility = 1;
+				new HGEdge(w->vertex, HGEdge::collapsed);
 				continue;
 			}
 			if   (	 (w->vertex->incident_c_edges.front() == w->vertex->incident_t_edges.front()

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -62,7 +62,7 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 		counter++;
 		for (Route *r : h->route_list)
 		  for (HighwaySegment *s : r->segment_list)
-		    if (!s->concurrent || s == s->concurrent->front())
+		    if (s == s->canonical_edge_segment())
 		    { ++se; 
 		      new HGEdge(s);
 		      // deleted by HGEdge::detach via ~HGVertex via HighwayGraph::clear

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -298,7 +298,7 @@ void HighwayGraph::write_master_graphs_tmg()
 	travelfile << "TMG 2.0 traveled\n";
 	simplefile << vertices.size() << ' ' << se << '\n';
 	collapfile << cv << ' ' << ce << '\n';
-	travelfile << tv << ' ' << te << ' ' << TravelerList::allusers.size() << '\n';
+	travelfile << tv << ' ' << te << ' ' << TravelerList::allusers.size << '\n';
 
 	// write vertices
 	unsigned int sv = 0;
@@ -314,7 +314,7 @@ void HighwayGraph::write_master_graphs_tmg()
 		}
 	}
 	// now edges, only write if not already written
-	size_t nibbles = ceil(double(TravelerList::allusers.size())/4);
+	size_t nibbles = ceil(double(TravelerList::allusers.size)/4);
 	char* cbycode = new char[nibbles+1];
 			// deleted after writing edges
 	cbycode[nibbles] = 0;
@@ -329,7 +329,7 @@ void HighwayGraph::write_master_graphs_tmg()
 			  if (!(e->written[0] &  HGEdge::traveled))
 			  {	e->written[0] |= HGEdge::traveled;
 				for (char*n=cbycode; n<cbycode+nibbles; ++n) *n = '0';
-				e->traveled_tmg_line(travelfile, fstr, 0, 0, &TravelerList::allusers, cbycode);
+				e->traveled_tmg_line(travelfile, fstr, 0, 0, TravelerList::allusers.size, cbycode);
 			  }
 	    default:	for (HGEdge *e : v.incident_s_edges)
 			  if (!(e->written[0] &  HGEdge::simple))
@@ -342,8 +342,8 @@ void HighwayGraph::write_master_graphs_tmg()
 	  }
 	delete[] cbycode;
 	// traveler names
-	for (TravelerList *t : TravelerList::allusers)
-		travelfile << t->traveler_name << ' ';
+	for (TravelerList& t : TravelerList::allusers)
+		travelfile << t.traveler_name << ' ';
 	travelfile << '\n';
 	simplefile.close();
 	collapfile.close();
@@ -391,7 +391,7 @@ void HighwayGraph::write_subgraphs_tmg
 	travelfile << "TMG 2.0 traveled\n";
 	simplefile << mv.size() << ' ' << mse.size() << '\n';
 	collapfile << cv_count << ' ' << mce.size() << '\n';
-	travelfile << tv_count << ' ' << mte.size() << ' ' << traveler_lists.size() << '\n';
+	travelfile << tv_count << ' ' << mte.size() << ' ' << travnum << '\n';
 
 	// write vertices
 	unsigned int sv = 0;
@@ -415,13 +415,13 @@ void HighwayGraph::write_subgraphs_tmg
 	}
 	for (HGEdge *e : mce)
 		e->collapsed_tmg_line(collapfile, fstr, threadnum, g->systems);
-	size_t nibbles = ceil(double(traveler_lists.size())/4);
+	size_t nibbles = ceil(double(travnum)/4);
 	char* cbycode = new char[nibbles+1];
 			// deleted after writing edges
 	cbycode[nibbles] = 0;
 	for (HGEdge *e : mte)
 	{	for (char*n=cbycode; n<cbycode+nibbles; ++n) *n = '0';
-		e->traveled_tmg_line (travelfile, fstr, threadnum, g->systems, &traveler_lists, cbycode);
+		e->traveled_tmg_line (travelfile, fstr, threadnum, g->systems, travnum, cbycode);
 	}
 	delete[] cbycode;
 	// traveler names
@@ -437,5 +437,5 @@ void HighwayGraph::write_subgraphs_tmg
 
 	g -> vertices = mv.size(); g -> edges = mse.size(); g -> travelers = 0;
 	g[1].vertices = cv_count;  g[1].edges = mce.size(); g[1].travelers = 0;
-	g[2].vertices = tv_count;  g[2].edges = mte.size(); g[2].travelers = traveler_lists.size();
+	g[2].vertices = tv_count;  g[2].edges = mte.size(); g[2].travelers = travnum;
 }

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -14,7 +14,6 @@
 #include "../Waypoint/Waypoint.h"
 #include "../WaypointQuadtree/WaypointQuadtree.h"
 #include "../../templates/contains.cpp"
-#include <cmath>
 #include <fstream>
 #include <thread>
 

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -43,17 +43,6 @@ class HighwayGraph
 	bool subgraph_contains(HGVertex*, const int);
 	void add_to_subgraph(HGVertex*, const int);
 	void clear_vbit(HGVertex*, const int);
-
-	inline void matching_vertices_and_edges
-	(	GraphListEntry&, WaypointQuadtree*,
-		std::list<TravelerList*> &,
-		std::vector<HGVertex*>&,	// final set of vertices matching all criteria
-		std::vector<HGEdge*>&,		// matching    simple edges
-		std::vector<HGEdge*>&,		// matching collapsed edges
-		std::vector<HGEdge*>&,		// matching  traveled edges
-		int, unsigned int&, unsigned int&
-	);
-
 	void write_master_graphs_tmg();
 	void write_subgraphs_tmg(size_t, unsigned int, WaypointQuadtree*, ElapsedTime*, std::mutex*);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
@@ -1,0 +1,66 @@
+// Find a set of vertices from the graph, optionally
+// restricted by region or system or placeradius area.
+if (g->placeradius)
+	g->placeradius->vertices(mv, qt, this, *g, threadnum);
+else	if (g->regions)
+	{ if (g->systems)
+	  {	// iterate via region & check for a system_match
+		for (Region *r : *g->regions)
+		  for (auto& vw : r->vertices)
+		    if (!subgraph_contains(vw.first, threadnum) && vw.second->system_match(g->systems))
+		    {	mv.push_back(vw.first);
+			add_to_subgraph(vw.first, threadnum);
+		    }
+	  }
+	  else	for (Region *r : *g->regions)
+		  for (auto& vw : r->vertices)
+		    if (!subgraph_contains(vw.first, threadnum))
+		    {	mv.push_back(vw.first);
+			add_to_subgraph(vw.first, threadnum);
+		    }
+	} else	for (HighwaySystem *h : *g->systems)
+		  for (HGVertex* v : h->vertices)
+		    if (!subgraph_contains(v, threadnum))
+		    {	mv.push_back(v);
+			add_to_subgraph(v, threadnum);
+		    }
+
+// initialize written booleans
+for (HGVertex *v : mv)
+{	for (HGEdge* e : v->incident_s_edges) e->written[threadnum] = 0;
+	for (HGEdge* e : v->incident_c_edges) e->written[threadnum] = 0;
+	for (HGEdge* e : v->incident_t_edges) e->written[threadnum] = 0;
+}
+
+// Compute sets of edges for subgraphs, optionally
+// restricted by region or system or placeradius.
+// Keep a count of collapsed & traveled vertices as we go.
+#define AREA (!g->placeradius || subgraph_contains(e->vertex1, threadnum) && subgraph_contains(e->vertex2, threadnum))
+#define REGION (!g->regions || contains(*g->regions, e->segment->route->region))
+for (HGVertex *v : mv)
+{	switch (v->visibility) // fall-thru is a Good Thing!
+	{   case 2:
+		cv_count++;
+		for (HGEdge *e : v->incident_c_edges)
+		  if (!(e->written[threadnum] & HGEdge::collapsed) && AREA && REGION && e->segment->system_match(g->systems))
+		  {	mce.push_back(e);
+			e->written[threadnum] |= HGEdge::collapsed;
+		  }
+	    case 1:
+		tv_count++;
+		for (HGEdge *e : v->incident_t_edges)
+		  if (!(e->written[threadnum] & HGEdge::traveled) && AREA && REGION && e->segment->system_match(g->systems))
+		  {	mte.push_back(e);
+			e->written[threadnum] |= HGEdge::traveled;
+			traveler_set |= e->segment->clinched_by;
+		  }
+	    default:
+		for (HGEdge *e : v->incident_s_edges)
+		  if (!(e->written[threadnum] & HGEdge::simple) && AREA && REGION && e->segment->system_match(g->systems))
+		  {	mse.push_back(e);
+			e->written[threadnum] |= HGEdge::simple;
+		  }
+	}   clear_vbit(v, threadnum);
+}
+#undef AREA
+#undef REGION

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -106,3 +106,16 @@ void HighwaySegment::write_label(std::ofstream& file, std::list<HighwaySystem*> 
 		file << route->abbrev;
 	     }
 }
+
+// find canonical segment for HGEdge construction, just in case a devel system is listed earlier in systems.csv
+HighwaySegment* HighwaySegment::canonical_edge_segment()
+{	if (!concurrent) return this;
+	for (auto& s : *concurrent)
+	  if (s->route->system->active_or_preview())
+	    return s;
+	// We should never reach this point, because this function will
+	// only be called on active/preview segments and a concurrent
+	// segment should always be in its own concurrency list.
+	// Nonetheless, let's stop the compiler from complaining.
+	throw 0xBAD;
+}

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -5,21 +5,21 @@
 #include "../Waypoint/Waypoint.h"
 #include "../../templates/contains.cpp"
 
-HighwaySegment::HighwaySegment(Waypoint *w1, Waypoint *w2, Route *rte)
-{	waypoint1 = w1;
-	waypoint2 = w2;
-	route = rte;
-	length = waypoint1->distance_to(waypoint2);
-	concurrent = 0;
-}
+HighwaySegment::HighwaySegment(Waypoint *w1, Waypoint *w2, Route *rte):
+	waypoint1(w1),
+	waypoint2(w2),
+	route(rte),
+	length(w1->distance_to(w2)),
+	concurrent(0),
+	clinched_by(TravelerList::allusers.data, TravelerList::allusers.size) {}
 
 std::string HighwaySegment::str()
 {	return route->readable_name() + " " + waypoint1->label + " " + waypoint2->label;
 }
 
-bool HighwaySegment::add_clinched_by(TravelerList *traveler)
+bool HighwaySegment::add_clinched_by(size_t t)
 {	clin_mtx.lock();
-	bool result = clinched_by.insert(traveler).second;
+	bool result = clinched_by.add_index(t);
 	clin_mtx.unlock();
 	return result;
 }

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -61,7 +61,7 @@ std::string HighwaySegment::segment_name()
 	return "";
 }//*/
 
-const char* HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_lists, char* code, unsigned int threadnum)
+const char* HighwaySegment::clinchedby_code(char* code, unsigned int threadnum)
 {	// Compute a hexadecimal string encoding which travelers
 	// have clinched this segment, for use in "traveled" graph files.
 	// Each character stores info for traveler #n thru traveler #n+3.
@@ -69,7 +69,6 @@ const char* HighwaySegment::clinchedby_code(std::list<TravelerList*> *traveler_l
 	// The second character stores traveler 4 thru traveler 7, etc.
 	// For each character, the low-order bit stores traveler n, and the high bit traveler n+3.
 
-	if (traveler_lists->empty()) return "0";
 	for (TravelerList* t : clinched_by)
 		code[t->traveler_num[threadnum]/4] += 1 << t->traveler_num[threadnum]%4;
 	for (char* nibble = code; *nibble; ++nibble) if (*nibble > '9') *nibble += 7;

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -29,4 +29,5 @@ class HighwaySegment
 	const char* clinchedby_code(std::list<TravelerList*>*, char*, unsigned int);
 	bool system_match(std::list<HighwaySystem*>*);
 	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
+	HighwaySegment* canonical_edge_segment();
 };

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -2,9 +2,9 @@ class HighwaySystem;
 class Route;
 class TravelerList;
 class Waypoint;
+#include "../../templates/TMBitset.cpp"
 #include <list>
 #include <mutex>
-#include <unordered_set>
 
 class HighwaySegment
 {   /* This class represents one highway segment: the connection between two
@@ -16,13 +16,13 @@ class HighwaySegment
 	Route *route;
 	double length;
 	std::list<HighwaySegment*> *concurrent;
-	std::unordered_set<TravelerList*> clinched_by;
+	TMBitset<TravelerList*, uint32_t> clinched_by;
 	std::mutex clin_mtx;
 
 	HighwaySegment(Waypoint *, Waypoint *, Route *);
 
 	std::string str();
-	bool add_clinched_by(TravelerList *);
+	bool add_clinched_by(size_t);
 	std::string csv_line(unsigned int);
 	std::string segment_name();
 	//std::string concurrent_travelers_sanity_check();

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -26,7 +26,7 @@ class HighwaySegment
 	std::string csv_line(unsigned int);
 	std::string segment_name();
 	//std::string concurrent_travelers_sanity_check();
-	const char* clinchedby_code(std::list<TravelerList*>*, char*, unsigned int);
+	const char* clinchedby_code(char*, unsigned int);
 	bool system_match(std::list<HighwaySystem*>*);
 	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
 	HighwaySegment* canonical_edge_segment();

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -170,12 +170,12 @@ void HighwaySystem::stats_csv()
 	for (Region *region : regions)
 		sysfile << ',' << region->code;
 	sysfile << '\n';
-	for (TravelerList *t : TravelerList::allusers)
+	for (TravelerList& t : TravelerList::allusers)
 	{	// only include entries for travelers who have any mileage in system
-		auto it = t->system_region_mileages.find(this);
-		if (it != t->system_region_mileages.end())
-		{	sprintf(fstr, ",%.2f", t->system_miles(this));
-			sysfile << t->traveler_name << fstr;
+		auto it = t.system_region_mileages.find(this);
+		if (it != t.system_region_mileages.end())
+		{	sprintf(fstr, ",%.2f", t.system_miles(this));
+			sysfile << t.traveler_name << fstr;
 			for (Region *region : regions)
 			  try {	sprintf(fstr, ",%.2f", it->second.at(region));
 				sysfile << fstr;

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -7,6 +7,7 @@
 #include "../HighwaySegment/HighwaySegment.h"
 #include "../HighwaySystem/HighwaySystem.h"
 #include "../Region/Region.h"
+#include "../TravelerList/TravelerList.h"
 #include "../Waypoint/Waypoint.h"
 #include "../../functions/lower.h"
 #include "../../functions/split.h"
@@ -157,10 +158,10 @@ std::string Route::name_no_abbrev()
 	return route + banner;
 }
 
-double Route::clinched_by_traveler(TravelerList *t)
+double Route::clinched_by_traveler_index(size_t t)
 {	double miles = 0;
 	for (HighwaySegment *s : segment_list)
-		if (s->clinched_by.count(t)) miles += s->length;
+		if (s->clinched_by[t]) miles += s->length;
 	return miles;
 }
 

--- a/siteupdate/cplusplus/classes/Route/Route.h
+++ b/siteupdate/cplusplus/classes/Route/Route.h
@@ -89,7 +89,7 @@ class Route
 	std::string readable_name();
 	std::string list_entry_name();
 	std::string name_no_abbrev();
-	double clinched_by_traveler(TravelerList *);
+	double clinched_by_traveler_index(size_t);
 	//std::string list_line(int, int);
 	void write_nmp_merged();
 	void store_traveled_segments(TravelerList*, std::ofstream&, std::string&, unsigned int, unsigned int);

--- a/siteupdate/cplusplus/classes/Route/store_traveled_segments.cpp
+++ b/siteupdate/cplusplus/classes/Route/store_traveled_segments.cpp
@@ -6,9 +6,10 @@
 
 void Route::store_traveled_segments(TravelerList* t, std::ofstream& log, std::string& update, unsigned int beg, unsigned int end)
 {	// store clinched segments with traveler and traveler with segments
+	size_t index = t-TravelerList::allusers.data;
 	for (unsigned int pos = beg; pos < end; pos++)
 	{	HighwaySegment *hs = segment_list[pos];
-		if (hs->add_clinched_by(t))
+		if (hs->add_clinched_by(index))
 		  t->clinched_segments.push_back(hs);
 	}
       #ifdef threading_enabled

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -14,11 +14,9 @@
 
 TravelerList::TravelerList(std::string& travname, ErrorList* el)
 {	// initialize object variables
-	in_subgraph = new bool[Args::numthreads];
 	traveler_num = new unsigned int[Args::numthreads];
 		       // deleted by ~TravelerList
 	traveler_num[0] = this - allusers.data; // init for master traveled graph
-	for (size_t i = 0; i < Args::numthreads; i++) in_subgraph[i] = 0;
 	traveler_name.assign(travname, 0, travname.size()-5); // strip ".list" from end of travname
 	if (traveler_name.size() > DBFieldLength::traveler)
 	  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");
@@ -180,7 +178,3 @@ std::list<std::string>::iterator TravelerList::id_it;
 TMArray<TravelerList> TravelerList::allusers;
 TravelerList* TravelerList::tl_it;
 bool TravelerList::file_not_found = 0;
-
-bool sort_travelers_by_name(const TravelerList *t1, const TravelerList *t2)
-{	return t1->traveler_name < t2->traveler_name;
-}

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -12,11 +12,12 @@
 #include "../../templates/contains.cpp"
 #include <cstring>
 
-TravelerList::TravelerList(std::string travname, ErrorList* el)
+TravelerList::TravelerList(std::string& travname, ErrorList* el)
 {	// initialize object variables
 	in_subgraph = new bool[Args::numthreads];
 	traveler_num = new unsigned int[Args::numthreads];
-		       // deleted on termination of program
+		       // deleted by ~TravelerList
+	traveler_num[0] = this - allusers.data; // init for master traveled graph
 	for (size_t i = 0; i < Args::numthreads; i++) in_subgraph[i] = 0;
 	traveler_name.assign(travname, 0, travname.size()-5); // strip ".list" from end of travname
 	if (traveler_name.size() > DBFieldLength::traveler)
@@ -150,6 +151,8 @@ TravelerList::TravelerList(std::string travname, ErrorList* el)
 	splist.close();
 }
 
+TravelerList::~TravelerList() {delete[] traveler_num;}
+
 /* Return active mileage across all regions */
 double TravelerList::active_only_miles()
 {	double mi = 0;
@@ -174,8 +177,8 @@ double TravelerList::system_miles(HighwaySystem *h)
 std::mutex TravelerList::mtx;
 std::list<std::string> TravelerList::ids;
 std::list<std::string>::iterator TravelerList::id_it;
-std::list<TravelerList*> TravelerList::allusers;
-std::list<TravelerList*>::iterator TravelerList::tl_it;
+TMArray<TravelerList> TravelerList::allusers;
+TravelerList* TravelerList::tl_it;
 bool TravelerList::file_not_found = 0;
 
 bool sort_travelers_by_name(const TravelerList *t1, const TravelerList *t2)

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -18,8 +18,7 @@ TravelerList::TravelerList(std::string travname, ErrorList* el)
 	traveler_num = new unsigned int[Args::numthreads];
 		       // deleted on termination of program
 	for (size_t i = 0; i < Args::numthreads; i++) in_subgraph[i] = 0;
-	traveler_name = travname.substr(0, travname.size()-5); // strip ".list" from end of travname
-	std::cout << traveler_name << ' ' << std::flush;
+	traveler_name.assign(travname, 0, travname.size()-5); // strip ".list" from end of travname
 	if (traveler_name.size() > DBFieldLength::traveler)
 	  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");
 
@@ -52,6 +51,15 @@ TravelerList::TravelerList(std::string travname, ErrorList* el)
 	  // at least one .list file contains newlines using only '\r' (0x0D):
 	  // https://github.com/TravelMapping/UserData/blob/6309036c44102eb3325d49515b32c5eef3b3cb1e/list_files/whopperman.list
 	file.open(Args::userlistfilepath+"/"+travname);
+	if (!file.is_open())
+	{	std::cout << "\nERROR: " << travname << " not found.";
+		file_not_found = 1;
+	}
+	if (file_not_found)
+		// We're going to abort, so no point in continuing to fully build out TravelerList objects.
+		// Future constructors will proceed only this far, to get a complete list of invalid names.
+		return;
+	else	std::cout << traveler_name << ' ' << std::flush;
 	file.seekg(0, std::ios::end);
 	unsigned long listdatasize = file.tellg();
 	file.seekg(0, std::ios::beg);
@@ -168,6 +176,7 @@ std::list<std::string> TravelerList::ids;
 std::list<std::string>::iterator TravelerList::id_it;
 std::list<TravelerList*> TravelerList::allusers;
 std::list<TravelerList*>::iterator TravelerList::tl_it;
+bool TravelerList::file_not_found = 0;
 
 bool sort_travelers_by_name(const TravelerList *t1, const TravelerList *t2)
 {	return t1->traveler_name < t2->traveler_name;

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -9,6 +9,7 @@
 #include "../Route/Route.h"
 #include "../Waypoint/Waypoint.h"
 #include "../../functions/upper.h"
+#include "../../templates/contains.cpp"
 #include <cstring>
 
 TravelerList::TravelerList(std::string travname, ErrorList* el)

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -47,6 +47,7 @@ class TravelerList
 	static std::list<std::string>::iterator id_it;
 	static std::list<TravelerList*> allusers;
 	static std::list<TravelerList*>::iterator tl_it;
+	static bool file_not_found;
 
 	TravelerList(std::string, ErrorList*);
 	double active_only_miles();

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -4,6 +4,7 @@ class HighwaySegment;
 class HighwaySystem;
 class Region;
 class Route;
+#include "../../templates/TMArray.cpp"
 #include <list>
 #include <mutex>
 #include <unordered_map>
@@ -40,16 +41,16 @@ class TravelerList
 	std::vector<std::pair<ConnectedRoute*,double>> ccr_values;	// for the clinchedConnectedRoutes DB table
 	bool* in_subgraph;
 	unsigned int *traveler_num;
-	// for locking the allusers list when reading .lists from disk
-	// and avoiding data races when creating userlog timestamps
-	static std::mutex mtx;
+	static std::mutex mtx;	// for avoiding data races when creating userlog timestamps
 	static std::list<std::string> ids;
 	static std::list<std::string>::iterator id_it;
-	static std::list<TravelerList*> allusers;
-	static std::list<TravelerList*>::iterator tl_it;
+	static TMArray<TravelerList> allusers;
+	static TravelerList* tl_it;
 	static bool file_not_found;
 
-	TravelerList(std::string, ErrorList*);
+	TravelerList(std::string&, ErrorList*);
+	~TravelerList();
+
 	double active_only_miles();
 	double active_preview_miles();
 	double system_miles(HighwaySystem *);

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.h
@@ -39,7 +39,6 @@ class TravelerList
 	std::unordered_set<Route*> updated_routes;
 	std::vector<std::pair<Route*,double>> cr_values;		// for the clinchedRoutes DB table
 	std::vector<std::pair<ConnectedRoute*,double>> ccr_values;	// for the clinchedConnectedRoutes DB table
-	bool* in_subgraph;
 	unsigned int *traveler_num;
 	static std::mutex mtx;	// for avoiding data races when creating userlog timestamps
 	static std::list<std::string> ids;
@@ -56,5 +55,3 @@ class TravelerList
 	double system_miles(HighwaySystem *);
 	void userlog(const double, const double);
 };
-
-bool sort_travelers_by_name(const TravelerList*, const TravelerList*);

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -128,14 +128,12 @@ if (r1 == r2)
      }
 else {	// user log warning for DISCONNECTED_ROUTE errors
 	if (r1->con_route->disconnected)
-	{	std::unordered_set<Region*> region_set;
+	{	std::vector<Region*> regions;
 		for (Route* r : r1->con_route->roots)
-		  if (r->is_disconnected())
-		    region_set.insert(r->region);
-		std::list<Region*> region_list(region_set.begin(), region_set.end());
-		region_list.sort(sort_regions_by_code);
-		for (Region* r : region_list)
-		  log << r->code << (r == region_list.back() ? ':' : '/');
+		  if (r->is_disconnected() && !contains(regions, r->region))
+		    regions.push_back(r->region);
+		for (Region* r : regions)
+		  log << r->code << (r == regions.back() ? ':' : '/');
 		log << " DISCONNECTED_ROUTE error in " << r1->con_route->readable_name()
 		    << ".\n  Please report this error in the Travel Mapping forum"
 		    << ".\n  Travels may potentially be shown incorrectly for line: " << trim_line << '\n';

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -32,6 +32,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 	unsigned int active_systems_clinched = 0;
 	unsigned int preview_systems_traveled = 0;
 	unsigned int preview_systems_clinched = 0;
+	size_t index = this - allusers.data;
 
 	// stats by system
 	for (HighwaySystem *h : HighwaySystem::syslist)
@@ -75,7 +76,7 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 				auto& roots = cr->roots;
 				for (Route *r : roots)
 				{	// find traveled mileage on this by this user
-					double miles = r->clinched_by_traveler(this);
+					double miles = r->clinched_by_traveler_index(index);
 					if (miles)
 					{	cr_values.emplace_back(r, miles);
 						con_clinched_miles += miles;

--- a/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
@@ -16,14 +16,14 @@ void allbyregionactiveonly(std::mutex* mtx, double total_mi)
 	for (Region *region : regions)
 		allfile << ',' << region->code;
 	allfile << '\n';
-	for (TravelerList *t : TravelerList::allusers)
+	for (TravelerList& t : TravelerList::allusers)
 	{	double t_total_mi = 0;
-		for (std::pair<Region* const, double>& rm : t->active_only_mileage_by_region)
+		for (std::pair<Region* const, double>& rm : t.active_only_mileage_by_region)
 			t_total_mi += rm.second;
 		sprintf(fstr, "%.2f", t_total_mi);
-		allfile << t->traveler_name << ',' << fstr;
+		allfile << t.traveler_name << ',' << fstr;
 		for (Region *region : regions)
-		  try {	sprintf(fstr, "%.2f", t->active_only_mileage_by_region.at(region));
+		  try {	sprintf(fstr, "%.2f", t.active_only_mileage_by_region.at(region));
 			allfile << ',' << fstr;
 		      }
 		  catch (const std::out_of_range& oor)

--- a/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
@@ -16,14 +16,14 @@ void allbyregionactivepreview(std::mutex* mtx, double total_mi)
 	for (Region *region : regions)
 		allfile << ',' << region->code;
 	allfile << '\n';
-	for (TravelerList *t : TravelerList::allusers)
+	for (TravelerList& t : TravelerList::allusers)
 	{	double t_total_mi = 0;
-		for (std::pair<Region* const, double>& rm : t->active_preview_mileage_by_region)
+		for (std::pair<Region* const, double>& rm : t.active_preview_mileage_by_region)
 			t_total_mi += rm.second;
 		sprintf(fstr, "%.2f", t_total_mi);
-		allfile << t->traveler_name << ',' << fstr;
+		allfile << t.traveler_name << ',' << fstr;
 		for (Region *region : regions)
-		  try {	sprintf(fstr, "%.2f", t->active_preview_mileage_by_region.at(region));
+		  try {	sprintf(fstr, "%.2f", t.active_preview_mileage_by_region.at(region));
 			allfile << ',' << fstr;
 		      }
 		  catch (const std::out_of_range& oor)

--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -310,16 +310,14 @@ void sqlfile1
 		<< "), activeMileage DOUBLE, activePreviewMileage DOUBLE);\n";
 	sqlfile << "INSERT INTO clinchedOverallMileageByRegion VALUES\n";
 	first = 1;
-	for (TravelerList *t : TravelerList::allusers)
-	  for (std::pair<Region* const,double>& rm : t->active_preview_mileage_by_region)
+	for (TravelerList& t : TravelerList::allusers)
+	  for (std::pair<Region* const,double>& rm : t.active_preview_mileage_by_region)
 	  {	if (!first) sqlfile << ',';
 		first = 0;
-		double active_miles = 0;
-		auto it = t->active_only_mileage_by_region.find(rm.first);
-		if (it != t->active_only_mileage_by_region.end())
-		  active_miles = it->second;
+		auto it = t.active_only_mileage_by_region.find(rm.first);
+		double active_miles = (it != t.active_only_mileage_by_region.end()) ? it->second : 0;
 		sprintf(fstr, "','%.17g','%.17g')\n", active_miles, rm.second);
-		sqlfile << "('" << rm.first->code << "','" << t->traveler_name << fstr;
+		sqlfile << "('" << rm.first->code << "','" << t.traveler_name << fstr;
 	  }
 	sqlfile << ";\n";
 
@@ -334,18 +332,16 @@ void sqlfile1
 		<< "), mileage DOUBLE, FOREIGN KEY (systemName) REFERENCES systems(systemName));\n";
 	sqlfile << "INSERT INTO clinchedSystemMileageByRegion VALUES\n";
 	first = 1;
-	for (TravelerList* t : TravelerList::allusers)
-	{	auto& traveler_name = t->traveler_name;
-		for (auto& csmbr : t->system_region_mileages)
-		{	auto& systemname = csmbr.first->systemname;
-			for (auto& rm : csmbr.second)
-			{	if (!first) sqlfile << ',';
-				first = 0;
-				sprintf(fstr, "%.17g", rm.second);
-				sqlfile << "('" << systemname << "','" << rm.first->code << "','" << traveler_name << "','" << fstr << "')\n";
-			}
+	for (TravelerList& t : TravelerList::allusers)
+	  for (auto& csmbr : t.system_region_mileages)
+	  {	auto& systemname = csmbr.first->systemname;
+		for (auto& rm : csmbr.second)
+		{	if (!first) sqlfile << ',';
+			first = 0;
+			sprintf(fstr, "%.17g", rm.second);
+			sqlfile << "('" << systemname << "','" << rm.first->code << "','" << t.traveler_name << "','" << fstr << "')\n";
 		}
-	}
+	  }
 	sqlfile << ";\n";
 
 	// clinched mileage by connected route, active systems and preview
@@ -356,16 +352,15 @@ void sqlfile1
 	sqlfile << "CREATE TABLE clinchedConnectedRoutes (route VARCHAR(" << DBFieldLength::root
 		<< "), traveler VARCHAR(" << DBFieldLength::traveler
 		<< "), mileage FLOAT, clinched BOOLEAN, FOREIGN KEY (route) REFERENCES connectedRoutes(firstRoot));\n";
-	for (TravelerList *t : TravelerList::allusers)
-	{	if (t->ccr_values.empty()) continue;
+	for (TravelerList& t : TravelerList::allusers)
+	{	if (t.ccr_values.empty()) continue;
 		sqlfile << "INSERT INTO clinchedConnectedRoutes VALUES\n";
-		auto& traveler_name = t->traveler_name;
 		first = 1;
-		for (auto& rm : t->ccr_values)
+		for (auto& rm : t.ccr_values)
 		{	if (!first) sqlfile << ',';
 			first = 0;
 			sprintf(fstr, "%.17g", rm.second);
-			sqlfile << "('" << rm.first->roots[0]->root << "','" << traveler_name << "','"
+			sqlfile << "('" << rm.first->roots[0]->root << "','" << t.traveler_name << "','"
 				<< fstr << "','" << (rm.second == rm.first->mileage) << "')\n";
 		}
 		sqlfile << ";\n";
@@ -378,16 +373,15 @@ void sqlfile1
 	sqlfile << "CREATE TABLE clinchedRoutes (route VARCHAR(" << DBFieldLength::root
 		<< "), traveler VARCHAR(" << DBFieldLength::traveler
 		<< "), mileage FLOAT, clinched BOOLEAN, FOREIGN KEY (route) REFERENCES routes(root));\n";
-	for (TravelerList *t : TravelerList::allusers)
-	{	if (t->cr_values.empty()) continue;
+	for (TravelerList& t : TravelerList::allusers)
+	{	if (t.cr_values.empty()) continue;
 		sqlfile << "INSERT INTO clinchedRoutes VALUES\n";
-		auto& traveler_name = t->traveler_name;
 		first = 1;
-		for (std::pair<Route*,double>& rm : t->cr_values)
+		for (std::pair<Route*,double>& rm : t.cr_values)
 		{	if (!first) sqlfile << ',';
 			first = 0;
 			sprintf(fstr, "%.17g", rm.second);
-			sqlfile << "('" << rm.first->root << "','" << traveler_name << "','"
+			sqlfile << "('" << rm.first->root << "','" << t.traveler_name << "','"
 				<< fstr << "','" << (rm.second >= rm.first->mileage) << "')\n";
 		}
 		sqlfile << ";\n";

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -330,6 +330,10 @@ int main(int argc, char *argv[])
       #else
 	for (string &t : TravelerList::ids) TravelerList::allusers.push_back(new TravelerList(t, &el));
       #endif
+	if (TravelerList::file_not_found)
+	{	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure .list files for all specified users exist.\nAborting." << endl;
+		return 1;
+	}
 	TravelerList::ids.clear();
 	cout << endl << et.et() << "Processed " << TravelerList::allusers.size() << " traveler list files. Sorting and numbering." << endl;
 	TravelerList::allusers.sort(sort_travelers_by_name);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -79,6 +79,8 @@ int main(int argc, char *argv[])
 		else	el.add_error("Error opening user list file path \""+Args::userlistfilepath+"\". (Not found?)");
 	}
 	else for (string &id : TravelerList::ids) id += ".list";
+	TravelerList::ids.sort();
+	TravelerList::tl_it = TravelerList::allusers.alloc(TravelerList::ids.size());
 
 	// read region, country, continent descriptions
 	cout << et.et() << "Reading region, country, and continent descriptions." << endl;
@@ -321,28 +323,23 @@ int main(int argc, char *argv[])
 
 	#include "tasks/read_updates.cpp"
 
-	// Create a list of TravelerList objects, one per person
+	// Create an array (must be stored sequentially!) of TravelerList objects, one per person
 	cout << et.et() << "Processing traveler list files:" << endl;
-      #ifdef threading_enabled
 	TravelerList::id_it = TravelerList::ids.begin();
+      #ifdef threading_enabled
 	THREADLOOP thr[t] = thread(ReadListThread, t, &list_mtx, &el);
 	THREADLOOP thr[t].join();
       #else
-	for (string &t : TravelerList::ids) TravelerList::allusers.push_back(new TravelerList(t, &el));
+	while (TravelerList::tl_it < TravelerList::allusers.end())
+		new(TravelerList::tl_it++) TravelerList(*TravelerList::id_it++, &el);
+		// placement new
       #endif
 	if (TravelerList::file_not_found)
 	{	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure .list files for all specified users exist.\nAborting." << endl;
 		return 1;
 	}
 	TravelerList::ids.clear();
-	cout << endl << et.et() << "Processed " << TravelerList::allusers.size() << " traveler list files. Sorting and numbering." << endl;
-	TravelerList::allusers.sort(sort_travelers_by_name);
-	// assign traveler numbers for master traveled graph
-	unsigned int travnum = 0;
-	for (TravelerList *t : TravelerList::allusers)
-	{	t->traveler_num[0] = travnum;
-		travnum++;
-	}
+	cout << endl << et.et() << "Processed " << TravelerList::allusers.size << " traveler list files." << endl;
 
 	cout << et.et() << "Clearing route & label hash tables." << endl;
 	Route::root_hash.clear();
@@ -439,7 +436,7 @@ int main(int argc, char *argv[])
 	THREADLOOP for (std::string& entry : augment_lists[t]) concurrencyfile << entry << '\n';
 	delete[] augment_lists;
       #else
-	for (TravelerList *t : TravelerList::allusers)
+	for (TravelerList *t = TravelerList::allusers.data, *end = TravelerList::allusers.end(); t != end; t++)
 	{	cout << '.' << flush;
 		for (HighwaySegment *s : t->clinched_segments)
 		  if (s->concurrent)
@@ -543,8 +540,8 @@ int main(int argc, char *argv[])
 	THREADLOOP thr[t] = thread(UserLogThread, t, &list_mtx, active_only_miles, active_preview_miles);
 	THREADLOOP thr[t].join();
       #else
-	for (TravelerList *t : TravelerList::allusers)
-		t->userlog(active_only_miles, active_preview_miles);
+	for (TravelerList& t : TravelerList::allusers)
+		t.userlog(active_only_miles, active_preview_miles);
       #endif
 	cout << "!" << endl;
 

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -49,6 +49,7 @@ int main(int argc, char *argv[])
 {	ifstream file;
 	string line;
 	mutex list_mtx, term_mtx;
+	ErrorList el;
 
 	// argument parsing
 	if (Args::init(argc, argv)) return 1;
@@ -61,10 +62,8 @@ int main(int argc, char *argv[])
 	time_t timestamp = time(0);
 	cout << "Start: " << ctime(&timestamp);
 
-	// create ErrorList
-	ErrorList el;
-
 	// Get list of travelers in the system
+	cout << et.et() << "Making list of travelers." << endl;
 	TravelerList::ids = move(Args::userlist);
 	if (TravelerList::ids.empty())
 	{	DIR *dir;

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -438,10 +438,11 @@ int main(int argc, char *argv[])
       #else
 	for (TravelerList *t = TravelerList::allusers.data, *end = TravelerList::allusers.end(); t != end; t++)
 	{	cout << '.' << flush;
+		size_t index = t-TravelerList::allusers.data;
 		for (HighwaySegment *s : t->clinched_segments)
 		  if (s->concurrent)
 		    for (HighwaySegment *hs : *(s->concurrent))
-		      if (hs != s && hs->route->system->active_or_preview() && hs->add_clinched_by(t))
+		      if (hs != s && hs->route->system->active_or_preview() && hs->add_clinched_by(index))
 		       	concurrencyfile << "Concurrency augment for traveler " << t->traveler_name << ": [" << hs->str() << "] based on [" << s->str() << "]\n";
 	}
 	cout << '!' << endl;

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -20,7 +20,7 @@ else {	list<Region*> *regions;
 	list<HighwaySystem*> *systems;
 	GraphListEntry::entries.emplace_back('s', graph_data.vertices.size(), graph_data.se, 0);
 	GraphListEntry::entries.emplace_back('c', graph_data.cv, graph_data.ce, 0);
-	GraphListEntry::entries.emplace_back('t', graph_data.tv, graph_data.te, TravelerList::allusers.size());
+	GraphListEntry::entries.emplace_back('t', graph_data.tv, graph_data.te, TravelerList::allusers.size);
 	graph_types.push_back({"master", "All Travel Mapping Data",
 				"These graphs contain all routes currently plotted in the Travel Mapping project."});
 	GraphListEntry::num = 3;

--- a/siteupdate/cplusplus/templates/TMArray.cpp
+++ b/siteupdate/cplusplus/templates/TMArray.cpp
@@ -1,0 +1,23 @@
+#include <cstdlib>
+
+template <class item>
+struct TMArray
+{	item * data;
+	size_t size;
+
+	TMArray(): data(0), size(0) {}
+	~TMArray()
+	{	for (auto& i : *this) i.~item();
+		free(data);
+	}
+
+	item* alloc(size_t s)
+	{	size=s;
+		return data = (item*)aligned_alloc(alignof(item), s*sizeof(item));
+	}
+
+	item& operator[](size_t i)
+			const {return data[i];}
+	item* begin()	const {return data;}
+	item* end()	const {return data+size;}
+};

--- a/siteupdate/cplusplus/templates/TMBitset.cpp
+++ b/siteupdate/cplusplus/templates/TMBitset.cpp
@@ -1,0 +1,87 @@
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+template <class item, class unit> struct TMBImpl;
+
+template <class item, class unit> class TMBitset
+{	size_t const units;
+	size_t const len;
+	item   const start;
+	unit * const data;
+
+	static constexpr size_t ubits = 8*sizeof(unit);
+	friend struct TMBImpl<item,unit>;
+
+	public:
+	TMBitset(item const s, const size_t l):
+	  units(ceil(double(l+1)/ubits)),
+	  len  (l),
+	  start(s),
+	  data ( (unit*const)calloc(units, sizeof(unit)) )
+	{	//create dummy end() item
+		data[len/ubits] |= (unit)1 << len%ubits;
+	}
+
+	~TMBitset() {free(data);}
+
+	bool add_index(size_t const index)
+	{	const unit u = data[index/ubits];
+		data[index/ubits] |= (unit)1 << index%ubits;
+		return u != data[index/ubits];
+	}
+
+	bool operator [] (const size_t index) const {return data[index/ubits] & (unit)1 << index%ubits;}
+
+	// The != and |= operators assume both objects have the
+	// same length, and shall only be used in this context.
+	bool operator != (const TMBitset<item,unit>& other) const {return memcmp(data, other.data, units*sizeof(unit));}
+	void operator |= (const TMBitset<item,unit>& other) {TMBImpl<item,unit>::bitwise_or(*this, other);}
+
+	class iterator
+	{	size_t bit;
+		unit* u;
+		item val;
+		unit bits;
+
+		friend iterator TMBitset::begin() const;
+
+		public:
+		iterator(const TMBitset& b, size_t const i): bit(i%ubits), u(b.data+i/ubits), val(b.start+i), bits(*u) {}
+
+		item const operator * () const {return val;}
+
+		void operator ++ ()
+		{ do {	if (!(bits >>= 1))
+			     {	val += ubits-bit;
+				bit  = 0;
+				bits = *++u;
+			     }
+			else {	++bit;
+				++val;
+			     }
+		     }	while (!(bits&1));
+		}
+
+		bool operator != (iterator& other) const {return val != other.val;}
+	};
+
+	iterator begin() const
+	{	iterator it(*this, 0);
+		if (!(it.bits&1)) ++it;
+		return it;
+	}
+
+	iterator end() const {return iterator(*this, len);}
+};
+
+template <class item> struct TMBImpl<item,uint32_t>
+{	static void bitwise_or(TMBitset<item,uint32_t>& a, const TMBitset<item,uint32_t>& b)
+	{	uint64_t *end = (uint64_t*)(a.data+a.units)-1;
+		uint64_t *d64 = (uint64_t*)a.data;
+		uint64_t *o64 = (uint64_t*)b.data;
+		while (d64 <= end) *d64++ |= *o64++;
+		if (a.units & 1) *(uint32_t*)d64 |= *(uint32_t*)o64;
+	}
+};

--- a/siteupdate/cplusplus/threads/ConcAugThread.cpp
+++ b/siteupdate/cplusplus/threads/ConcAugThread.cpp
@@ -1,16 +1,12 @@
-void ConcAugThread(unsigned int id, std::mutex* tl_mtx, std::vector<std::string>* augment_list)
+void ConcAugThread(unsigned int id, std::mutex* mtx, std::vector<std::string>* augment_list)
 {	//printf("Starting ConcAugThread %02i\n", id); fflush(stdout);
 	while (TravelerList::tl_it != TravelerList::allusers.end())
-	{	tl_mtx->lock();
+	{	mtx->lock();
 		if (TravelerList::tl_it == TravelerList::allusers.end())
-		{	tl_mtx->unlock();
-			return;
-		}
-		TravelerList* t(*TravelerList::tl_it);
-		//printf("ConcAugThread %02i assigned %s\n", id, t->traveler_name.data()); fflush(stdout);
-		TravelerList::tl_it++;
-		//printf("ConcAugThread %02i TravelerList::tl_it++\n", id); fflush(stdout);
-		tl_mtx->unlock();
+			return mtx->unlock();
+		TravelerList* t = TravelerList::tl_it++;
+		mtx->unlock();
+
 		std::cout << '.' << std::flush;
 		for (HighwaySegment *s : t->clinched_segments)
 		  if (s->concurrent)

--- a/siteupdate/cplusplus/threads/ConcAugThread.cpp
+++ b/siteupdate/cplusplus/threads/ConcAugThread.cpp
@@ -7,11 +7,12 @@ void ConcAugThread(unsigned int id, std::mutex* mtx, std::vector<std::string>* a
 		TravelerList* t = TravelerList::tl_it++;
 		mtx->unlock();
 
+		size_t index = t - TravelerList::allusers.data;
 		std::cout << '.' << std::flush;
 		for (HighwaySegment *s : t->clinched_segments)
 		  if (s->concurrent)
 		    for (HighwaySegment *hs : *(s->concurrent))
-		      if (hs != s && hs->route->system->active_or_preview() && hs->add_clinched_by(t))
+		      if (hs != s && hs->route->system->active_or_preview() && hs->add_clinched_by(index))
 		      {	augment_list->push_back("Concurrency augment for traveler " + t->traveler_name + ": [" + hs->str() + "] based on [" + s->str() + ']');
 			// create key/value pairs in regional tables, to be computed in a threadsafe manner later
 			t->active_preview_mileage_by_region[hs->route->region];

--- a/siteupdate/cplusplus/threads/ReadListThread.cpp
+++ b/siteupdate/cplusplus/threads/ReadListThread.cpp
@@ -1,20 +1,14 @@
-void ReadListThread(unsigned int id, std::mutex* tl_mtx, ErrorList* el)
-{	//printf("Starting ReadListThread %02i\n", id); fflush(stdout);
+void ReadListThread(unsigned int num, std::mutex* mtx, ErrorList* el)
+{	//printf("Starting ReadListThread %02i\n", num); fflush(stdout);
 	while (TravelerList::id_it != TravelerList::ids.end())
-	{	tl_mtx->lock();
+	{	mtx->lock();
 		if (TravelerList::id_it == TravelerList::ids.end())
-		{	tl_mtx->unlock();
-			return;
-		}
-		std::string& tl(*TravelerList::id_it);
-		//printf("ReadListThread %02i assigned %s\n", id, tl.data()); fflush(stdout);
-		TravelerList::id_it++;
-		//printf("ReadListThread %02i (*it)++\n", id); fflush(stdout);
-		tl_mtx->unlock();
-		TravelerList *t = new TravelerList(tl, el);
-				  // deleted on termination of program
-		TravelerList::mtx.lock();
-		TravelerList::allusers.push_back(t);
-		TravelerList::mtx.unlock();
+			return mtx->unlock();
+		std::string& id = *TravelerList::id_it++;
+		TravelerList* tl = TravelerList::tl_it++;
+		mtx->unlock();
+
+		new(tl) TravelerList(id, el);
+		// placement new
 	}
 }

--- a/siteupdate/cplusplus/threads/UserLogThread.cpp
+++ b/siteupdate/cplusplus/threads/UserLogThread.cpp
@@ -1,20 +1,12 @@
-void UserLogThread
-(	unsigned int id, std::mutex* mtx,
-	const double total_active_only_miles,
-	const double total_active_preview_miles
-)
+void UserLogThread(unsigned int id, std::mutex* mtx, const double ao_mi, const double ap_mi)
 {	//printf("Starting UserLogThread %02i\n", id); fflush(stdout);
 	while (TravelerList::tl_it != TravelerList::allusers.end())
 	{	mtx->lock();
 		if (TravelerList::tl_it == TravelerList::allusers.end())
-		{	mtx->unlock();
-			return;
-		}
-		TravelerList* t(*TravelerList::tl_it);
-		//printf("UserLogThread %02i assigned %s\n", id, t->traveler_name.data()); fflush(stdout);
-		TravelerList::tl_it++;
-		//printf("UserLogThread %02i TravelerList::tl_it++\n", id); fflush(stdout);
+			return mtx->unlock();
+		TravelerList* t = TravelerList::tl_it++;
 		mtx->unlock();
-		t->userlog(total_active_only_miles, total_active_preview_miles);
+
+		t->userlog(ao_mi, ap_mi);
 	}
 }

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -955,6 +955,19 @@ class HighwaySegment:
             code += "0123456789ABCDEF"[c]
         return code
 
+    def canonical_edge_segment(self):
+        """find canonical segment for HGEdge construction, just in
+        case a devel system is listed earlier in systems.csv"""
+        if self.concurrent is None:
+            return self
+        for s in self.concurrent:
+            if s.route.system.active_or_preview():
+                return s
+        # We should never reach this point, because this function will
+        # only be called on active/preview segments and a concurrent
+        # segment should always be in its own concurrency list.
+        raise Exception
+
 class Route:
     """This class encapsulates the contents of one .csv file line
     that represents a highway within a system and the corresponding
@@ -2296,7 +2309,7 @@ class HighwayGraph:
             counter += 1;
             for r in h.route_list:
                 for s in r.segment_list:
-                    if s.concurrent is None or s == s.concurrent[0]:
+                    if s == s.canonical_edge_segment():
                         self.se += 1
                         HGEdge(s, self)
         self.ce = self.se

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -1721,14 +1721,13 @@ class TravelerList:
                 else:
                     # user log warning for DISCONNECTED_ROUTE errors
                     if r1.con_route.disconnected:
-                        region_set = set()
+                        regions = []
                         for r in r1.con_route.roots:
-                          if r.is_disconnected():
-                            region_set.add(r.region)
-                        region_list = sorted(region_set)
+                          if r.is_disconnected() and r.region not in regions:
+                            regions.append(r.region)
                         log_entry = ''
-                        for r in region_list:
-                          log_entry += r + (':' if r == region_list[-1] else '/')
+                        for r in regions:
+                          log_entry += r + (':' if r == regions[-1] else '/')
                         log_entry += " DISCONNECTED_ROUTE error in " + r1.con_route.readable_name() \
                                   +  ".\n  Please report this error in the Travel Mapping forum" \
                                   +  ".\n  Travels may potentially be shown incorrectly for line: " + line

--- a/siteupdate/python-teresco/siteupdate.py
+++ b/siteupdate/python-teresco/siteupdate.py
@@ -2703,6 +2703,7 @@ args = parser.parse_args()
 
 #
 # Get list of travelers in the system
+print(et.et() + "Making list of travelers.")
 traveler_ids = args.userlist
 traveler_ids = os.listdir(args.userlistfilepath) if traveler_ids is None else (id + ".list" for id in traveler_ids)
 


### PR DESCRIPTION
I believe this is all ready to rock. But if you feel like waiting a few days before merging it all in, no harm there.

This does not address the [Makefile issues](https://github.com/TravelMapping/DataProcessing/issues/591). I want to give that some more thought.
You can `make clean`, or if you don't want to recompile *everything*, `rm threads/threads.d classes/Route/read_wpt.d` (from the `cplusplus/` dir) should be sufficient.

What *is* included?

**Lower impact items:**
* Closes #588
* siteupdate.log timestamp for "Making list of travelers". I've occasionally seen this task take a bit of time after a lot of disk activity or cold boot.
* Closes #525
* Misc. minor cleanup

**Big-ticket items:**
* Implements new `TMArray` & `TMBitset` template classes. More on these below.
* Closes yakra#245.

It's possible this closes some older more obscure issues too (probably in yakra/DataProcessing rather than TravelMapping/DataProcessing). If so I'll close them manually as I come across them.