### PR TITLE
HIDDEN_JUNCTION w/devel data; graph gen out of errorcheck

### DIFF
--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.cpp
@@ -1,4 +1,5 @@
 #include "Datacheck.h"
+#include "../Args/Args.h"
 #include "../ElapsedTime/ElapsedTime.h"
 #include "../ErrorList/ErrorList.h"
 #include "../Route/Route.h"
@@ -40,9 +41,9 @@ std::string Datacheck::str() const
 {	return route->root + ";" + label1 + ";" + label2 + ";" + label3 + ";" + code + ";" + info;
 }
 
-void Datacheck::read_fps(std::string& path, ErrorList &el)
+void Datacheck::read_fps(ErrorList &el)
 {	// read in the datacheck false positives list
-	std::ifstream file(path+"/datacheckfps.csv");
+	std::ifstream file(Args::datapath+"/datacheckfps.csv");
 	std::string line;
 	getline(file, line); // ignore header line
 	while (getline(file, line))
@@ -71,9 +72,9 @@ void Datacheck::read_fps(std::string& path, ErrorList &el)
 	file.close();
 }
 
-void Datacheck::mark_fps(std::string& path, ElapsedTime &et)
+void Datacheck::mark_fps(ElapsedTime &et)
 {	errors.sort();
-	std::ofstream fpfile(path+"/nearmatchfps.log");
+	std::ofstream fpfile(Args::logfilepath+"/nearmatchfps.log");
 	time_t timestamp = time(0);
 	fpfile << "Log file created at: " << ctime(&timestamp);
 	unsigned int counter = 0;
@@ -102,9 +103,9 @@ void Datacheck::mark_fps(std::string& path, ElapsedTime &et)
 	std::cout << et.et() << "Found " << Datacheck::errors.size() << " datacheck errors and matched " << fpcount << " FP entries." << std::endl;
 }
 
-void Datacheck::unmatchedfps_log(std::string& path)
+void Datacheck::unmatchedfps_log()
 {	// write log of unmatched false positives from datacheckfps.csv
-	std::ofstream fpfile(path+"/unmatchedfps.log");
+	std::ofstream fpfile(Args::logfilepath+"/unmatchedfps.log");
 	time_t timestamp = time(0);
 	fpfile << "Log file created at: " << ctime(&timestamp);
 	if (fps.empty()) fpfile << "No unmatched FP entries.\n";
@@ -115,8 +116,8 @@ void Datacheck::unmatchedfps_log(std::string& path)
 	fpfile.close();
 }
 
