### PR TITLE
TMBitsets for subgraph membership, etc

### DIFF
--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -7,6 +7,7 @@
 /* k */ bool Args::skipgraphs = 0;
 /* v */ bool Args::mtvertices = 0;
 /* C */ bool Args::mtcsvfiles = 0;
+/* E */ bool Args::edgecounts = 0;
 /* w */ std::string Args::datapath = "../../HighwayData";
 /* s */ std::string Args::systemsfile = "systems.csv";
 /* u */ std::string Args::userlistfilepath = "../../UserData/list_files";
@@ -33,6 +34,7 @@ bool Args::init(int argc, char *argv[])
 		else if ARG(0, "-k", "--skipgraphs")		 skipgraphs = 1;
 		else if ARG(0, "-v", "--mt-vertices")		 mtvertices = 1;
 		else if ARG(0, "-C", "--mt-csvs")		 mtcsvfiles = 1;
+		else if ARG(0, "-E", "--edge-counts")		 edgecounts = 1;
 		else if ARG(0, "-h", "--help")			{show_help(); return 1;}
 		else if ARG(1, "-w", "--datapath")		{datapath	  = argv[++n];}
 		else if ARG(1, "-s", "--systemsfile")		{systemsfile      = argv[++n];}
@@ -81,7 +83,7 @@ void Args::show_help()
 	std::cout  <<  indent << "        [-c CSVSTATFILEPATH] [-g GRAPHFILEPATH] [-k]\n";
 	std::cout  <<  indent << "        [-n NMPMERGEPATH] [-p SPLITREGIONPATH SPLITREGION]\n";
 	std::cout  <<  indent << "        [-U USERLIST [USERLIST ...]] [-t NUMTHREADS] [-e]\n";
-	std::cout  <<  indent << "        [-T TIMEPRECISION] [-v] [-C]\n";
+	std::cout  <<  indent << "        [-T TIMEPRECISION] [-v] [-C] [-E]\n";
 	std::cout  <<  indent << "        [-L COLOCATIONLIMIT] [-N NMPTHRESHOLD]\n";
 	std::cout  <<  "\n";
 	std::cout  <<  "Create SQL, stats, graphs, and log files from highway and user data for the\n";
@@ -124,6 +126,7 @@ void Args::show_help()
 	std::cout  <<  "		        timestamp readouts\n";
 	std::cout  <<  "  -v, --mt-vertices     Multi-threaded vertex construction\n";
 	std::cout  <<  "  -C, --mt-csvs         Multi-threaded stats csv files\n";
+	std::cout  <<  "  -E, --edge-counts     Report the quantity of each format graph edge\n";
 	std::cout  <<  "  -L, --colocationlimit COLOCATIONLIMIT\n";
 	std::cout  <<  "		        Threshold to report colocation counts\n";
 	std::cout  <<  "  -N, --nmp-threshold NMPTHRESHOLD\n";

--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -8,6 +8,7 @@
 /* v */ bool Args::mtvertices = 0;
 /* C */ bool Args::mtcsvfiles = 0;
 /* E */ bool Args::edgecounts = 0;
+/* b */ bool Args::bitsetlogs = 0;
 /* w */ std::string Args::datapath = "../../HighwayData";
 /* s */ std::string Args::systemsfile = "systems.csv";
 /* u */ std::string Args::userlistfilepath = "../../UserData/list_files";
@@ -35,6 +36,7 @@ bool Args::init(int argc, char *argv[])
 		else if ARG(0, "-v", "--mt-vertices")		 mtvertices = 1;
 		else if ARG(0, "-C", "--mt-csvs")		 mtcsvfiles = 1;
 		else if ARG(0, "-E", "--edge-counts")		 edgecounts = 1;
+		else if ARG(0, "-b", "--bitset-logs")		 bitsetlogs = 1;
 		else if ARG(0, "-h", "--help")			{show_help(); return 1;}
 		else if ARG(1, "-w", "--datapath")		{datapath	  = argv[++n];}
 		else if ARG(1, "-s", "--systemsfile")		{systemsfile      = argv[++n];}
@@ -83,7 +85,7 @@ void Args::show_help()
 	std::cout  <<  indent << "        [-c CSVSTATFILEPATH] [-g GRAPHFILEPATH] [-k]\n";
 	std::cout  <<  indent << "        [-n NMPMERGEPATH] [-p SPLITREGIONPATH SPLITREGION]\n";
 	std::cout  <<  indent << "        [-U USERLIST [USERLIST ...]] [-t NUMTHREADS] [-e]\n";
-	std::cout  <<  indent << "        [-T TIMEPRECISION] [-v] [-C] [-E]\n";
+	std::cout  <<  indent << "        [-T TIMEPRECISION] [-v] [-C] [-E] [-b]\n";
 	std::cout  <<  indent << "        [-L COLOCATIONLIMIT] [-N NMPTHRESHOLD]\n";
 	std::cout  <<  "\n";
 	std::cout  <<  "Create SQL, stats, graphs, and log files from highway and user data for the\n";
@@ -127,6 +129,8 @@ void Args::show_help()
 	std::cout  <<  "  -v, --mt-vertices     Multi-threaded vertex construction\n";
 	std::cout  <<  "  -C, --mt-csvs         Multi-threaded stats csv files\n";
 	std::cout  <<  "  -E, --edge-counts     Report the quantity of each format graph edge\n";
+	std::cout  <<  "  -b, --bitset-logs     Write TMBitset RAM use logs for region & system\n";
+	std::cout  <<  "		        vertices & edges\n";
 	std::cout  <<  "  -L, --colocationlimit COLOCATIONLIMIT\n";
 	std::cout  <<  "		        Threshold to report colocation counts\n";
 	std::cout  <<  "  -N, --nmp-threshold NMPTHRESHOLD\n";

--- a/siteupdate/cplusplus/classes/Args/Args.h
+++ b/siteupdate/cplusplus/classes/Args/Args.h
@@ -19,6 +19,7 @@ class Args
 	/* T */ static int timeprecision;
 	/* v */ static bool mtvertices;
 	/* C */ static bool mtcsvfiles;
+	/* E */ static bool edgecounts;
 	/* L */ static int colocationlimit;
 	/* N */ static double nmpthreshold; 
 		static const char* exec;

--- a/siteupdate/cplusplus/classes/Args/Args.h
+++ b/siteupdate/cplusplus/classes/Args/Args.h
@@ -20,6 +20,7 @@ class Args
 	/* v */ static bool mtvertices;
 	/* C */ static bool mtcsvfiles;
 	/* E */ static bool edgecounts;
+	/* b */ static bool bitsetlogs;
 	/* L */ static int colocationlimit;
 	/* N */ static double nmpthreshold; 
 		static const char* exec;

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
@@ -6,11 +6,11 @@
 std::vector<GraphListEntry> GraphListEntry::entries;
 size_t GraphListEntry::num; // iterator for entries
 
-GraphListEntry::GraphListEntry(std::string r, std::string d, char f, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr):
+GraphListEntry::GraphListEntry(std::string r, std::string d, char f, char c, std::vector<Region*> *rg, std::vector<HighwaySystem*> *sys, PlaceRadius *pr):
 	regions(rg), systems(sys), placeradius(pr),
 	root(r), descr(d), form(f), cat(c) {}
 
-void GraphListEntry::add_group(std::string&& r, std::string&& d, char c, std::list<Region*> *rg, std::list<HighwaySystem*> *sys, PlaceRadius *pr)
+void GraphListEntry::add_group(std::string&& r, std::string&& d, char c, std::vector<Region*> *rg, std::vector<HighwaySystem*> *sys, PlaceRadius *pr)
 {	GraphListEntry::entries.emplace_back(r, d, 's', c, rg, sys, pr);
 	GraphListEntry::entries.emplace_back(r, d, 'c', c, rg, sys, pr);
 	GraphListEntry::entries.emplace_back(r, d, 't', c, rg, sys, pr);

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
@@ -1,7 +1,6 @@
 class HighwaySystem;
 class PlaceRadius;
 class Region;
-#include <list>
 #include <string>
 #include <vector>
 
@@ -12,8 +11,8 @@ class GraphListEntry
 	match column names in the "graphs" DB table. */
 	public:
 	// Info for use in threaded subgraph generation. Not used in DB.
-	std::list<Region*> *regions;
-	std::list<HighwaySystem*> *systems;
+	std::vector<Region*> *regions;
+	std::vector<HighwaySystem*> *systems;
 	PlaceRadius *placeradius;
 
 	// Info for the "graphs" DB table
@@ -29,6 +28,6 @@ class GraphListEntry
 	static size_t num; // iterator for entries
 	std::string tag();
 
-	GraphListEntry(std::string, std::string, char, char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
-	static void add_group(std::string&&,  std::string&&,  char, std::list<Region*>*, std::list<HighwaySystem*>*, PlaceRadius*);
+	GraphListEntry(std::string, std::string, char, char, std::vector<Region*>*, std::vector<HighwaySystem*>*, PlaceRadius*);
+	static void add_group(std::string&&,  std::string&&,  char, std::vector<Region*>*, std::vector<HighwaySystem*>*, PlaceRadius*);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -146,7 +146,7 @@ void HGEdge::detach(unsigned char fmt_mask)
 }
 
 // write line to tmg collapsed edge file
-void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems)
+void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems)
 {	file << vertex1->c_vertex_num[threadnum] << ' ' << vertex2->c_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	for (HGVertex *intermediate : intermediate_points)
@@ -157,7 +157,7 @@ void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int th
 }
 
 // write line to tmg traveled edge file
