### PR TITLE
#585 phase 1

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -107,25 +107,21 @@ void HGEdge::detach()
 }
 
 // write line to tmg collapsed edge file
-void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems)
+void HGEdge::collapsed_tmg_line(std::ofstream& file, unsigned int threadnum, std::vector<HighwaySystem*> *systems)
 {	file << vertex1->c_vertex_num[threadnum] << ' ' << vertex2->c_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	for (HGVertex *intermediate : intermediate_points)
-	{	sprintf(fstr, " %.15g %.15g", intermediate->lat, intermediate->lng);
-		file << fstr;
-	}
+		file << ' ' << intermediate->lat << ' ' << intermediate->lng;
 	file << '\n';
 }
 
 // write line to tmg traveled edge file
-void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems, bool trav, char* code)
+void HGEdge::traveled_tmg_line(std::ofstream& file, unsigned int threadnum, std::vector<HighwaySystem*> *systems, bool trav, char* code)
 {	file << vertex1->t_vertex_num[threadnum] << ' ' << vertex2->t_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	file << ' ' << (trav ? segment->clinchedby_code(code, threadnum) : "0");
 	for (HGVertex *intermediate : intermediate_points)
-	{	sprintf(fstr, " %.15g %.15g", intermediate->lat, intermediate->lng);
-		file << fstr;
-	}
+		file << ' ' << intermediate->lat << ' ' << intermediate->lng;
 	file << '\n';
 }
 

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -31,8 +31,8 @@ class HGEdge
 	HGEdge(HGVertex *, unsigned char, HGEdge*, HGEdge*);
 
 	void detach();