-void Datacheck::datacheck_log(std::string& path)
-{	std::ofstream logfile(path+"/datacheck.log");
+void Datacheck::datacheck_log()
+{	std::ofstream logfile(Args::logfilepath+"/datacheck.log");
 	time_t timestamp = time(0);
 	logfile << "Log file created at: " << ctime(&timestamp);
 	logfile << "Datacheck errors that have been flagged as false positives are not included.\n";

--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
@@ -74,10 +74,10 @@ class Datacheck
 
 	static std::list<Datacheck> errors;
 	static void add(Route*, std::string, std::string, std::string, std::string, std::string);
-	static void read_fps(std::string&, ErrorList &);
-	static void mark_fps(std::string&, ElapsedTime &);
-	static void unmatchedfps_log(std::string&);
-	static void datacheck_log(std::string&);
+	static void read_fps(ErrorList &);
+	static void mark_fps(ElapsedTime &);
+	static void unmatchedfps_log();
+	static void datacheck_log();
 
 	Datacheck(Route*, std::string, std::string, std::string, std::string, std::string);
 

--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
@@ -28,7 +28,7 @@ class Datacheck
     DISCONNECTED_ROUTE     | adjacent root's expected connection point
     DUPLICATE_COORDS       | coordinate pair
     DUPLICATE_LABEL        |
-    HIDDEN_JUNCTION        | number of incident edges in TM master graph
+    HIDDEN_JUNCTION        | number of unique adjacent point locations
     HIDDEN_TERMINUS        |
     INTERSTATE_NO_HYPHEN   |
     INVALID_FINAL_CHAR     | final character in label
@@ -37,7 +37,7 @@ class Datacheck
     LABEL_LOOKS_HIDDEN     |
     LABEL_LOWERCASE        |
     LABEL_PARENS           |
-    LABEL_SELFREF          |
+    LABEL_SELFREF          | subtype / cause of error (see syserr.php)
     LABEL_SLASHES          |
     LABEL_TOO_LONG         | excess label that can't fit in DB
     LABEL_UNDERSCORES      |

--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
@@ -54,7 +54,7 @@ class Datacheck
     SINGLE_FIELD_LINE      |
     US_LETTER              |
     VISIBLE_DISTANCE       | distance in miles
-    VISIBLE_HIDDEN_COLOC   | hidden point at same coordinates
+    VISIBLE_HIDDEN_COLOC   | 1st hidden point at same coordinates
 
     fp is a boolean indicating whether this has been reported as a
     false positive (would be set to true later)

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
@@ -6,13 +6,6 @@
 std::vector<GraphListEntry> GraphListEntry::entries;
 size_t GraphListEntry::num; // iterator for entries
 
-// master graph constructor
-GraphListEntry::GraphListEntry(char f, unsigned int v, unsigned int e, unsigned int t):
-	root("tm-master"), descr("All Travel Mapping Data"),
-	vertices(v), edges(e), travelers(t),
-	form(f), cat('M') {}
-
-// subgraph constructor
 GraphListEntry::GraphListEntry(std::string r, std::string d, char f, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr):
 	regions(rg), systems(sys), placeradius(pr),
 	root(r), descr(d), form(f), cat(c) {}

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
@@ -29,7 +29,6 @@ class GraphListEntry
 	static size_t num; // iterator for entries
 	std::string tag();
 
-	GraphListEntry(char, unsigned int, unsigned int, unsigned int); // < master graph ctor | v----- subgraph ctor -----v 
 	GraphListEntry(std::string, std::string, char, char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
 	static void add_group(std::string&&,  std::string&&,  char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -77,17 +77,11 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 	{	if (counter % 10000 == 0) std::cout << '.' << std::flush;
 		counter++;
 		if (!w->vertex->visibility)
-		{	// cases with only one edge are flagged as HIDDEN_TERMINUS
-			if (w->vertex->incident_c_edges.size() < 2)
+		{	// <2 edges = HIDDEN_TERMINUS
+			// >2 edges = HIDDEN_JUNCTION
+			// datachecks have been flagged earlier in the program; mark as visible and do not compress
+			if (w->vertex->incident_c_edges.size() != 2)
 			{	w->vertex->visibility = 2;
-				continue;
-			}
-			// if >2 edges, flag HIDDEN_JUNCTION, mark as visible, and do not compress
-			if (w->vertex->incident_c_edges.size() > 2)
-			{	Datacheck::add(w->colocated->front()->route,
-					       w->colocated->front()->label,
-					       "", "", "HIDDEN_JUNCTION", std::to_string(w->vertex->incident_c_edges.size()));
-				w->vertex->visibility = 2;
 				continue;
 			}
 			// construct from vertex this time

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -257,6 +257,10 @@ void HighwayGraph::write_master_graphs_tmg()
 	simplefile.close();
 	collapfile.close();
 	travelfile.close();
+	GraphListEntry* g = GraphListEntry::entries.data();
+	g[0].vertices = vertices.size(); g[0].edges = se; g[0].travelers = 0;
+	g[1].vertices = cv;		 g[1].edges = ce; g[1].travelers = 0;
+	g[2].vertices = tv;		 g[2].edges = te; g[2].travelers = TravelerList::allusers.size;
 }
 
 // write a subset of the data,
@@ -286,9 +290,9 @@ void HighwayGraph::write_subgraphs_tmg
 	}
       #ifdef threading_enabled
 	term->lock();
+      #endif
 	if (g->cat != g[-1].cat)
 		std::cout << '\n' << et->et() << "Writing " << g->category() << " graphs.\n";
-      #endif
 	std::cout << g->tag()
 		  << '(' << mv.size() << ',' << mse.size() << ") "
 		  << '(' << cv_count << ',' << mce.size() << ") "

--- a/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
@@ -26,7 +26,14 @@ void HighwaySystem::route_integrity(ErrorList& el)
 		for (Waypoint& w : r.points)
 		{	if (!w.is_hidden)
 			{	w.label_selfref();
-			}
+				// "visible front" flavored VISIBLE_HIDDEN_COLOC check
+				if (w.colocated && &w == w.colocated->front())
+				  for (auto p = ++w.colocated->begin(), end = w.colocated->end(); p != end; p++)
+				    if ((*p)->is_hidden)
+				    {	Datacheck::add(w.route, w.label, "", "", "VISIBLE_HIDDEN_COLOC", (*p)->root_at_label());
+					break;
+				    }
+			}	// "hidden front" flavored VHC is handled via Waypoint::hidden_junction below
 			else	w.hidden_junction();
 			//#include "unexpected_designation.cpp"
 		}

--- a/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
@@ -13,7 +13,7 @@ void HighwaySystem::route_integrity(ErrorList& el)
 		if (!r.con_route)
 			el.add_error(systemname + ".csv: root " + r.root + " not matched by any connected route root.");
 
-		// datachecks
+		// per-route CSV datachecks
 		#define CSV_LINE r.system->systemname + ".csv#L" + std::to_string(r.index()+2)
 		if (r.abbrev.empty())
 		{	if ( r.banner.size() && !strncmp(r.banner.data(), r.city.data(), r.banner.size()) )
@@ -21,12 +21,18 @@ void HighwaySystem::route_integrity(ErrorList& el)
 		} else	if (r.city.empty())
 			  Datacheck::add(&r, "", "", "", "ABBREV_NO_CITY", CSV_LINE);
 		#undef CSV_LINE
+
+		// per-waypoint colocation-based datachecks
 		for (Waypoint& w : r.points)
 		{	if (!w.is_hidden)
 			{	w.label_selfref();
 			}
+			else	w.hidden_junction();
 			//#include "unexpected_designation.cpp"
 		}
+
+		// Yes, these two loops could be combined into one.
+		// But that performs worse, probably due to increased cache evictions.
 
 		// create label hashes and check for duplicates
 		for (unsigned int index = 0; index < r.points.size; index++)

--- a/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/route_integrity.cpp
@@ -21,7 +21,12 @@ void HighwaySystem::route_integrity(ErrorList& el)
 		} else	if (r.city.empty())
 			  Datacheck::add(&r, "", "", "", "ABBREV_NO_CITY", CSV_LINE);
 		#undef CSV_LINE
-		for (Waypoint& w : r.points) if (!w.is_hidden) w.label_selfref();
+		for (Waypoint& w : r.points)
+		{	if (!w.is_hidden)
+			{	w.label_selfref();
+			}
+			//#include "unexpected_designation.cpp"
+		}
 
 		// create label hashes and check for duplicates
 		for (unsigned int index = 0; index < r.points.size; index++)

--- a/siteupdate/cplusplus/classes/HighwaySystem/unexpected_designation.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/unexpected_designation.cpp
@@ -1,0 +1,14 @@
+/* duplicate the old canonical_waypoint_name-based functionality
+if (w.colocated && w.route->system->active_or_preview())
+{	std::vector<Waypoint*> ap_coloc;
+	for (Waypoint* p : *w.colocated) if (p->route->system->active_or_preview()) ap_coloc.push_back(p);
+	if (ap_coloc.size() == 2)
+	{	Waypoint* other = &w == ap_coloc[1] ? ap_coloc[0] : ap_coloc[1];
+		w.label_references_route(other->route);
+	}
+}//*/
+
+if (w.colocated && w.colocated->size() == 2)
+{	Waypoint* other = &w == w.colocated->back() ? w.colocated->front() : w.colocated->back();
+	w.label_references_route(other->route);
+}

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -268,17 +268,17 @@ bool Waypoint::label_references_route(Route *r)
 {	std::string no_abbrev = r->name_no_abbrev();
 	if ( strncmp(label.data(), no_abbrev.data(), no_abbrev.size()) )
 		return 0;
-	if (label[no_abbrev.size()] == 0 || label[no_abbrev.size()] == '_')
+	const char* c = label.data() + no_abbrev.size();
+	if (*c == 0 || *c == '_')
 		return 1;
-	if ( strncmp(label.data()+no_abbrev.size(), r->abbrev.data(), r->abbrev.size()) )
-	{	/*if (label[no_abbrev.size()] == '/')
-			Datacheck::add(route, label, "", "", "UNEXPECTED_DESIGNATION", label.data()+no_abbrev.size()+1);//*/
+	if ( strncmp(c, r->abbrev.data(), r->abbrev.size()) )
+	{	//if (*c == '/') Datacheck::add(route, label, "", "", "UNEXPECTED_DESIGNATION", c+1);
 		return 0;
 	}
-	if (label[no_abbrev.size() + r->abbrev.size()] == 0 || label[no_abbrev.size() + r->abbrev.size()] == '_')
+	c += r->abbrev.size();
+	if (*c == 0 || *c == '_')
 		return 1;
-	/*if (label[no_abbrev.size() + r->abbrev.size()] == '/')
-		Datacheck::add(route, label, "", "", "UNEXPECTED_DESIGNATION", label.data()+no_abbrev.size()+r->abbrev.size()+1);//*/
+	//if (*c == '/') Datacheck::add(route, label, "", "", "UNEXPECTED_DESIGNATION", c+1);
 	return 0;
 }
 

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -350,9 +350,13 @@ void Waypoint::hidden_junction()
 	if (!colocated || this != colocated->front()) return;
 	std::vector<void*> adjacent;	// Make a list of unique adjacent locations
 	for (Waypoint* w : *colocated)	// before & after every point on this colocation list
-	{
+	{	// Kill 2 birds with 1 stone:
+		// 1.	As with graph vertices where it originated, all colocated points must be
+		//	hidden for the junction to count as hidden for purposes of this datacheck.
+		//	If we find a visible point, return.
+		// 2.	If we do find one, there's our VISIBLE_HIDDEN_COLOC error, so return that.
 		if (!w->is_hidden)
-			return;
+			return Datacheck::add(w->route, w->label, "", "", "VISIBLE_HIDDEN_COLOC", root_at_label());
 		if (w != w->route->points.data) // unless the 1st point in route, add prev point
 			w[-1].add_to_adjacent(adjacent);
 		if (w != &w->route->points.back()) // unless last point in route, add next point

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -47,13 +47,17 @@ class Waypoint
 	bool region_match(std::list<Region*>*);
 	bool system_match(std::list<HighwaySystem*>*);
 	bool label_references_route(Route *);
+
+	// Datacheck helpers
 	Route* coloc_same_number(const char*);
 	Route* coloc_same_designation(const std::string&);
 	Route* self_intersection();
 	bool banner_after_slash(const char*);
 	Route* coloc_banner_matches_abbrev();
+	void add_to_adjacent(std::vector<void*>&);
 
 	// Datacheck
+	void hidden_junction();
 	void invalid_url(const char* const, const char* const);
 	void label_invalid_char();
 	void out_of_bounds(char *);

--- a/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/straightforward_intersection.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/canonical_waypoint_name/straightforward_intersection.cpp
@@ -5,29 +5,26 @@
 // suffixes but otherwise matching route
 // US24@CO21_N&CO21@US24_E would become US24_E/CO21_N
 
-if (ap_coloc.size() == 2)
-{	// check both refs independently, because datachecks are involved
-	bool one_ref_zero = ap_coloc[1]->label_references_route(ap_coloc[0]->route);
-	bool zero_ref_one = ap_coloc[0]->label_references_route(ap_coloc[1]->route);
-	if (one_ref_zero && zero_ref_one)
-	{	std::string newname = ap_coloc[1]->label+'/'+ap_coloc[0]->label;
-		// if this is taken or if name_no_abbrev()s match, attempt to add in abbrevs if there's point in doing so
-		if (ap_coloc[0]->route->abbrev.size() || ap_coloc[1]->route->abbrev.size())
-		{    g->set_mtx[newname.back()].lock();
-		     bool taken = g->vertex_names[newname.back()].count(newname);
-		     g->set_mtx[newname.back()].unlock();
-		     if (taken || ap_coloc[0]->route->name_no_abbrev() == ap_coloc[1]->route->name_no_abbrev())
-		     {	const char *u0 = strchr(ap_coloc[0]->label.data(), '_');
+if (	ap_coloc.size() == 2
+     &&	ap_coloc[1]->label_references_route(ap_coloc[0]->route)
+     &&	ap_coloc[0]->label_references_route(ap_coloc[1]->route)
+   ) {	std::string newname = ap_coloc[1]->label+'/'+ap_coloc[0]->label;
+	// if this is taken or if name_no_abbrev()s match, attempt to add in abbrevs if there's point in doing so
+	if (ap_coloc[0]->route->abbrev.size() || ap_coloc[1]->route->abbrev.size())
+	{	g->set_mtx[newname.back()].lock();
+		bool taken = g->vertex_names[newname.back()].count(newname);
+		g->set_mtx[newname.back()].unlock();
+		if (taken || ap_coloc[0]->route->name_no_abbrev() == ap_coloc[1]->route->name_no_abbrev())
+		{	const char *u0 = strchr(ap_coloc[0]->label.data(), '_');
 			const char *u1 = strchr(ap_coloc[1]->label.data(), '_');
-			std::string newname = (ap_coloc[0]->route->list_entry_name() + (u1 ? u1 : "")) + "/"
+			std::string newname = (ap_coloc[0]->route->list_entry_name() + (u1 ? u1 : "")) + '/'
 					    + (ap_coloc[1]->route->list_entry_name() + (u0 ? u0 : ""));
 			std::string message = "Straightforward_intersection: " + name + " -> " + newname;
 			if (taken) message += " (" + ap_coloc[1]->label+'/'+ap_coloc[0]->label + " already taken)";
 			g->namelog(std::move(message));
 			return newname;
-		     }
 		}
-		g->namelog("Straightforward_intersection: " + name + " -> " + newname);
-		return newname;
 	}
-}
+	g->namelog("Straightforward_intersection: " + name + " -> " + newname);
+	return newname;
+     }

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -205,20 +205,8 @@ void WaypointQuadtree::graph_points(std::vector<Waypoint*>& hi_priority_points, 
 		sw_child->graph_points(hi_priority_points, lo_priority_points);
 	     }
 	else for (Waypoint *w : points)
-	     {	if (w->colocated)
-		{	// skip if not at front of list
-			if (w != w->colocated->front()) continue;
-			// VISIBLE_HIDDEN_COLOC datacheck
-			for (auto p = ++w->colocated->begin(); p != w->colocated->end(); p++)
-			  if ((*p)->is_hidden != w->colocated->front()->is_hidden)
-			  {	if ((*p)->is_hidden)
-					Datacheck::add(w->route, w->label, "", "", "VISIBLE_HIDDEN_COLOC",
-						       (*p)->route->root+"@"+(*p)->label);
-				else	Datacheck::add((*p)->route, (*p)->label, "", "", "VISIBLE_HIDDEN_COLOC",
-						       w->route->root+"@"+w->label);
-				break;
-			  }
-		}
+	     {	// skip if not at front of colocation list
+		if (w->colocated && w != w->colocated->front()) continue;
 		// skip if this point is occupied by only waypoints in devel systems
 		if (!w->is_or_colocated_with_active_or_preview()) continue;
 		// store a colocated list with any devel system entries removed

--- a/siteupdate/cplusplus/functions/sql_file.cpp
+++ b/siteupdate/cplusplus/functions/sql_file.cpp
@@ -425,16 +425,6 @@ void sqlfile1
 		delete[] systemupdate;
 	}
 	sqlfile << ";\n";
-	sqlfile.close();
-      #ifdef threading_enabled
-	term_mtx->lock();
-	std::cout << '\n' << et->et() << "Pause writing database file " << Args::databasename << ".sql.\n" << std::flush;
-	term_mtx->unlock();
-      #endif
-     }
-
-void sqlfile2(ElapsedTime *et, std::list<std::array<std::string,3>> *graph_types)
-{	std::ofstream sqlfile(Args::databasename+".sql", std::ios::app);
 
 	// datacheck errors into the db
       #ifndef threading_enabled
@@ -459,6 +449,16 @@ void sqlfile2(ElapsedTime *et, std::list<std::array<std::string,3>> *graph_types
 		}
 	}
 	sqlfile << ";\n";
+	sqlfile.close();
+      #ifdef threading_enabled
+	term_mtx->lock();
+	std::cout << '\n' << et->et() << "Pause writing database file " << Args::databasename << ".sql.\n" << std::flush;
+	term_mtx->unlock();
+      #endif
+     }
+
+void sqlfile2(ElapsedTime *et, std::list<std::array<std::string,3>> *graph_types)
+{	std::ofstream sqlfile(Args::databasename+".sql", std::ios::app);
 
 	// update graph info in DB if graphs were generated
 	if (!Args::skipgraphs)

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -1,10 +1,10 @@
 // Tab Width = 8
 
-// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2023
+// Travel Mapping Project, Jim Teresco and Eric Bryant, 2015-2024
 /* Code to read .csv and .wpt files and prepare for
 adding to the Travel Mapping Project database.
 
-(c) 2015-2023, Jim Teresco and Eric Bryant
+(c) 2015-2024, Jim Teresco and Eric Bryant
 Original Python version by Jim Teresco, with contributions from Eric Bryant and the TravelMapping team
 C++ translation by Eric Bryant
 

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -1,5 +1,3 @@
-// Build a graph structure out of all highway data in active and
-// preview systems
 cout << et.et() << "Setting up for graphs of highway data." << endl;
 HighwayGraph graph_data(all_waypoints, et);
 
@@ -10,19 +8,8 @@ for (string& line : graph_data.waypoint_naming_log)
 wslogfile.close();
 graph_data.waypoint_naming_log.clear();
 
-// create list of graph information for the DB
-list<array<string,3>> graph_types;
-
 // start generating graphs and making entries for graph DB table
-if (Args::skipgraphs || Args::errorcheck)
-	cout << et.et() << "SKIPPING generation of subgraphs." << endl;
-else {	list<Region*> *regions;
-	list<HighwaySystem*> *systems;
-	GraphListEntry::entries.emplace_back('s', graph_data.vertices.size(), graph_data.se, 0);
-	GraphListEntry::entries.emplace_back('c', graph_data.cv, graph_data.ce, 0);
-	GraphListEntry::entries.emplace_back('t', graph_data.tv, graph_data.te, TravelerList::allusers.size);
-	graph_types.push_back({"master", "All Travel Mapping Data",
-				"These graphs contain all routes currently plotted in the Travel Mapping project."});
+{	// Let's keep these braces here, for easily commenting out subgraph generation when developing waypoint simplification routines
 	GraphListEntry::num = 3;
 
 	cout << et.et() << "Writing master TM graph files." << endl;
@@ -31,30 +18,21 @@ else {	list<Region*> *regions;
 	std::cout << "Collapsed graph has " << graph_data.cv << " vertices, " << graph_data.ce << " edges." << std::endl;
 	std::cout << " Traveled graph has " << graph_data.tv << " vertices, " << graph_data.te << " edges." << std::endl;
 
-      #ifndef threading_enabled
-	graph_data.write_master_graphs_tmg();
-      #else
-	cout << et.et() << "Setting up subgraphs." << endl;
-      #endif
-	HighwaySystem *h, *const sys_end = HighwaySystem::syslist.end();
-	#include "subgraphs/continent.cpp"
-	#include "subgraphs/multisystem.cpp"
-	#include "subgraphs/system.cpp"
-	#include "subgraphs/country.cpp"
-	#include "subgraphs/multiregion.cpp"
-	#include "subgraphs/fullcustom.cpp"
-	#include "subgraphs/region.cpp"
-	#include "subgraphs/area.cpp"
-      #ifdef threading_enabled
 	// write graph vector entries to disk
+      #ifdef threading_enabled
 	thr[0] = thread(MasterTmgThread, &graph_data, &list_mtx, &term_mtx, &all_waypoints, &et);
 	// start at t=1, because MasterTmgThread will spawn another SubgraphThread when finished
 	for (unsigned int t = 1; t < thr.size(); t++)
 	  thr[t] = thread(SubgraphThread, t, &list_mtx, &term_mtx, &graph_data, &all_waypoints, &et);
 	THREADLOOP thr[t].join();
-	cout << '!' << endl;
+      #else
+	for (	graph_data.write_master_graphs_tmg();
+		GraphListEntry::num < GraphListEntry::entries.size();
+		GraphListEntry::num += 3
+	    )	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
       #endif
-     }
+	cout << '!' << endl;
+} //*/
 
 cout << et.et() << "Clearing HighwayGraph contents from memory." << endl;
 graph_data.clear();

--- a/siteupdate/cplusplus/tasks/graph_setup.cpp
+++ b/siteupdate/cplusplus/tasks/graph_setup.cpp
@@ -1,0 +1,15 @@
+list<Region*> *regions;
+list<HighwaySystem*> *systems;
+list<array<string,3>> graph_types; // create list of graph information for the DB
+graph_types.push_back({"master", "All Travel Mapping Data",
+			"These graphs contain all routes currently plotted in the Travel Mapping project."});
+GraphListEntry::add_group("tm-master", "All Travel Mapping Data", 'M', nullptr, nullptr, nullptr);
+HighwaySystem *h, *const sys_end = HighwaySystem::syslist.end();
+#include "subgraphs/continent.cpp"
+#include "subgraphs/multisystem.cpp"
+#include "subgraphs/system.cpp"
+#include "subgraphs/country.cpp"
+#include "subgraphs/multiregion.cpp"
+#include "subgraphs/fullcustom.cpp"
+#include "subgraphs/region.cpp"
+#include "subgraphs/area.cpp"

--- a/siteupdate/cplusplus/tasks/subgraphs/area.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/area.cpp
@@ -1,11 +1,7 @@
 // graphs restricted by place/area - from areagraphs.csv file
-#ifndef threading_enabled
-cout << et.et() << "Creating area data graphs." << endl;
-#endif
 file.open(Args::datapath+"/graphs/areagraphs.csv");
 getline(file, line);  // ignore header line
 
-// add entries to graph vector
 while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
@@ -44,13 +40,5 @@ while (getline(file, line))
 	delete[] cline;
 }
 file.close();
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << '!' << endl;
-#endif
 graph_types.push_back({"area", "Routes Within a Given Radius of a Place",
 		       "These graphs contain all routes currently plotted within the given distance radius of the given place."});

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -1,8 +1,4 @@
-// continent graphs -- any continent with active or preview mileage will be created
-#ifndef threading_enabled
-cout << et.et() << "Creating continent graphs." << endl;
-#endif
-// add entries to graph vector
+// continent graphs - any continent with active or preview mileage will be created
 for (auto c = Region::continents.data(), dummy = c+Region::continents.size()-1; c < dummy; c++)
 {	regions = new list<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
@@ -18,12 +14,4 @@ for (auto c = Region::continents.data(), dummy = c+Region::continents.size()-1; 
 			'C', regions, nullptr, nullptr);
 	     }
 }
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"continent", "Routes Within a Continent", "These graphs contain the routes on a continent."});

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -1,8 +1,4 @@
 // country graphs - we find countries that have regions with active or preview mileage
-#ifndef threading_enabled
-cout << et.et() << "Creating country graphs." << endl;
-#endif
-// add entries to graph vector
 for (auto c = Region::countries.data(), dummy = c+Region::countries.size()-1; c < dummy; c++)
 {	regions = new list<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
@@ -18,14 +14,6 @@ for (auto c = Region::countries.data(), dummy = c+Region::countries.size()-1; c 
 			'c', regions, nullptr, nullptr);
 	     }
 }
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"country", "Routes Within a Single Multi-Region Country",
 		       "These graphs contain the routes within a single country that is composed of multiple regions that contain plotted routes.  " + 
 		       string("Countries consisting of a single region are represented by their regional graph.")});

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -2,10 +2,6 @@
 file.open(Args::datapath+"/graphs/fullcustom.csv");
 if (file.is_open())
 {	getline(file, line);  // ignore header line
-	#ifndef threading_enabled
-	cout << et.et() << "Creating full custom graphs." << endl;
-	#endif
-	// add entries to graph vector
 	while (getline(file, line))
 	{	// parse fullcustom.csv line
 		if (line.empty()) continue;
@@ -95,14 +91,6 @@ if (file.is_open())
 		     }
 	}
 	file.close();
-	#ifndef threading_enabled
-	// write new graph vector entries to disk
-	while (GraphListEntry::num < GraphListEntry::entries.size())
-	{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-		GraphListEntry::num += 3;
-	}
-	cout << "!" << endl;
-	#endif
 	graph_types.push_back({"fullcustom", "Full Custom Graphs",
 	"These graphs can be restricted by any combination of one more more regions and one or more highway systems, and optionally within the given distance radius of a given place."});
 }

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -1,11 +1,7 @@
 // Some additional interesting graphs, the "multiregion" graphs