-void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::list<HighwaySystem*> *systems, bool trav, char* code)
+void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems, bool trav, char* code)
 {	file << vertex1->t_vertex_num[threadnum] << ' ' << vertex2->t_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	file << ' ' << (trav ? segment->clinchedby_code(code, threadnum) : "0");
@@ -169,7 +169,7 @@ void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int thr
 }
 
 /* line appropriate for a tmg collapsed edge file, with debug info
-std::string HGEdge::debug_tmg_line(std::list<HighwaySystem*> *systems, unsigned int threadnum)
+std::string HGEdge::debug_tmg_line(std::vector<HighwaySystem*> *systems, unsigned int threadnum)
 {	std::string line = std::to_string(vertex1->c_vertex_num[threadnum]) + " [" + *vertex1->unique_name + "] " \
 			 + std::to_string(vertex2->c_vertex_num[threadnum]) + " [" + *vertex2->unique_name + "] " + label(systems);
 	char fstr[58];

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -9,21 +9,14 @@
 
 HGEdge::HGEdge(HighwaySegment *s)
 {	// initial construction is based on a HighwaySegment
-	written = new char[Args::numthreads];
-		  // deleted by HGEdge::detach
-	// we only need to initialize the first element, for master graphs.
-	// the rest will get zeroed out for each subgraph set.
-	written[0] = 0;
 	vertex1 = s->waypoint1->hashpoint()->vertex;
 	vertex2 = s->waypoint2->hashpoint()->vertex;
 	format = simple | collapsed | traveled;
 	segment_name = s->segment_name();
-	vertex1->incident_s_edges.push_back(this);
-	vertex2->incident_s_edges.push_back(this);
-	vertex1->incident_c_edges.push_back(this);
-	vertex2->incident_c_edges.push_back(this);
-	vertex1->incident_t_edges.push_back(this);
-	vertex2->incident_t_edges.push_back(this);
+	vertex1->incident_edges.push_back(this);
+	vertex2->incident_edges.push_back(this);
+	vertex1->edge_count++;
+	vertex2->edge_count++;
 	// canonical segment, used to reference region and list of travelers
 	// assumption: each edge/segment lives within a unique region
 	// and a 'multi-edge' would not be able to span regions as there
@@ -31,27 +24,11 @@ HGEdge::HGEdge(HighwaySegment *s)
 	segment = s;
 }
 
-HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask)
+HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *e1, HGEdge *e2)
 {	// build by collapsing two existing edges around a common hidden vertex
-	written = new char[Args::numthreads];
-		  // deleted by HGEdge::detach
-	written[0] = 0;
 	format = fmt_mask;
-	// we know there are exactly 2 incident edges, as we
-	// checked for that, and we will replace these two
-	// with the single edge we are constructing here...
-	HGEdge *edge1 = 0;
-	HGEdge *edge2 = 0;
-	if (fmt_mask & collapsed)
-	{	// ...in the compressed graph, and/or...
-		edge1 = vertex->incident_c_edges.front();
-		edge2 = vertex->incident_c_edges.back();
-	}
-	if (fmt_mask & traveled)
-	{	// ...in the traveled graph, as appropriate
-		edge1 = vertex->incident_t_edges.front();
-		edge2 = vertex->incident_t_edges.back();
-	}
+	HGEdge *edge1 = e1;
+	HGEdge *edge2 = e2;
 	// segment names should match as routes should not start or end
 	// nor should concurrencies begin or end at a hidden point
 	if (edge1->segment_name != edge2->segment_name)
@@ -103,46 +80,27 @@ HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask)
 			intermediate_point_string() << " to " << *(vertex2->unique_name) << std::endl;
 	//std::cout << "DEBUG: new " << str() << std::endl;
 
+	// clear format bits of old edges
+	edge1->format &= ~fmt_mask;
+	edge2->format &= ~fmt_mask;
 	// replace edge references at our endpoints with ourself
-	edge1->detach(fmt_mask);
-	edge2->detach(fmt_mask);
-	if (fmt_mask & collapsed)
-	{	vertex1->incident_c_edges.push_back(this);
-		vertex2->incident_c_edges.push_back(this);
-	}
-	if (fmt_mask & traveled)
-	{	vertex1->incident_t_edges.push_back(this);
-		vertex2->incident_t_edges.push_back(this);
-	}
+	if (!edge1->format) edge1->detach();
+	if (!edge2->format) edge2->detach();
+	vertex1->incident_edges.push_back(this);
+	vertex2->incident_edges.push_back(this);
 }
 
-void HGEdge::detach() {return detach(format);}
-void HGEdge::detach(unsigned char fmt_mask)
+void HGEdge::detach()
 {	// detach edge from vertices in graph(s) specified in fmt_mask
-	#define DETACH(v) \
-	  for (std::list<HGEdge*>::iterator e = v.begin(); e != v.end(); e++) \
+	auto detach = [&](std::vector<HGEdge*>& v) \
+	{ for (std::vector<HGEdge*>::iterator e = v.begin(); e != v.end(); e++) \
 	    if (*e == this) \
 	    {	v.erase(e); \
 		break; \
 	    }
-	if (fmt_mask & simple)
-	{	DETACH(vertex1->incident_s_edges)
-		DETACH(vertex2->incident_s_edges)
-	}
-	if (fmt_mask & collapsed)
-	{	DETACH(vertex1->incident_c_edges)
-		DETACH(vertex2->incident_c_edges)
-	}
-	if (fmt_mask & traveled)
-	{	DETACH(vertex1->incident_t_edges)
-		DETACH(vertex2->incident_t_edges)
-	}
-	#undef DETACH
-	format &= ~fmt_mask;
-	if (!format)
-	{	delete[] written;
-		delete this;
-	}
+	};
+	detach(vertex1->incident_edges);
+	detach(vertex2->incident_edges);
 }
 
 // write line to tmg collapsed edge file

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -7,6 +7,8 @@
 #include "../Waypoint/Waypoint.h"
 #include "../../templates/contains.cpp"
 
+HGVertex* HGEdge::v_array;
+
 HGEdge::HGEdge(HighwaySegment *s)
 {	// initial construction is based on a HighwaySegment
 	vertex1 = s->waypoint1->hashpoint()->vertex;
@@ -26,6 +28,7 @@ HGEdge::HGEdge(HighwaySegment *s)
 
 HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *e1, HGEdge *e2)
 {	// build by collapsing two existing edges around a common hidden vertex
+	c_idx = vertex - v_array;
 	format = fmt_mask;
 	HGEdge *edge1 = e1;
 	HGEdge *edge2 = e2;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -14,12 +14,18 @@ class HGEdge
 	HGVertex *vertex1, *vertex2;
 	std::list<HGVertex*> intermediate_points; // if more than 1, will go from vertex1 to vertex2
 	HighwaySegment *segment;
+	uint32_t c_idx; // index of last vertex collapsed, if applicable
+			// no "real" use, only for diagnostics & logging
 	unsigned char format;
 
 	// constants for more human-readable format masks
 	static constexpr unsigned char simple = 1;
 	static constexpr unsigned char collapsed = 2;
 	static constexpr unsigned char traveled = 4;
+
+	// this avoids adding more arguments to the collapse ctor
+	// and adding more ugly code to the collapse routine in the graph ctor
+	static HGVertex* v_array;	// for calculating c_idx
 
 	HGEdge(HighwaySegment *);
 	HGEdge(HGVertex *, unsigned char, HGEdge*, HGEdge*);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -3,6 +3,7 @@ class HighwaySegment;
 class HighwaySystem;
 #include <iostream>
 #include <list>
+#include <vector>
 
 class HGEdge
 {   /* This class encapsulates information needed for a highway graph
@@ -26,9 +27,9 @@ class HGEdge
 
 	void detach();
 	void detach(unsigned char);
-	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*);
-	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::list<HighwaySystem*>*, bool, char*);
-	std::string debug_tmg_line(std::list<HighwaySystem*> *, unsigned int);
+	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*);
+	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
+	std::string debug_tmg_line(std::vector<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -10,7 +10,6 @@ class HGEdge
     edge that can incorporate intermediate points.
     */
 	public:
-	char *written;
 	std::string segment_name;
 	HGVertex *vertex1, *vertex2;
 	std::list<HGVertex*> intermediate_points; // if more than 1, will go from vertex1 to vertex2
@@ -23,10 +22,9 @@ class HGEdge
 	static constexpr unsigned char traveled = 4;
 
 	HGEdge(HighwaySegment *);