-	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*);
-	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
+	void collapsed_tmg_line(std::ofstream&, unsigned int, std::vector<HighwaySystem*>*);
+	void traveled_tmg_line (std::ofstream&, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
 	std::string debug_tmg_line(std::vector<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -4,7 +4,6 @@
 #include "HGVertex.h"
 #include "PlaceRadius.h"
 #include "../Args/Args.h"
-#include "../Datacheck/Datacheck.h"
 #include "../ElapsedTime/ElapsedTime.h"
 #include "../HighwaySegment/HighwaySegment.h"
 #include "../HighwaySystem/HighwaySystem.h"

--- a/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/userlog.cpp
@@ -8,12 +8,23 @@
 #include <fstream>
 
 void TravelerList::userlog(const double total_active_only_miles, const double total_active_preview_miles)
-{	char fstr[112];
-	std::cout << "." << std::flush;
+{	std::cout << "." << std::flush;
 	std::ofstream log(Args::logfilepath+"/users/"+traveler_name+".log", std::ios::app);
+	log.setf(std::ios::fixed);
+	log.precision(2);
+	auto log_clinched_mi = [&](double clinched, double total)->std::ofstream&
+	{	log << clinched << " of " << total << " mi ";
+		if (total)
+			log << "(" << 100*clinched/total << "%)";
+		else	log << "-.--%";
+		return	log;
+	};
+
 	log << "Clinched Highway Statistics\n";
-	log << "Overall in active systems: " << format_clinched_mi(fstr, active_only_miles(), total_active_only_miles) << '\n';
-	log << "Overall in active+preview systems: " << format_clinched_mi(fstr, active_preview_miles(), total_active_preview_miles) << '\n';
+	log << "Overall in active systems: ";
+	log_clinched_mi(active_only_miles(), total_active_only_miles) << '\n';
+	log << "Overall in active+preview systems: ";
+	log_clinched_mi(active_preview_miles(), total_active_preview_miles) << '\n';
 
 	log << "Overall by region: (each line reports active only then active+preview)\n";
 	std::list<Region*> travregions;
@@ -24,8 +35,9 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 	{	double t_active_miles = 0;
 		if (active_only_mileage_by_region.count(region))
 			t_active_miles = active_only_mileage_by_region.at(region);
-		log << region->code << ": " << format_clinched_mi(fstr, t_active_miles, region->active_only_mileage) << ", "
-		    << format_clinched_mi(fstr, active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
+		log << region->code << ": ";
+		log_clinched_mi(t_active_miles, region->active_only_mileage) << ", ";
+		log_clinched_mi(active_preview_mileage_by_region.at(region), region->active_preview_mileage) << '\n';
 	}
 	unsigned int active_systems_traveled = 0;
 	unsigned int active_systems_clinched = 0;
@@ -46,8 +58,9 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 			// the DB, but add to logs only if it's been traveled at
 			// all and it covers multiple regions
 			auto& sysmbr = h->mileage_by_region;
-			log << "System " << h->systemname << " (" << h->level_name() << ") overall: "
-			    << format_clinched_mi(fstr, t_system_overall, h->total_mileage()) << '\n';
+			log.precision(2);
+			log << "System " << h->systemname << " (" << h->level_name() << ") overall: ";
+			log_clinched_mi(t_system_overall, h->total_mileage()) << '\n';
 			if (sysmbr.size() > 1)
 			{	log << "System " << h->systemname << " by region:\n";
 				std::list<Region*> sysregions;
@@ -59,7 +72,8 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 					auto it = system_region_mileages.at(h).find(region);
 					if (it != system_region_mileages.at(h).end())
 						system_region_mileage = it->second;
-					log << "  " << region->code << ": " << format_clinched_mi(fstr, system_region_mileage, sysmbr.at(region)) << '\n';
+					log << "  " << region->code << ": ";
+					log_clinched_mi(system_region_mileage, sysmbr.at(region)) << '\n';
 				}
 			}
 
@@ -85,12 +99,14 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 				{	num_con_rtes_traveled += 1;
 					num_con_rtes_clinched += (con_clinched_miles == cr.mileage);
 					ccr_values.emplace_back(&cr, con_clinched_miles);
-					log << cr.readable_name() << ": " << format_clinched_mi(fstr, con_clinched_miles, cr.mileage) << '\n';
+					log << cr.readable_name() << ": ";
+					log_clinched_mi(con_clinched_miles, cr.mileage) << '\n';
 					if (roots.size() == 1)
 						log << " (" << roots[0]->readable_name() << " only)\n";
 					else {	for (auto& rm : chop_mi)
-						    log << "  " << rm.first->readable_name() << ": "
-							<< format_clinched_mi(fstr, rm.second,rm.first->mileage) << "\n";
+						{   log << "  " << rm.first->readable_name() << ": ";
+						    log_clinched_mi(rm.second,rm.first->mileage) << "\n";
+						}
 						log << '\n';
 					     }
 				}
@@ -99,23 +115,26 @@ void TravelerList::userlog(const double total_active_only_miles, const double to
 			  if (h->active())
 				active_systems_clinched++;
 			  else	preview_systems_clinched++;
-			sprintf(fstr, " connected routes traveled: %i of %i (%.1f%%), clinched: %i of %i (%.1f%%).",
-				num_con_rtes_traveled, (int)h->con_routes.size, 100*(double)num_con_rtes_traveled/h->con_routes.size,
-				num_con_rtes_clinched, (int)h->con_routes.size, 100*(double)num_con_rtes_clinched/h->con_routes.size);
-			log << "System " << h->systemname << fstr << '\n';
+			log.precision(1);
+			log << "System " << h->systemname
+			    << " connected routes traveled: " << num_con_rtes_traveled << " of " << h->con_routes.size
+			    << " (" << 100*(double)num_con_rtes_traveled/h->con_routes.size
+					  << "%), clinched: " << num_con_rtes_clinched << " of " << h->con_routes.size
+			    << " (" << 100*(double)num_con_rtes_clinched/h->con_routes.size << "%).\n";
 		}
 	  }
+	log.precision(1); // for the few users with no traveled mileage
 
 	// grand summary, active only
-	sprintf(fstr,"\nTraveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) active systems",
-		active_systems_traveled, HighwaySystem::num_active, 100*(double)active_systems_traveled/HighwaySystem::num_active,
-		active_systems_clinched, HighwaySystem::num_active, 100*(double)active_systems_clinched/HighwaySystem::num_active);
-	log << fstr << '\n';
+	log << "\nTraveled " << active_systems_traveled << " of " << HighwaySystem::num_active
+		      << " (" << 100*(double)active_systems_traveled/HighwaySystem::num_active
+	  << "%), Clinched " << active_systems_clinched << " of " << HighwaySystem::num_active
+		      << " (" << 100*(double)active_systems_clinched/HighwaySystem::num_active << "%) active systems\n";
 	// grand summary, active+preview
-	sprintf(fstr,"Traveled %i of %i (%.1f%%), Clinched %i of %i (%.1f%%) preview systems",
-		preview_systems_traveled, HighwaySystem::num_preview, 100*(double)preview_systems_traveled/HighwaySystem::num_preview,
-		preview_systems_clinched, HighwaySystem::num_preview, 100*(double)preview_systems_clinched/HighwaySystem::num_preview);
-	log << fstr << '\n';
+	log << "Traveled " << preview_systems_traveled << " of " << HighwaySystem::num_preview
+		    << " (" << 100*(double)preview_systems_traveled/HighwaySystem::num_preview
+	<< "%), Clinched " << preview_systems_clinched << " of " << HighwaySystem::num_preview
+		    << " (" << 100*(double)preview_systems_clinched/HighwaySystem::num_preview << "%) preview systems\n";
 
 	// updated routes, sorted by date
 	log << "\nMost recent updates for listed routes:\n";

--- a/siteupdate/cplusplus/functions/tmstring.cpp
+++ b/siteupdate/cplusplus/functions/tmstring.cpp
@@ -65,15 +65,6 @@ const char* strdstr(const char* h, const char* n, const char d)
 	return 0;
 }
 
-char* format_clinched_mi(char* str, double clinched, double total)
-{	/* return a nicely-formatted string for a given number of miles
-	clinched and total miles, including percentage */
-	if (total)
-		sprintf(str, "%0.2f of %0.2f mi (%0.2f%%)", clinched, total, 100*clinched/total);
-	else	sprintf(str, "%0.2f of %0.2f mi -.--%%", clinched, total);
-	return str;
-}
-
 std::string double_quotes(std::string str)
 {	for (size_t i = 0; i < str.size(); i++)
 	  if (str[i] == '\'')

--- a/siteupdate/cplusplus/functions/tmstring.h
+++ b/siteupdate/cplusplus/functions/tmstring.h
@@ -7,5 +7,4 @@ const char* upper(const char*);
 bool valid_num_str(const char*, const char);
 int strdcmp(const char*, const char*, const char);
 const char* strdstr(const char*, const char*, const char);
-char* format_clinched_mi(char*, double, double);
 std::string double_quotes(std::string);


### PR DESCRIPTION
Closes #518!

The performance-killing `sprintf` function has been removed from user log, DB file, and graph generation routines.
More to come in the future; I've yet to work on NMPs and stats CSVs.

@jteresco, I recommend a compile & test drive of this, if for no other reason than to see how blazingly fast graph generation is now. :grinning:

I am curious to see though, how fast  `--errorcheck` is with the userlog speedups.

One minor change: the `waypoints` table in the DB has done away with what I call "Python style floats", where a trailing `.0` is written after an integral value. `42.0` -> `42`.
This could in theory happen in other tables too; it's just in `waypoints` where we see it in practice. I don't expect it'll cause any problems.

---

We're nearing the end of the road for big **graph generation** improvements.
Percentagewise, this beats any of the [first](https://github.com/TravelMapping/DataProcessing/pull/180) [big](https://github.com/TravelMapping/DataProcessing/pull/182) [five](https://github.com/TravelMapping/DataProcessing/pull/185) [pull](https://github.com/TravelMapping/DataProcessing/pull/186) [requests](https://github.com/TravelMapping/DataProcessing/pull/193) from 2019. And it wasn't even something I had planned.
While I still have [a few ideas](https://github.com/yakra/DataProcessing/issues/270) left, there probably won't be anything else of this magnitude. Just smaller incremental changes, much lower impact.
I do expect to get lab2 to more consistently break the 1-second barrier, until the ever-increasing size of the HighwayData repo takes that possibility (using the most recent commit) away permanently.