-#ifndef threading_enabled
-cout << et.et() << "Creating multiregion graphs." << endl;
-#endif
 file.open(Args::datapath+"/graphs/multiregion.csv");
 getline(file, line);  // ignore header line
 
-// add entries to graph vector
 while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
@@ -38,12 +34,4 @@ while (getline(file, line))
 	delete[] cline;
 }
 file.close();
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"multiregion", "Routes Within Multiple Regions", "These graphs contain the routes within a set of regions."});

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -1,11 +1,7 @@
 // Some additional interesting graphs, the "multisystem" graphs
-#ifndef threading_enabled
-cout << et.et() << "Creating multisystem graphs." << endl;
-#endif
 file.open(Args::datapath+"/graphs/multisystem.csv");
 getline(file, line);  // ignore header line
 
-// add entries to graph vector
 while (getline(file, line))
 {	if (line.empty()) continue;
 	vector<char*> fields;
@@ -41,12 +37,4 @@ while (getline(file, line))
 	delete[] cline;
 }
 file.close();
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"multisystem", "Routes Within Multiple Highway Systems", "These graphs contain the routes within a set of highway systems."});

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -1,11 +1,4 @@
-// Graphs restricted by region
-#ifndef threading_enabled
-cout << et.et() << "Creating regional data graphs." << endl;
-#endif
-// We will create graph data and a graph file for each region that includes
-// any active or preview systems
-
-// add entries to graph vector
+// region graphs - for each region with active or preview mileage
 for (Region& region : Region::allregions)
 {	if (region.active_preview_mileage == 0) continue;
 	GraphListEntry::add_group(
@@ -14,12 +7,4 @@ for (Region& region : Region::allregions)
 		new list<Region*>(1, &region), nullptr, nullptr);
 		// deleted @ end of HighwayGraph::write_subgraphs_tmg
 }
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"region", "Routes Within a Single Region", "These graphs contain all routes currently plotted within the given region."});

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -1,13 +1,7 @@
-// Graphs restricted by system - from systemgraphs.csv file
-#ifndef threading_enabled
-cout << et.et() << "Creating system data graphs." << endl;
-#endif
-// We will create graph data and a graph file for only a few interesting
-// systems, as many are not useful on their own
+// system graphs - only a few interesting systems; many aren't useful on their own
 file.open(Args::datapath+"/graphs/systemgraphs.csv");
 getline(file, line);  // ignore header line
 