-	HGEdge(HGVertex *, unsigned char);
+	HGEdge(HGVertex *, unsigned char, HGEdge*, HGEdge*);
 
 	void detach();
-	void detach(unsigned char);
 	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*);
 	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
 	std::string debug_tmg_line(std::vector<HighwaySystem*> *, unsigned int);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h
@@ -2,7 +2,8 @@ class HGEdge;
 class HighwaySystem;
 class Region;
 class Waypoint;
-#include <list>
+#include <atomic>
+#include <vector>
 #include <string>
 
 class HGVertex
@@ -12,14 +13,18 @@ class HGVertex
 	public:
 	double lat, lng;
 	const std::string *unique_name;
-	std::list<HGEdge*> incident_s_edges; // simple
-	std::list<HGEdge*> incident_c_edges; // collapsed
-	std::list<HGEdge*> incident_t_edges; // traveled
+	std::vector<HGEdge*> incident_edges;
 	int *s_vertex_num;
 	int *c_vertex_num;
 	int *t_vertex_num;
+	uint16_t edge_count;
 	char visibility;
+
+	static std::atomic_uint num_hidden;
 
 	void setup(Waypoint*, const std::string*);
 	~HGVertex();
+
+	HGEdge* front(unsigned char);
+	HGEdge* back (unsigned char);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -4,7 +4,6 @@
 #include "HGVertex.h"
 #include "PlaceRadius.h"
 #include "../Args/Args.h"
-#include "../Datacheck/Datacheck.h"
 #include "../ElapsedTime/ElapsedTime.h"
 #include "../HighwaySegment/HighwaySegment.h"
 #include "../HighwaySystem/HighwaySystem.h"

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -109,6 +109,8 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 		}
 	}
 	std::cout << '!' << std::endl;
+
+	std::cout << et.et() << "Master graph construction complete. Destroying temporary variables." << std::endl;
 } // end ctor
 
 void HighwayGraph::clear()

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -41,6 +41,7 @@ class HighwayGraph
 
 	void namelog(std::string&&);
 	void simplify(int, std::vector<Waypoint*>*, unsigned int*, const size_t);
+	void bitsetlogs(HGVertex*);
 	inline std::pair<std::unordered_set<std::string>::iterator,bool> vertex_name(std::string&);
 	void write_master_graphs_tmg();
 	void write_subgraphs_tmg(size_t, unsigned int, WaypointQuadtree*, ElapsedTime*, std::mutex*);

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -6,6 +6,7 @@ class HighwaySystem;
 class TravelerList;
 class Waypoint;
 class WaypointQuadtree;
+#include "../../templates/TMArray.cpp"
 #include <list>
 #include <mutex>
 #include <unordered_map>
@@ -18,31 +19,29 @@ class HighwayGraph
     data structures representing the highway data.
 
     On construction, build a set of unique vertex names
-    and determine edges, at most one per concurrent segment.
-    Create three sets of edges:
-     - one for the simple graph
-     - one for the collapsed graph with hidden waypoints compressed into multi-point edges
-     - one for the traveled graph: collapsed edges split at endpoints of users' travels
+    and determine edges, at most one per concurrent segment per graph format.
+    Edge objects can be 1 or more of the following per the HGEdge::format bitmask:
+      - in the simple graph
+      - in the collapsed graph with hidden waypoints compressed into multi-point edges
+      - in the traveled graph: collapsed edges split at endpoints of users' travels
+      - in no graph at all for temporary partially-collapsed edges created
+	during the compression process. These stick around taking up
+	space until the HighwayGraph object is destroyed. Mostly harmless.
     */
 
 	public:
-	size_t vbytes;		// number of bytes allocated to each thread in the vbits array
-	unsigned char* vbits;	// bit field to track whether each vertex is included in a given subgraph
 	std::unordered_set<std::string> vertex_names[256];	// unique vertex labels
 	std::list<std::string> waypoint_naming_log;		// to track waypoint name compressions
 	std::mutex set_mtx[256], log_mtx;
-	std::vector<HGVertex> vertices;				// MUST be stored sequentially!
+	std::vector<HGVertex> vertices;				// MUST be stored
+	TMArray<HGEdge> edges;					// sequentially!
 	unsigned int cv, tv, se, ce, te;			// vertex & edge counts
 
 	HighwayGraph(WaypointQuadtree&, ElapsedTime&);
 
-	void clear();
 	void namelog(std::string&&);
 	void simplify(int, std::vector<Waypoint*>*, unsigned int*, const size_t);
 	inline std::pair<std::unordered_set<std::string>::iterator,bool> vertex_name(std::string&);
-	bool subgraph_contains(HGVertex*, const int);
-	void add_to_subgraph(HGVertex*, const int);
-	void clear_vbit(HGVertex*, const int);
 	void write_master_graphs_tmg();
 	void write_subgraphs_tmg(size_t, unsigned int, WaypointQuadtree*, ElapsedTime*, std::mutex*);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.h
@@ -40,7 +40,7 @@ class HighwayGraph
 	HighwayGraph(WaypointQuadtree&, ElapsedTime&);
 
 	void namelog(std::string&&);
-	void simplify(int, std::vector<Waypoint*>*, unsigned int*, const size_t);
+	void simplify(int, std::vector<std::pair<Waypoint*,size_t>>*, unsigned int*);
 	void bitsetlogs(HGVertex*);
 	inline std::pair<std::unordered_set<std::string>::iterator,bool> vertex_name(std::string&);
 	void write_master_graphs_tmg();

--- a/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/PlaceRadius.h
@@ -3,6 +3,7 @@ class HGEdge;
 class HGVertex;
 class HighwayGraph;
 class WaypointQuadtree;
+#include "../../templates/TMBitset.cpp"
 #include <iostream>
 #include <vector>
 
@@ -20,8 +21,7 @@ class PlaceRadius
 
 	PlaceRadius(const char *, const char *, double &, double &, double &);
 
-	bool contains_vertex(HGVertex *);
 	bool contains_vertex(double, double);
-	void vertices(std::vector<HGVertex*>&, WaypointQuadtree *, HighwayGraph *, GraphListEntry&, const int);
-	void v_search(std::vector<HGVertex*>&, WaypointQuadtree *, HighwayGraph *, GraphListEntry&, const int, double, double);
+	void matching_ve(TMBitset<HGVertex*,uint64_t>&, TMBitset<HGEdge*,uint64_t>&, WaypointQuadtree*);
+	void   ve_search(TMBitset<HGVertex*,uint64_t>&, TMBitset<HGEdge*,uint64_t>&, WaypointQuadtree*, double, double);
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
@@ -52,7 +52,7 @@ for (HGVertex *v : mv)
 		  if (!(e->written[threadnum] & HGEdge::traveled) && AREA && REGION && e->segment->system_match(g->systems))
 		  {	mte.push_back(e);
 			e->written[threadnum] |= HGEdge::traveled;
-			traveler_set |= e->segment->clinched_by;
+			traveler_set.fast_union(e->segment->clinched_by);
 		  }
 	    default:
 		for (HGEdge *e : v->incident_s_edges)

--- a/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp
@@ -1,66 +1,71 @@
-// Find a set of vertices from the graph, optionally
+// Find sets of vertices & edges from the graph, optionally
 // restricted by region or system or placeradius area.
-if (g->placeradius)
-	g->placeradius->vertices(mv, qt, this, *g, threadnum);
-else	if (g->regions)
-	{ if (g->systems)
-	  {	// iterate via region & check for a system_match
-		for (Region *r : *g->regions)
-		  for (auto& vw : r->vertices)
-		    if (!subgraph_contains(vw.first, threadnum) && vw.second->system_match(g->systems))
-		    {	mv.push_back(vw.first);
-			add_to_subgraph(vw.first, threadnum);
-		    }
-	  }
-	  else	for (Region *r : *g->regions)
-		  for (auto& vw : r->vertices)
-		    if (!subgraph_contains(vw.first, threadnum))
-		    {	mv.push_back(vw.first);
-			add_to_subgraph(vw.first, threadnum);
-		    }
-	} else	for (HighwaySystem *h : *g->systems)
-		  for (HGVertex* v : h->vertices)
-		    if (!subgraph_contains(v, threadnum))
-		    {	mv.push_back(v);
-			add_to_subgraph(v, threadnum);
-		    }
+auto pr = [&]()
+{	TMBitset<HGVertex*, uint64_t> pr_mv(vertices.data(), vertices.size());
+	TMBitset<HGEdge*,   uint64_t> pr_me(edges.data, edges.size);
+	g->placeradius->matching_ve(pr_mv, pr_me, qt);
+	pr_mv.shrink_to_fit();
+	pr_me.shrink_to_fit();
+	mv &= pr_mv;
+	me &= pr_me;
+};
+if (g->regions)
+     {	auto &r = *g->regions;
+	mv = r[0]->vertices;
+	me = r[0]->edges;
+	for (size_t i = 1; i < r.size(); ++i)
+	{	mv |= r[i]->vertices;
+		me |= r[i]->edges;
+	}
+	if (g->systems)
+	{	auto &h = *g->systems;
+		auto sys_mv(h[0]->vertices);
+		auto sys_me(h[0]->edges);
+		for (size_t i = 1; i < h.size(); ++i)
+		{	sys_mv |= h[i]->vertices;
+			sys_me |= h[i]->edges;
+		}
+		mv &= sys_mv;
+		me &= sys_me;
+	}
+	if (g->placeradius) pr();
+     }
+else if (g->systems)
+     {	auto &h = *g->systems;
+	mv = h[0]->vertices;
+	me = h[0]->edges;
+	for (size_t i = 1; i < h.size(); ++i)
+	{	mv |= h[i]->vertices;
+		me |= h[i]->edges;
+	}
+	if (g->placeradius) pr();
+     }
+else {	// We know there's a PlaceRadius, as no GraphListEntry
+	// is created for invalid fullcustom.csv data
+	mv.alloc(vertices.data(), vertices.size());
+	me.alloc(edges.data, edges.size);
+	g->placeradius->matching_ve(mv, me, qt);
+	mv.shrink_to_fit();
+	me.shrink_to_fit();
+     }
 
-// initialize written booleans
-for (HGVertex *v : mv)
-{	for (HGEdge* e : v->incident_s_edges) e->written[threadnum] = 0;
-	for (HGEdge* e : v->incident_c_edges) e->written[threadnum] = 0;
-	for (HGEdge* e : v->incident_t_edges) e->written[threadnum] = 0;
-}
-
-// Compute sets of edges for subgraphs, optionally
-// restricted by region or system or placeradius.
-// Keep a count of collapsed & traveled vertices as we go.
-#define AREA (!g->placeradius || subgraph_contains(e->vertex1, threadnum) && subgraph_contains(e->vertex2, threadnum))
-#define REGION (!g->regions || contains(*g->regions, e->segment->route->region))
-for (HGVertex *v : mv)
+// count vertices
+for (HGVertex* v : mv)
 {	switch (v->visibility) // fall-thru is a Good Thing!
-	{   case 2:
-		cv_count++;
-		for (HGEdge *e : v->incident_c_edges)
-		  if (!(e->written[threadnum] & HGEdge::collapsed) && AREA && REGION && e->segment->system_match(g->systems))
-		  {	mce.push_back(e);
-			e->written[threadnum] |= HGEdge::collapsed;
-		  }
-	    case 1:
-		tv_count++;
-		for (HGEdge *e : v->incident_t_edges)
-		  if (!(e->written[threadnum] & HGEdge::traveled) && AREA && REGION && e->segment->system_match(g->systems))
-		  {	mte.push_back(e);
-			e->written[threadnum] |= HGEdge::traveled;
-			traveler_set.fast_union(e->segment->clinched_by);
-		  }
-	    default:
-		for (HGEdge *e : v->incident_s_edges)
-		  if (!(e->written[threadnum] & HGEdge::simple) && AREA && REGION && e->segment->system_match(g->systems))
-		  {	mse.push_back(e);
-			e->written[threadnum] |= HGEdge::simple;
-		  }
-	}   clear_vbit(v, threadnum);
+	{	case 2:	 cv_count++;
+		case 1:	 tv_count++;
+		default: sv_count++;
+	}
 }
-#undef AREA
-#undef REGION
+
+// count edges & create traveler set
+for (HGEdge* e : me)
+{	if (e->format & HGEdge::simple)
+		se_count++;
+	if (e->format & HGEdge::collapsed)
+		ce_count++;
+	if (e->format & HGEdge::traveled)
+	{	te_count++;
+		traveler_set.fast_union(e->segment->clinched_by);
+	}
+}

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -90,7 +90,7 @@ const char* HighwaySegment::clinchedby_code(char* code, unsigned int threadnum)
 	return code;
 }
 
-bool HighwaySegment::system_match(std::list<HighwaySystem*>* systems)
+bool HighwaySegment::system_match(std::vector<HighwaySystem*>* systems)
 {	if (!systems) return 1;
 	// devel routes are already excluded from graphs,
 	// so no need to check on non-concurrent segments
@@ -103,7 +103,7 @@ bool HighwaySegment::system_match(std::list<HighwaySystem*>* systems)
 }
 
 // compute an edge label, optionally restricted by systems
-void HighwaySegment::write_label(std::ofstream& file, std::list<HighwaySystem*> *systems)
+void HighwaySegment::write_label(std::ofstream& file, std::vector<HighwaySystem*> *systems)
 {	if (concurrent)
 	     {	bool write_comma = 0;
 		for (HighwaySegment* cs : *concurrent)

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -90,18 +90,6 @@ const char* HighwaySegment::clinchedby_code(char* code, unsigned int threadnum)
 	return code;
 }
 
-bool HighwaySegment::system_match(std::vector<HighwaySystem*>* systems)
-{	if (!systems) return 1;
-	// devel routes are already excluded from graphs,
-	// so no need to check on non-concurrent segments
-	if (!concurrent) return contains(*systems, route->system);
-	for (HighwaySegment *cs : *(concurrent))
-	  // no devel systems should be listed
-	  // in CSVs, so no need for that check
-	  if (contains(*systems, cs->route->system)) return 1;
-	return 0;
-}
-
 // compute an edge label, optionally restricted by systems
 void HighwaySegment::write_label(std::ofstream& file, std::vector<HighwaySystem*> *systems)
 {	if (concurrent)

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -29,7 +29,6 @@ class HighwaySegment
 	// graph generation functions
 	std::string segment_name();
 	const char* clinchedby_code(char*, unsigned int);
-	bool system_match(std::vector<HighwaySystem*>*);
 	void write_label(std::ofstream&, std::vector<HighwaySystem*> *);
 	HighwaySegment* canonical_edge_segment();
 };

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -5,6 +5,7 @@ class Waypoint;
 #include "../../templates/TMBitset.cpp"
 #include <list>
 #include <mutex>
+#include <vector>
 
 class HighwaySegment
 {   /* This class represents one highway segment: the connection between two
@@ -28,7 +29,7 @@ class HighwaySegment
 	// graph generation functions
 	std::string segment_name();
 	const char* clinchedby_code(char*, unsigned int);
-	bool system_match(std::list<HighwaySystem*>*);
-	void write_label(std::ofstream&, std::list<HighwaySystem*> *);
+	bool system_match(std::vector<HighwaySystem*>*);
+	void write_label(std::ofstream&, std::vector<HighwaySystem*> *);
 	HighwaySegment* canonical_edge_segment();
 };

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -13,6 +13,7 @@
 
 TMArray<HighwaySystem> HighwaySystem::syslist;
 HighwaySystem* HighwaySystem::it;
+std::unordered_map<std::string, HighwaySystem*> HighwaySystem::sysname_hash;
 unsigned int HighwaySystem::num_active  = 0;
 unsigned int HighwaySystem::num_preview = 0;
 
@@ -26,12 +27,17 @@ HighwaySystem::HighwaySystem(std::string &line, ErrorList &el)
 	if (NumFields != 6)
 	{	el.add_error("Could not parse " + Args::systemsfile
 			   + " line: [" + line + "], expected 6 fields, found " + std::to_string(NumFields));
-		throw 0xBAD;
+		throw 0xf1e1d5;
 	}
 	// System
 	if (systemname.size() > DBFieldLength::systemName)
 		el.add_error("System code > " + std::to_string(DBFieldLength::systemName)
 			   + " bytes in " + Args::systemsfile + " line " + line);
+	if (!sysname_hash.emplace(systemname, this).second)
+	{	el.add_error("Duplicate system code " + systemname
+			   + " in " + Args::systemsfile + " line " + line);
+		throw 0xc0de;
+	}
 	// CountryCode
 	country = country_or_continent_by_code(country_str, Region::countries);
 	if (!country)

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -65,6 +65,7 @@ HighwaySystem::HighwaySystem(std::string &line, ErrorList &el)
 	{	case 'a': num_active++; break;
 		case 'p': num_preview++;
 	}
+	is_subgraph_system = 0;
 	std::cout /*<< systemname*/ << '.' << std::flush;
 
 	// read chopped routes CSV

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -34,6 +34,7 @@ class HighwaySystem
 	short tier;
 	char level; // 'a' for active, 'p' for preview, 'd' for devel
 
+	bool is_subgraph_system;
 	TMArray<Route> routes;
 	TMArray<ConnectedRoute> con_routes;
       #ifdef Ubuntu_16_04_7_LTS

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -53,6 +53,7 @@ class HighwaySystem
 
 	static TMArray<HighwaySystem> syslist;
 	static HighwaySystem* it;
+	static std::unordered_map<std::string, HighwaySystem*> sysname_hash;
 	static unsigned int num_active;
 	static unsigned int num_preview;
 

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.h
@@ -1,9 +1,11 @@
 class ConnectedRoute;
 class ErrorList;
+class HGEdge;
 class HGVertex;
 class Region;
 class Route;
 #include "../../templates/TMArray.cpp"
+#include "../../templates/TMBitset.cpp"
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -37,17 +39,8 @@ class HighwaySystem
 	bool is_subgraph_system;
 	TMArray<Route> routes;
 	TMArray<ConnectedRoute> con_routes;
-      #ifdef Ubuntu_16_04_7_LTS
-	// If this padding is omitted, compute_stats runs about 76% as fast,
-	// (69% on siteupdateST) with both clang and gcc. ~74-82% the speed
-	// of 79fbeb3 *before* the TMArray conversion. It's not clear why --
-	// while this does pad objects out to 384 bytes, exactly 6 cache lines,
-	// 1. No attempt to over-align the data has been made.
-	// 2. Dropping below 384 B hurts performance, but not going above.
-	// Nonetheless, the benchmarks are clear & consistent.
-	size_t padding;
-      #endif
-	std::vector<HGVertex*> vertices;
+	TMBitset<HGVertex*, uint64_t> vertices;
+	TMBitset<HGEdge*,   uint64_t> edges;
 	std::unordered_map<Region*, double> mileage_by_region;
 	std::unordered_set<std::string>listnamesinuse, unusedaltroutenames;
 	std::mutex mtx;
@@ -67,10 +60,10 @@ class HighwaySystem
 	double total_mileage();		// Return total system mileage across all regions
 	std::string level_name();	// Return full "active" / "preview" / "devel" string
 	void route_integrity(ErrorList& el);
-	void add_vertex(HGVertex*);
 	void stats_csv();
 	void mark_route_in_use(std::string&);
 	void mark_routes_in_use(std::string&, std::string&);
 
 	static void systems_csv(ErrorList&);
+	static void ve_thread(std::mutex* mtx, std::vector<HGVertex>*, TMArray<HGEdge>*);
 };

--- a/siteupdate/cplusplus/classes/Region/Region.h
+++ b/siteupdate/cplusplus/classes/Region/Region.h
@@ -1,8 +1,10 @@
 class ErrorList;
+class HGEdge;
 class HGVertex;
 class Route;
 class Waypoint;
 #include "../../templates/TMArray.cpp"
+#include "../../templates/TMBitset.cpp"
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -45,9 +47,9 @@ class Region
 	double active_only_mileage;
 	double active_preview_mileage;
 	double overall_mileage;
-	std::mutex mtx;
 	std::vector<Route*> routes;
-	std::vector<std::pair<HGVertex*,Waypoint*>> vertices;
+	TMBitset<HGVertex*, uint64_t> vertices;
+	TMBitset<HGEdge*,   uint64_t> edges;
 
 	static TMArray<Region> allregions;
 	static Region* it;
@@ -60,7 +62,7 @@ class Region
 	void compute_stats();
 	std::string &country_code();
 	std::string &continent_code();
-	void add_vertex(HGVertex*, Waypoint*);
 	static void read_csvs(ErrorList&);
 	static void cccsv(ErrorList&, std::string, std::string, size_t, size_t, std::vector<std::pair<std::string, std::string>>&);
+	static void ve_thread(std::mutex* mtx, std::vector<HGVertex>*, TMArray<HGEdge>*);
 };

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -248,22 +248,6 @@ Waypoint* Waypoint::hashpoint()
 	return colocated->front();
 }
 