-// add entries to graph vector
 while (getline(file, line))
 {	for (h = HighwaySystem::syslist.data; h < sys_end; h++)
 	  if (h->systemname == line)
@@ -22,13 +16,5 @@ while (getline(file, line))
 		el.add_error("unrecognized system code "+line+" in systemgraphs.csv");
 }
 file.close();
-#ifndef threading_enabled
-// write new graph vector entries to disk
-while (GraphListEntry::num < GraphListEntry::entries.size())
-{	graph_data.write_subgraphs_tmg(GraphListEntry::num, 0, &all_waypoints, &et, &term_mtx);
-	GraphListEntry::num += 3;
-}
-cout << "!" << endl;
-#endif
 graph_types.push_back({"system", "Routes Within a Single Highway System",
 		       "These graphs contain the routes within a single highway system and are not restricted by region."});


### PR DESCRIPTION
Happy St. Tib's Day!
**TLDR:**
* HIDDEN_JUNCTION datacheck takes data from devel systems into account now.
  I wanted to get this working before doing any work on railway datachecks.
* Datachecks out of graph gen = no more graph gen in errorcheck mode. **Way faster.**
  Plus fixed some errorchecks that weren't done in errorcheck mode before. Oops.

Closes #433
Closes yakra#242

Before we really get rolling, a couple minor commits:

### 1dd4799 label_references_route cleanup
cleans up an obscure canonical_waypoint_name function, making it more readable IMO.
Compiles into slightly fewer machine commands too.
Only tangentially related to the main focus of this pull request.

### 3bcedfc unexpected_designation outside graph gen
There's an unused datacheck I like to uncomment sometimes to see what I can see.
This enables us to keep doing so after 387c99b, while adding support for devel system data, and speeding up CWN a tiny bit.
This commit is used as the basis for future commits' speed comparisons, even though it doesn't affect the same tasks they do.