-bool Waypoint::region_match(std::vector<Region*>* regions)
-{	if (!regions) return 1;
-	if (!colocated) return contains(*regions, route->region);
-	for (Waypoint* w : *colocated)
-	  if (w->route->system->active_or_preview() && contains(*regions, w->route->region)) return 1;
-	return 0;
-}
-
-bool Waypoint::system_match(std::vector<HighwaySystem*>* systems)
-{	if (!systems) return 1;
-	if (!colocated) return contains(*systems, route->system);
-	for (Waypoint* w : *colocated)
-	  if (contains(*systems, w->route->system)) return 1;
-	return 0;
-}
-
 bool Waypoint::label_references_route(Route *r)
 {	std::string no_abbrev = r->name_no_abbrev();
 	if ( strncmp(label.data(), no_abbrev.data(), no_abbrev.size()) )

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -248,7 +248,7 @@ Waypoint* Waypoint::hashpoint()
 	return colocated->front();
 }
 
-bool Waypoint::region_match(std::list<Region*>* regions)
+bool Waypoint::region_match(std::vector<Region*>* regions)
 {	if (!regions) return 1;
 	if (!colocated) return contains(*regions, route->region);
 	for (Waypoint* w : *colocated)
@@ -256,7 +256,7 @@ bool Waypoint::region_match(std::list<Region*>* regions)
 	return 0;
 }
 
-bool Waypoint::system_match(std::list<HighwaySystem*>* systems)
+bool Waypoint::system_match(std::vector<HighwaySystem*>* systems)
 {	if (!systems) return 1;
 	if (!colocated) return contains(*systems, route->system);
 	for (Waypoint* w : *colocated)

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -43,8 +43,6 @@ class Waypoint
 	std::string root_at_label();
 	void nmplogs(std::unordered_set<std::string> &, std::ofstream &, std::list<std::string> &);
 	Waypoint* hashpoint();
-	bool region_match(std::vector<Region*>*);
-	bool system_match(std::vector<HighwaySystem*>*);
 	bool label_references_route(Route *);
 
 	// Datacheck helpers

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -43,8 +43,8 @@ class Waypoint
 	std::string root_at_label();
 	void nmplogs(std::unordered_set<std::string> &, std::ofstream &, std::list<std::string> &);
 	Waypoint* hashpoint();
-	bool region_match(std::list<Region*>*);
-	bool system_match(std::list<HighwaySystem*>*);
+	bool region_match(std::vector<Region*>*);
+	bool system_match(std::vector<HighwaySystem*>*);
 	bool label_references_route(Route *);
 
 	// Datacheck helpers

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -196,13 +196,16 @@ std::list<Waypoint*> WaypointQuadtree::point_list()
 	else	return points;
 }
 
-void WaypointQuadtree::graph_points(std::vector<Waypoint*>& hi_priority_points, std::vector<Waypoint*>& lo_priority_points)
-{	// return a list of points to be used as indices to HighwayGraph vertices
+void WaypointQuadtree::graph_points(VInfoVec& hi_priority_points, VInfoVec& lo_priority_points, size_t& v_idx)
+{	// Populate 2 vectors (hi & lo priority for name simplification) of Waypoint*/index pairs. Elements:
+	// 1st: Waypoint* from which an HGVertex is to be constructed.
+	//	This point receives a pointer to the vertex to enable lookups.
+	// 2nd: The future vertex's index in the HighwayGraph::vertices array.
 	if (refined())
-	     {	ne_child->graph_points(hi_priority_points, lo_priority_points);
-		nw_child->graph_points(hi_priority_points, lo_priority_points);
-		se_child->graph_points(hi_priority_points, lo_priority_points);
-		sw_child->graph_points(hi_priority_points, lo_priority_points);
+	     {	ne_child->graph_points(hi_priority_points, lo_priority_points, v_idx);
+		nw_child->graph_points(hi_priority_points, lo_priority_points, v_idx);
+		se_child->graph_points(hi_priority_points, lo_priority_points, v_idx);
+		sw_child->graph_points(hi_priority_points, lo_priority_points, v_idx);
 	     }
 	else for (Waypoint *w : points)
 	     {	// skip if not at front of colocation list
@@ -218,8 +221,8 @@ void WaypointQuadtree::graph_points(std::vector<Waypoint*>& hi_priority_points, 
 		if (	w->ap_coloc.size() != 2
 		     || w->ap_coloc.front()->route->abbrev.size()
 		     || w->ap_coloc.back()->route->abbrev.size()
-		   )	lo_priority_points.push_back(w);
-		else	hi_priority_points.push_back(w);
+		   )	lo_priority_points.emplace_back(w, v_idx++);
+		else	hi_priority_points.emplace_back(w, v_idx++);
 	     }
 }
 

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.h
@@ -6,6 +6,7 @@ class Waypoint;
 #include <mutex>
 #include <vector>
 
+using VInfoVec = std::vector<std::pair<Waypoint*,size_t>>;
 class WaypointQuadtree
 {	// This class defines a recursive quadtree structure to store
 	// Waypoint objects for efficient geometric searching.
@@ -26,7 +27,7 @@ class WaypointQuadtree
 	std::string str();
 	unsigned int size();
 	std::list<Waypoint*> point_list();
-	void graph_points(std::vector<Waypoint*>&, std::vector<Waypoint*>&);
+	void graph_points(VInfoVec&, VInfoVec&, size_t&);
 	bool is_valid(ErrorList &);
 	unsigned int total_nodes();
 	void get_tmg_lines(std::list<std::string> &, std::list<std::string> &, std::string);

--- a/siteupdate/cplusplus/siteupdate.cpp
+++ b/siteupdate/cplusplus/siteupdate.cpp
@@ -19,6 +19,7 @@ This module defines classes to represent the contents of a
 #include "classes/ElapsedTime/ElapsedTime.h"
 #include "classes/ErrorList/ErrorList.h"
 #include "classes/GraphGeneration/GraphListEntry.h"
+#include "classes/GraphGeneration/HGEdge.h"
 #include "classes/GraphGeneration/HGVertex.h"
 #include "classes/GraphGeneration/HighwayGraph.h"
 #include "classes/GraphGeneration/PlaceRadius.h"

--- a/siteupdate/cplusplus/tasks/graph_generation.cpp
+++ b/siteupdate/cplusplus/tasks/graph_generation.cpp
@@ -35,4 +35,3 @@ graph_data.waypoint_naming_log.clear();
 } //*/
 
 cout << et.et() << "Clearing HighwayGraph contents from memory." << endl;
-graph_data.clear();

--- a/siteupdate/cplusplus/tasks/graph_setup.cpp
+++ b/siteupdate/cplusplus/tasks/graph_setup.cpp
@@ -4,7 +4,6 @@ list<array<string,3>> graph_types; // create list of graph information for the D
 graph_types.push_back({"master", "All Travel Mapping Data",
 			"These graphs contain all routes currently plotted in the Travel Mapping project."});
 GraphListEntry::add_group("tm-master", "All Travel Mapping Data", 'M', nullptr, nullptr, nullptr);
-HighwaySystem *h, *const sys_end = HighwaySystem::syslist.end();
 #include "subgraphs/continent.cpp"
 #include "subgraphs/multisystem.cpp"
 #include "subgraphs/system.cpp"

--- a/siteupdate/cplusplus/tasks/graph_setup.cpp
+++ b/siteupdate/cplusplus/tasks/graph_setup.cpp
@@ -1,5 +1,5 @@
-list<Region*> *regions;
-list<HighwaySystem*> *systems;
+vector<Region*> *regions;
+vector<HighwaySystem*> *systems;
 list<array<string,3>> graph_types; // create list of graph information for the DB
 graph_types.push_back({"master", "All Travel Mapping Data",
 			"These graphs contain all routes currently plotted in the Travel Mapping project."});

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -1,6 +1,6 @@
 // continent graphs - any continent with active or preview mileage will be created
 for (auto c = Region::continents.data(), dummy = c+Region::continents.size()-1; c < dummy; c++)
-{	regions = new list<Region*>;
+{	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for (Region& r : Region::allregions)
 	  // does it match this continent and have routes?

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -1,6 +1,6 @@
 // country graphs - we find countries that have regions with active or preview mileage
 for (auto c = Region::countries.data(), dummy = c+Region::countries.size()-1; c < dummy; c++)
-{	regions = new list<Region*>;
+{	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for (Region& r : Region::allregions)
 	  // does it match this country and have routes?

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -72,16 +72,16 @@ if (file.is_open())
 				      // deleted once system tokens are processed
 			strcpy(field, systemlist.data());
 			for(char* s = strtok(field, ","); s; s = strtok(0, ","))
-			{	for (h = HighwaySystem::syslist.data; h < sys_end; h++)
-				  if (s == h->systemname)
-				  {	systems->push_back(h);
-					break;
-				  }
-				if (h == sys_end)
-				{	el.add_error("unrecognized system code "+string(s)+" in fullcustom.csv line: "+line);
-					ok = 0;
-				}
-			}
+			  try {	HighwaySystem* const h = HighwaySystem::sysname_hash.at(s);
+				if (h->active_or_preview())
+				{	systems->push_back(h);
+					h->is_subgraph_system = 1;
+				} else	el.add_error("devel system "+h->systemname+" in fullcustom.csv line: "+line);
+			      }
+			  catch (const std::out_of_range&)
+			      {	el.add_error("unrecognized system code "+string(s)+" in fullcustom.csv line: "+line);
+				ok = 0;
+			      }
 			delete[] field;
 		     }
 		if (ok)	GraphListEntry::add_group(move(root), move(descr), 'f', regions, systems, a);

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -49,7 +49,7 @@ if (file.is_open())
 
 		// regionlist
 		if (regionlist.empty()) regions = 0;
-		else {	regions = new list<Region*>;
+		else {	regions = new vector<Region*>;
 				  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 			char* field = new char[regionlist.size()+1];
 				      // deleted once region tokens are processed
@@ -66,7 +66,7 @@ if (file.is_open())
 
 		// systemlist
 		if (systemlist.empty()) systems = 0;
-		else {	systems = new list<HighwaySystem*>;
+		else {	systems = new vector<HighwaySystem*>;
 				  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 			char* field = new char[systemlist.size()+1];
 				      // deleted once system tokens are processed

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -21,7 +21,7 @@ while (getline(file, line))
 	if (fields[2]-fields[1] > DBFieldLength::graphFilename-13)
 	  el.add_error("title > " + std::to_string(DBFieldLength::graphFilename-14)
 		     + " bytes in multiregion.csv line: " + line);
-	regions = new list<Region*>;
+	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for(char* rg = strtok(fields[2], ","); rg; rg = strtok(0, ","))
 	  try {	regions->push_back(Region::code_hash.at(rg));

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -21,7 +21,7 @@ while (getline(file, line))
 	if (fields[2]-fields[1] > DBFieldLength::graphFilename-13)
 	  el.add_error("title > " + std::to_string(DBFieldLength::graphFilename-14)
 		     + " bytes in multisystem.csv line: " + line);
-	systems = new list<HighwaySystem*>;
+	systems = new vector<HighwaySystem*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for(char* s = strtok(fields[2], ","); s; s = strtok(0, ","))
 	  try {	HighwaySystem* const h = HighwaySystem::sysname_hash.at(s);

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -24,14 +24,15 @@ while (getline(file, line))
 	systems = new list<HighwaySystem*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	for(char* s = strtok(fields[2], ","); s; s = strtok(0, ","))
-	{	for (h = HighwaySystem::syslist.data; h < sys_end; h++)
-		  if (s == h->systemname)
-		  {	systems->push_back(h);
-			break;
-		  }
-		if (h == sys_end)
-			el.add_error("unrecognized system code "+string(s)+" in multisystem.csv line: "+line);
-	}
+	  try {	HighwaySystem* const h = HighwaySystem::sysname_hash.at(s);
+		if (h->active_or_preview())
+		{	systems->push_back(h);
+			h->is_subgraph_system = 1;
+		} else	el.add_error("devel system "+h->systemname+" in multisystem.csv line: "+line);
+	      }
+	  catch (const std::out_of_range&)
+	      {	el.add_error("unrecognized system code "+string(s)+" in multisystem.csv line: "+line);
+	      }
 	if (systems->size()) GraphListEntry::add_group(fields[1], fields[0], 'S', nullptr, systems, nullptr);
 	else delete systems;
 	delete[] cline;

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -4,7 +4,7 @@ for (Region& region : Region::allregions)
 	GraphListEntry::add_group(
 		region.code + "-region",
 		region.name + " (" + region.type + ")", 'r',
-		new list<Region*>(1, &region), nullptr, nullptr);
+		new vector<Region*>(1, &region), nullptr, nullptr);
 		// deleted @ end of HighwayGraph::write_subgraphs_tmg
 }
 graph_types.push_back({"region", "Routes Within a Single Region", "These graphs contain all routes currently plotted within the given region."});

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -3,18 +3,19 @@ file.open(Args::datapath+"/graphs/systemgraphs.csv");
 getline(file, line);  // ignore header line
 
 while (getline(file, line))
-{	for (h = HighwaySystem::syslist.data; h < sys_end; h++)
-	  if (h->systemname == line)
-	  {	GraphListEntry::add_group(
-			h->systemname + "-system",
-			h->systemname + " (" + h->fullname + ")",
-			's', nullptr, new list<HighwaySystem*>(1, h), nullptr);
-				      // deleted @ end of HighwayGraph::write_subgraphs_tmg
-		break;
-	  }
-	if (h == sys_end)
-		el.add_error("unrecognized system code "+line+" in systemgraphs.csv");
-}
+  try {	HighwaySystem* const h = HighwaySystem::sysname_hash.at(line);
+	if (h->active_or_preview())
+	{   GraphListEntry::add_group(
+		h->systemname + "-system",
+		h->systemname + " (" + h->fullname + ")",
+		's', nullptr, new list<HighwaySystem*>(1, h), nullptr);
+			      // deleted @ end of HighwayGraph::write_subgraphs_tmg
+	    h->is_subgraph_system = 1;
+	} else el.add_error("devel system "+h->systemname+" in systemgraphs.csv");
+      }
+  catch (const std::out_of_range&)
+      {	el.add_error("unrecognized system code "+line+" in systemgraphs.csv");
+      }
 file.close();
 graph_types.push_back({"system", "Routes Within a Single Highway System",
 		       "These graphs contain the routes within a single highway system and are not restricted by region."});

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -8,7 +8,7 @@ while (getline(file, line))
 	{   GraphListEntry::add_group(
 		h->systemname + "-system",
 		h->systemname + " (" + h->fullname + ")",
-		's', nullptr, new list<HighwaySystem*>(1, h), nullptr);
+		's', nullptr, new vector<HighwaySystem*>(1, h), nullptr);
 			      // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	    h->is_subgraph_system = 1;
 	} else el.add_error("devel system "+h->systemname+" in systemgraphs.csv");

--- a/siteupdate/cplusplus/templates/TMBitset.cpp
+++ b/siteupdate/cplusplus/templates/TMBitset.cpp
@@ -1,65 +1,201 @@
+#ifndef TMBITSET
+#define TMBITSET
+
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <utility>
 
-template <class item, class unit> struct TMBImpl;
+template <class unit> struct TMBImpl;
 
 template <class item, class unit> class TMBitset
-{	size_t const units;
-	size_t const len;
-	item   const start;
-	unit * const data;
+{	size_t units;
+	size_t len;
+	item   start;
+	unit * data;
 
 	static constexpr size_t ubits = 8*sizeof(unit);
-	friend struct TMBImpl<item,unit>;
+	static const unit null_datum; // constexpr inline under C++17
 
 	public:
-	TMBitset(item const s, const size_t l):
-	  units(ceil(double(l+1)/ubits)),
-	  len  (l),
-	  start(s),
-	  data ( (unit*const)calloc(units, sizeof(unit)) )
-	{	//create dummy end() item
-		data[len/ubits] |= (unit)1 << len%ubits;
+	TMBitset(): units(1), len(0), start(0), data((unit*)&null_datum) {}
+	TMBitset(item const s, const size_t l) {alloc(s,l);}
+	TMBitset(const TMBitset<item,unit>& other) {*this = other;}
+	~TMBitset() {if (data != &null_datum) free(data);}
+
+	// Does not free resources. Only call on
+	// unallocated objects or manually free beforehand.
+	void operator = (const TMBitset<item,unit>& other)
+	{	units = other.units;
+		len   = other.len;
+		start = other.start;
+		data  = (unit*)malloc(units*sizeof(unit));
+		memcpy(data, other.data, units*sizeof(unit));
 	}
 
-	~TMBitset() {free(data);}
+	// Does not free resources. Only intended for
+	// post-facto setup of default-constructed objects.
+	void alloc(item const s, const size_t l)
+	{	units = ceil(double(l+1)/ubits);
+		len   = l;
+		start = s;
+		data  = (unit*)calloc(units, sizeof(unit));
+		//create dummy end() item
+		data[units-1] |= (unit)1 << len%ubits;
+	}
 
+	// Don't clear null sets; there's nothing to free.
+	void clear()
+	{	units=1; len=0; start=0;
+		free(data);
+		data=(unit*)&null_datum;
+	}
+
+	// No bounds checking. No testing for null sets.
+	// Only to be used with properly allocated sets.
+	bool add_value(item   const value) {return add_index(value-start);}
 	bool add_index(size_t const index)
 	{	const unit u = data[index/ubits];
 		data[index/ubits] |= (unit)1 << index%ubits;
 		return u != data[index/ubits];
 	}
 
+	// For use when both sets' start & len are known to match, e.g. HighwaySegmwent::clinched_by
+	void fast_union(const TMBitset<item,unit>& other) {TMBImpl<unit>::bitwise_oreq(data, other.data, units);}
+
+	// return an end() index (one past the last 1 bit in the set) for shrink_to_fit()
+	size_t end_index() const
+	{	long u = units-1;
+		if (unit bits = data[u] ^ unit(1) << len%ubits) // copy sans end() bit
+			return u*ubits + 64 - __builtin_clzl(bits);
+		while (--u >= 0)
+		    if (data[u])
+			return u*ubits + 64 - __builtin_clzl(data[u]);
+		return 0;
+	}
+
+	void shrink_to_fit()
+	{	if (!len) return;
+		unit* const old_data = data;
+		size_t lo_index = *ibegin() & ~(ubits-1);
+
+		start += lo_index;
+		len = end_index() - lo_index;
+		units = ceil(double(len+1)/ubits);
+		data = (unit*)malloc(units*sizeof(unit));
+
+		memcpy(data, old_data+lo_index/ubits, units*sizeof(unit));
+		free(old_data);
+		//create dummy end() item
+		data[units-1] |= (unit)1 << len%ubits;
+	}
+
 	bool operator [] (const size_t index) const {return data[index/ubits] & (unit)1 << index%ubits;}
 
-	// The != and |= operators assume both objects have the
-	// same length, and shall only be used in this context.
+	// The != operator assumes both objects have the same start & length, and shall only be used in this context.
 	bool operator != (const TMBitset<item,unit>& other) const {return memcmp(data, other.data, units*sizeof(unit));}
-	void operator |= (const TMBitset<item,unit>& other) {TMBImpl<item,unit>::bitwise_or(*this, other);}
 
-	class iterator
+	void operator |= (const TMBitset<item,unit>& b)
+	{	if (!b.len) return;
+		if (!len)
+		{	if (data != &null_datum) free(data);
+			*this = b;
+			return;
+		}
+		item   const a_end = start + len;
+		item   const b_end = b.start + b.len;
+		size_t const old_l = len;
+		size_t const old_u = units;
+		unit * const old_d = data;
+		size_t copy_offset, oreq_offset;
+
+		if (start > b.start)
+		     {	oreq_offset = start-b.start;
+			if (oreq_offset % ubits) throw std::make_pair(this, &b);
+			oreq_offset /= ubits;
+			copy_offset = 0;
+			start = b.start;
+		     }
+		else {	copy_offset = b.start-start;
+			if (copy_offset % ubits) throw std::make_pair(this, &b);
+			copy_offset /= ubits;
+			oreq_offset = 0;
+		     }
+		len = (a_end > b_end ? a_end : b_end) - start;
+		units = ceil(double(len+1)/ubits);
+		data = (unit*)calloc(units, sizeof(unit));
+
+		memcpy(data+copy_offset, b.data, b.units*sizeof(unit));
+		if (a_end < b_end) // clear lower end() bit
+			old_d[old_u-1] ^= (unit)1 << old_l%ubits;
+		else	data[b.units+copy_offset-1] ^= (unit)1 << b.len%ubits;
+		TMBImpl<unit>::bitwise_oreq(data+oreq_offset, old_d, old_u);
+		free(old_d);
+	}
+
+	void operator &= (const TMBitset<item,unit>& b)
+	{	if (!len)   return;
+		if (!b.len) return clear();
+		item   const a_end = start + len;
+		item   const b_end = b.start + b.len;
+		size_t const old_l = len;
+		unit * const old_d = data;
+		size_t copy_offset, band_offset;
+
+		if (start < b.start)
+		     {	band_offset = b.start-start;
+			if (band_offset % ubits) throw std::make_pair(this, &b);
+			band_offset /= ubits;
+			copy_offset = 0;
+			start = b.start;
+		     }
+		else {	copy_offset = start-b.start;
+			if (copy_offset % ubits) throw std::make_pair(this, &b);
+			copy_offset /= ubits;
+			band_offset = 0;
+		     }
+		item new_end = a_end < b_end ? a_end : b_end;
+		if ( new_end < start ) return clear();
+		len = new_end - start;
+		units = ceil(double(len+1)/ubits);
+		data = (unit*)calloc(units, sizeof(unit));
+
+		memcpy(data, b.data+copy_offset, units*sizeof(unit));
+		if (a_end > b_end) // clear higher end() bit
+			old_d[old_l/ubits] ^= (unit)1 << old_l%ubits;
+		else if (b.units == units) // if it's in the new dataset's range
+			   data[b.units-1] ^= (unit)1 << b.len%ubits;
+		TMBImpl<unit>::bitwise_andeq(data, old_d+band_offset, units);
+		free(old_d);
+		//create dummy end() item
+		data[units-1] |= (unit)1 << len%ubits;
+	}
+
+	template <class deref> class iterator
 	{	size_t bit;
 		unit* u;
-		item val;
+		deref val;
 		unit bits;
 
-		friend iterator TMBitset::begin() const;
+		friend iterator<item>	TMBitset::begin() const;
+		friend iterator<size_t>	TMBitset::ibegin() const;
 
 		public:
-		iterator(const TMBitset& b, size_t const i): bit(i%ubits), u(b.data+i/ubits), val(b.start+i), bits(*u) {}
+		iterator(unit* const d, deref const s, size_t const i): bit(i%ubits), u(d+i/ubits), val(s+i), bits(*u) {}
 
-		item const operator * () const {return val;}
+		deref const operator * () const {return val;}
 
 		void operator ++ ()
-		{ do {	if (!(bits >>= 1))
+		{ do {	if (!(bits &= ~(unit)1))
 			     {	val += ubits-bit;
 				bit  = 0;
 				bits = *++u;
 			     }
-			else {	++bit;
-				++val;
+			else {	auto tz = __builtin_ctzl(bits);
+				bit += tz;
+				val += tz;
+				bits >>= tz;
 			     }
 		     }	while (!(bits&1));
 		}
@@ -67,21 +203,59 @@ template <class item, class unit> class TMBitset
 		bool operator != (iterator& other) const {return val != other.val;}
 	};
 
-	iterator begin() const
-	{	iterator it(*this, 0);
+	iterator<item> begin() const
+	{	iterator<item> it(data, start, 0);
 		if (!(it.bits&1)) ++it;
 		return it;
 	}
+	iterator<item> end() const {return iterator<item>(data, start, len);}
 
-	iterator end() const {return iterator(*this, len);}
-};
+	iterator<size_t> ibegin() const
+	{	iterator<size_t> it(data, 0, 0);
+		if (!(it.bits&1)) ++it;
+		return it;
+	}
+	iterator<size_t> iend() const {return iterator<size_t>(data, 0, len);}
 
-template <class item> struct TMBImpl<item,uint32_t>
-{	static void bitwise_or(TMBitset<item,uint32_t>& a, const TMBitset<item,uint32_t>& b)
-	{	uint64_t *end = (uint64_t*)(a.data+a.units)-1;
-		uint64_t *d64 = (uint64_t*)a.data;
-		uint64_t *o64 = (uint64_t*)b.data;
-		while (d64 <= end) *d64++ |= *o64++;
-		if (a.units & 1) *(uint32_t*)d64 |= *(uint32_t*)o64;
+	// diagnostics, debug, etc.
+	bool is_null_set() {return data == &null_datum;}
+
+	size_t count()
+	{	size_t count = 0;
+		for (unit *d = data, *e = d+units; d < e; ++d)
+			count += __builtin_popcountl(*d);
+		return	count-1;
+	}
+
+	size_t heap()	  {return sizeof(unit) * units;}
+	size_t vec_size() {return sizeof(item) * count();}
+	size_t vec_cap()
+	{	size_t c = count();
+		size_t res = c & size_t(-1) << (63-__builtin_clzl(c));
+		if (c^res) res <<= 1;
+		return sizeof(item) * res;
 	}
 };
+
+// Not necessary under C++17; just use a constexpr
+template <class item, class unit> const unit TMBitset<item, unit>::null_datum = 1;
+
+template <> struct TMBImpl<uint32_t>
+{	static void bitwise_oreq(uint32_t* a, const uint32_t* const b, size_t units)
+	{	uint64_t *end = (uint64_t*)(a+units)-1;
+		uint64_t *d64 = (uint64_t*)a;
+		uint64_t *o64 = (uint64_t*)b;
+		while (d64 <= end) *d64++ |= *o64++;
+		if (units & 1) *(uint32_t*)d64 |= *(uint32_t*)o64;
+	}
+};
+
+template <> struct TMBImpl<uint64_t>
+{	static void bitwise_oreq(uint64_t* a, const uint64_t* b, size_t units)
+	{	for (uint64_t *end = a+units; a < end; *a++ |= *b++);
+	}
+	static void bitwise_andeq(uint64_t* a, const uint64_t* b, size_t units)
+	{	for (uint64_t *end = a+units; a < end; *a++ &= *b++);
+	}
+};
+#endif


### PR DESCRIPTION
* Closes #616.
* Closes #621.
* Closes #614.
* Closes yakra#269.
* Closes yakra#95.
* Closes yakra#265.
* Closes yakra#254.
* Closes yakra#251.

@jteresco, I'd recommend to be absolutely safe, downloading & doing a MacOS/XCode compile ([warnings](https://github.com/TravelMapping/DataProcessing/issues/585) notwithstanding) before merging this, due to using a few clang builtins.

### What's this about?
Taking care of a couple errorcheck items (#614, #621) along the way, the main focus here is implementing some long-planned speed improvements for graph generation.
A couple extra steps in the HighwayGraph ctor populate sets of vertex & edge pointers for each region & system in a subgraph.
When writing the subgraphs, we quickly populate vertex & edge sets via the magic of `|=` and (for fullcustom graphs) `&=`.
No more of [this clunky](https://github.com/TravelMapping/DataProcessing/blob/fd96ac64ba2eff23600e86df8dcc84e94cb0a916/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp#L40-L64) iterating through vectors, chasing pointers around, checking membership with ad-hoc bitmasks, and populating more vectors.
Edges in particular benefit. There used to be [3 lists of incident edges](https://github.com/TravelMapping/DataProcessing/blob/fd96ac64ba2eff23600e86df8dcc84e94cb0a916/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h#L15-L17) for each vertex and [3 vectors of matching edges](https://github.com/TravelMapping/DataProcessing/blob/fd96ac64ba2eff23600e86df8dcc84e94cb0a916/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp#L281) for each subgraph. Simple, collapsed, traveled. Now, there's [1 vector](https://github.com/TravelMapping/DataProcessing/blob/32829211cd8f93bb26a76d8ac339e4c454168a55/siteupdate/cplusplus/classes/GraphGeneration/HGVertex.h#L16) and [1 TMBitset](https://github.com/TravelMapping/DataProcessing/blob/32829211cd8f93bb26a76d8ac339e4c454168a55/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp#L424).
No more redundantly checking an edge for membership 2, 4 or 6 times. It's *just there* in the TMBitset.
(The redundancy is limited to 2 checks, one for each vertex, back in the ctor when the region/system sets are populated.)
From here, we iterate 1 container, not 3, and write each edge's info to the simple, collapsed, or traveled files per its `format` bits.
HGVertex & HGedge objects are more lightweight, and they mey get smaller in the future too.

**What does it *not* do?**
This doesn't reach the goal of getting FreeBSD to scale gracefully to more threads ([next pull request](https://github.com/TravelMapping/DataProcessing/issues/585#issuecomment-2106346470)) but still yields a significant additional improvement.

### Nota Bene:
In d218c4d, [Region::ve_thread](https://github.com/TravelMapping/DataProcessing/commit/d218c4d7639d4370d9e8c44f59bacdf5495a91e4?diff=split&w=0#diff-725206f9efb720527dea3da0107c674f344f4dbe7649e00f5c86f4fb27f0d95bR76-R85) introduces some diffs to graphs, omitting 5 points in 4 graphs in 3 regions.
**TLDR:** When a location at a border contains only devel points in Region A and active/preview points only in Region B:
• **Before:** The vertex is included in A's region graph, and any 2+region graphs that include Region A but not B.
• **After:** The vertex is omitted from these graphs.
More details, including a list of the affected points & graphs, at https://github.com/yakra/DataProcessing/issues/265#issuecomment-2033378755.
I believe this is The Right Thing To Do.

### Misc. facts:
* I switched to the C++17 standard for a bit when some changes caused some weird behavior by the compiler & linking errors, and added in some C++17 syntactic sugar including structured bindings.
  Later, some last-minute optimizations removed the need to do this, so I reverted those commits, allowing us to continue to build siteupdate using older toolchains.
* 71 commits (69 if we don't count 2 that only reverted C++17 changes) got squashed down to 9.
* *Lambdas!* Lambdas are one of my new favorite things. [#617](https://github.com/TravelMapping/DataProcessing/pull/617) had the 1st one; [the 2nd](https://github.com/TravelMapping/DataProcessing/blob/fd96ac64ba2eff23600e86df8dcc84e94cb0a916/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp#L128-L139) was in [#619](https://github.com/TravelMapping/DataProcessing/pull/619).
  This pull request introduces 7 more:
  * [one to populate vertex & edge TMBitsets from a PlaceRadius](https://github.com/TravelMapping/DataProcessing/blob/32829211cd8f93bb26a76d8ac339e4c454168a55/siteupdate/cplusplus/classes/GraphGeneration/get_subgraph_data.cpp#L3-L11)
  * [one to detach temporary partially-collapsed edges from vertices during edge compression](https://github.com/TravelMapping/DataProcessing/blob/32829211cd8f93bb26a76d8ac339e4c454168a55/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp#L98-L104)
  * ...Then there's the new optional TMBitset logs. 5 new lambdas here, including 2 lambdas *within* a lambda because `niram` has only one edge in the entire system.
* TMBitset.cpp has tripled in size (that'd make a good [John Lennon](https://www.youtube.com/watch?v=EX7roXRmkOU) parody), 87 -> 261 lines.
* Getting all the HGEdge objects into contiguous storage ended up a lot simpler than [originally conceptualized](https://github.com/TravelMapping/DataProcessing/issues/518#issuecomment-1418233143). No need to make `new` objects on the heap & come up with clever ways to track & delete them if I can just emplace them in a temporary container like a `std::list` which goes out of scope at the end of the HighwayGraph ctor. I ultimately decided to do away with the temporary container and moves entirely, and just store all the edges, including the "dead" ones, in a TMArray. The cost of copying all the edges & then destroying the temporary container outweighed the benefit of keeping the HGEdge TMBitsets absolutely minimized and free of extraneous 0s. [TMBitset iteration is pretty efficient now](https://github.com/TravelMapping/DataProcessing/commit/a5c60b88efba28faa7522448ce812c29b70970bb#diff-f357887f8771cdd6d83cb932dd1b16acbc479e4fb8503a9f36bedf7d87fc4aefL55-R201), and the extra 0s don't hurt much.
* [I considered sorting](https://github.com/TravelMapping/DataProcessing/issues/518#issuecomment-2051026759) edges after construction in order to defragment their TMBitsets, but that took up more time (0.7 s on BiggaTomato) than it saved.
 Skipping the sorting optimizes for speed though not RAM use, and leaves open the possibility of finding clever ways to reorder edge construction in the future.