### PR TITLE
{fmt}: #585 phase 1 take 2

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,7 @@ This document is intended to describe how one can set up an environment to run T
 
 Standard tools expected include `bash`, `bzip2`, a GNU version of `make` (often named `gmake`), `ssh`.
 
-There are two versions of the site update program: one written in Python and one in C++.  Both produce the same result.  The Python version requires a Python3 installation (as of this writing, Python 3.9.13).  Below, we will assume that Python can be launched with the command "python3".  The C++ version requires a C++ compiler (as of this writing, FreeBSD clang 13.0.0).
+There are two versions of the site update program: one written in Python and one in C++.  Both produce the same result.  The Python version requires a Python3 installation (as of this writing, Python 3.9.13).  Below, we will assume that Python can be launched with the command "python3".  The C++ version requires a C++ compiler (as of this writing, FreeBSD clang 13.0.0) and the [{fmt}](https://fmt.dev/) library (as of this writing, {fmt} 10.2.0).
 
 ### Cloning Needed Repositories
 

--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -4,7 +4,7 @@ ifeq ($(OS), Linux)
 endif
 
 CXX = clang++
-CXXFLAGS = -O3 -std=c++11 -Wno-comment -Wno-dangling-else -Wno-logical-op-parentheses
+CXXFLAGS = -O3 -std=c++11 -isystem /usr/local/include -Wno-comment -Wno-dangling-else -Wno-logical-op-parentheses
 
 STObjects = \
   classes/GraphGeneration/HighwayGraphST.o \

--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -6,7 +6,7 @@
 /* e */ bool Args::errorcheck = 0;
 /* k */ bool Args::skipgraphs = 0;
 /* v */ bool Args::mtvertices = 0;
-/* C */ bool Args::mtcsvfiles = 0;
+/* C */ bool Args::stcsvfiles = 0;
 /* E */ bool Args::edgecounts = 0;
 /* b */ bool Args::bitsetlogs = 0;
 /* w */ std::string Args::datapath = "../../HighwayData";
@@ -34,7 +34,7 @@ bool Args::init(int argc, char *argv[])
 	{	     if ARG(0, "-e", "--errorcheck")		 errorcheck = 1;
 		else if ARG(0, "-k", "--skipgraphs")		 skipgraphs = 1;
 		else if ARG(0, "-v", "--mt-vertices")		 mtvertices = 1;
-		else if ARG(0, "-C", "--mt-csvs")		 mtcsvfiles = 1;
+		else if ARG(0, "-C", "--st-csvs")		 stcsvfiles = 1;
 		else if ARG(0, "-E", "--edge-counts")		 edgecounts = 1;
 		else if ARG(0, "-b", "--bitset-logs")		 bitsetlogs = 1;
 		else if ARG(0, "-h", "--help")			{show_help(); return 1;}
@@ -127,7 +127,7 @@ void Args::show_help()
 	std::cout  <<  "		        Number of digits (1-9) after decimal point in\n";
 	std::cout  <<  "		        timestamp readouts\n";
 	std::cout  <<  "  -v, --mt-vertices     Multi-threaded vertex construction\n";
-	std::cout  <<  "  -C, --mt-csvs         Multi-threaded stats csv files\n";
+	std::cout  <<  "  -C, --st-csvs         Single-threaded stats csv files\n";
 	std::cout  <<  "  -E, --edge-counts     Report the quantity of each format graph edge\n";
 	std::cout  <<  "  -b, --bitset-logs     Write TMBitset RAM use logs for region & system\n";
 	std::cout  <<  "		        vertices & edges\n";

--- a/siteupdate/cplusplus/classes/Args/Args.h
+++ b/siteupdate/cplusplus/classes/Args/Args.h
@@ -18,7 +18,7 @@ class Args
 	/* e */ static bool errorcheck;
 	/* T */ static int timeprecision;
 	/* v */ static bool mtvertices;
-	/* C */ static bool mtcsvfiles;
+	/* C */ static bool stcsvfiles;
 	/* E */ static bool edgecounts;
 	/* b */ static bool bitsetlogs;
 	/* L */ static int colocationlimit;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "HGEdge.h"
 #include "HGVertex.h"
 #include "../Args/Args.h"
@@ -6,6 +7,7 @@
 #include "../Route/Route.h"
 #include "../Waypoint/Waypoint.h"
 #include "../../templates/contains.cpp"
+#include <fmt/format.h>
 
 HGVertex* HGEdge::v_array;
 
@@ -107,21 +109,25 @@ void HGEdge::detach()
 }
 
 // write line to tmg collapsed edge file
-void HGEdge::collapsed_tmg_line(std::ofstream& file, unsigned int threadnum, std::vector<HighwaySystem*> *systems)
+void HGEdge::collapsed_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems)
 {	file << vertex1->c_vertex_num[threadnum] << ' ' << vertex2->c_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	for (HGVertex *intermediate : intermediate_points)
-		file << ' ' << intermediate->lat << ' ' << intermediate->lng;
+	{	*fmt::format_to(fstr, " {:.15} {:.15}", intermediate->lat, intermediate->lng) = 0;
+		file << fstr;
+	}
 	file << '\n';
 }
 
 // write line to tmg traveled edge file
-void HGEdge::traveled_tmg_line(std::ofstream& file, unsigned int threadnum, std::vector<HighwaySystem*> *systems, bool trav, char* code)
+void HGEdge::traveled_tmg_line(std::ofstream& file, char* fstr, unsigned int threadnum, std::vector<HighwaySystem*> *systems, bool trav, char* code)
 {	file << vertex1->t_vertex_num[threadnum] << ' ' << vertex2->t_vertex_num[threadnum] << ' ';
 	segment->write_label(file, systems);
 	file << ' ' << (trav ? segment->clinchedby_code(code, threadnum) : "0");
 	for (HGVertex *intermediate : intermediate_points)
-		file << ' ' << intermediate->lat << ' ' << intermediate->lng;
+	{	*fmt::format_to(fstr, " {:.15} {:.15}", intermediate->lat, intermediate->lng) = 0;
+		file << fstr;
+	}
 	file << '\n';
 }
 
@@ -131,7 +137,7 @@ std::string HGEdge::debug_tmg_line(std::vector<HighwaySystem*> *systems, unsigne
 			 + std::to_string(vertex2->c_vertex_num[threadnum]) + " [" + *vertex2->unique_name + "] " + label(systems);
 	char fstr[58];
 	for (HGVertex *intermediate : intermediate_points)
-	{	sprintf(fstr, "] %.15g %.15g", intermediate->lat, intermediate->lng);
+	{	*fmt::format_to(fstr, "] {:.15} {:.15}", intermediate->lat, intermediate->lng) = 0;
 		line += " [" + *intermediate->unique_name + fstr;
 	}
 	return line;
@@ -157,7 +163,7 @@ std::string HGEdge::intermediate_point_string()
 	std::string line = "";
 	char fstr[56];
 	for (HGVertex *i : intermediate_points)
-	{	sprintf(fstr, "%.15g %.15g", i->lat, i->lng);
+	{	*fmt::format_to(fstr, "{:.15} {:.15}", i->lat, i->lng) = 0;
 		line += " [" + *i->unique_name + "] " + fstr;
 	}
 	return line;

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.h
@@ -31,8 +31,8 @@ class HGEdge
 	HGEdge(HGVertex *, unsigned char, HGEdge*, HGEdge*);
 
 	void detach();
-	void collapsed_tmg_line(std::ofstream&, unsigned int, std::vector<HighwaySystem*>*);
-	void traveled_tmg_line (std::ofstream&, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
+	void collapsed_tmg_line(std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*);
+	void traveled_tmg_line (std::ofstream&, char*, unsigned int, std::vector<HighwaySystem*>*, bool, char*);
 	std::string debug_tmg_line(std::vector<HighwaySystem*> *, unsigned int);
 	std::string str();
 	std::string intermediate_point_string();

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "HighwayGraph.h"
 #include "GraphListEntry.h"
 #include "HGEdge.h"
@@ -13,6 +14,7 @@
 #include "../Waypoint/Waypoint.h"
 #include "../WaypointQuadtree/WaypointQuadtree.h"
 #include "../../templates/contains.cpp"
+#include <fmt/format.h>
 #include <fstream>
 #include <thread>
 
@@ -345,9 +347,9 @@ void HighwayGraph::bitsetlogs(HGVertex* hp_end)
 //     for intermediate "shaping points" along the edge, ordered from endpoint 1 to endpoint 2.
 //
 void HighwayGraph::write_master_graphs_tmg()
-{	std::ofstream simplefile(Args::graphfilepath + "/tm-master-simple.tmg");   simplefile.precision(15);
-	std::ofstream collapfile(Args::graphfilepath + "/tm-master.tmg");	   collapfile.precision(15);
-	std::ofstream travelfile(Args::graphfilepath + "/tm-master-traveled.tmg"); travelfile.precision(15);
+{	std::ofstream simplefile(Args::graphfilepath + "/tm-master-simple.tmg");
+	std::ofstream collapfile(Args::graphfilepath + "/tm-master.tmg");
+	std::ofstream travelfile(Args::graphfilepath + "/tm-master-traveled.tmg");
 	simplefile << "TMG 1.0 simple\n";
 	collapfile << "TMG 1.0 collapsed\n";
 	travelfile << "TMG 2.0 traveled\n";
@@ -359,14 +361,13 @@ void HighwayGraph::write_master_graphs_tmg()
 	unsigned int sv = 0;
 	unsigned int cv = 0;
 	unsigned int tv = 0;
+	char fstr[57];
 	for (HGVertex& v : vertices)
-	{	auto write_vertex = [&](std::ofstream& tmg)
-		{	tmg << *(v.unique_name) << ' ' << v.lat << ' ' << v.lng << '\n';
-		};
+	{	*fmt::format_to(fstr, " {:.15} {:.15}", v.lat, v.lng) = 0;
 		switch (v.visibility) // fall-thru is a Good Thing!
-		{ case 2:  write_vertex(collapfile); v.c_vertex_num[0] = cv++;
-		  case 1:  write_vertex(travelfile); v.t_vertex_num[0] = tv++;
-		  default: write_vertex(simplefile); v.s_vertex_num[0] = sv++;
+		{ case 2:  collapfile << *(v.unique_name) << fstr << '\n'; v.c_vertex_num[0] = cv++;
+		  case 1:  travelfile << *(v.unique_name) << fstr << '\n'; v.t_vertex_num[0] = tv++;
+		  default: simplefile << *(v.unique_name) << fstr << '\n'; v.s_vertex_num[0] = sv++;
 		}
 	}
 
@@ -380,10 +381,10 @@ void HighwayGraph::write_master_graphs_tmg()
 	//TODO: multiple functions performing the same instructions for multiple files?
 	for (HGEdge *e = edges.begin(), *end = edges.end(); e != end; ++e)
 	{ if (e->format & HGEdge::collapsed)
-		e->collapsed_tmg_line(collapfile, 0, 0);
+		e->collapsed_tmg_line(collapfile, fstr, 0, 0);
 	  if (e->format & HGEdge::traveled)
 	  {	for (char*n=cbycode; n<cbycode+nibbles; ++n) *n = '0';
-		e->traveled_tmg_line(travelfile, 0, 0, TravelerList::allusers.size, cbycode);
+		e->traveled_tmg_line(travelfile, fstr, 0, 0, TravelerList::allusers.size, cbycode);
 	  }
 	  if (e->format & HGEdge::simple)
 	  {	simplefile << e->vertex1->s_vertex_num[0] << ' '
@@ -418,9 +419,9 @@ void HighwayGraph::write_subgraphs_tmg
 {	unsigned int cv_count = 0, sv_count = 0, tv_count = 0;
 	unsigned int ce_count = 0, se_count = 0, te_count = 0;
 	GraphListEntry* g = GraphListEntry::entries.data()+graphnum;
-	std::ofstream simplefile(Args::graphfilepath+'/'+g -> filename()); simplefile.precision(15);
-	std::ofstream collapfile(Args::graphfilepath+'/'+g[1].filename()); collapfile.precision(15);
-	std::ofstream travelfile(Args::graphfilepath+'/'+g[2].filename()); travelfile.precision(15);
+	std::ofstream simplefile(Args::graphfilepath+'/'+g -> filename());
+	std::ofstream collapfile(Args::graphfilepath+'/'+g[1].filename());
+	std::ofstream travelfile(Args::graphfilepath+'/'+g[2].filename());
 	TMBitset<HGVertex*, uint64_t> mv; // vertices matching all criteria
 	TMBitset<HGEdge*,   uint64_t> me; //    edges matching all criteria
 	std::vector<TravelerList*> traveler_lists;
@@ -455,14 +456,13 @@ void HighwayGraph::write_subgraphs_tmg
 	unsigned int sv = 0;
 	unsigned int cv = 0;
 	unsigned int tv = 0;
+	char fstr[57];
 	for (HGVertex *v : mv)
-	{	auto write_vertex = [&](std::ofstream& tmg)
-		{	tmg << *(v->unique_name) << ' ' << v->lat << ' ' << v->lng << '\n';
-		};
+	{	*fmt::format_to(fstr, " {:.15} {:.15}", v->lat, v->lng) = 0;
 		switch(v->visibility) // fall-thru is a Good Thing!
-		{ case 2:  write_vertex(collapfile); v->c_vertex_num[threadnum] = cv++;
-		  case 1:  write_vertex(travelfile); v->t_vertex_num[threadnum] = tv++;
-		  default: write_vertex(simplefile); v->s_vertex_num[threadnum] = sv++;
+		{ case 2:  collapfile << *(v->unique_name) << fstr << '\n'; v->c_vertex_num[threadnum] = cv++;
+		  case 1:  travelfile << *(v->unique_name) << fstr << '\n'; v->t_vertex_num[threadnum] = tv++;
+		  default: simplefile << *(v->unique_name) << fstr << '\n'; v->s_vertex_num[threadnum] = sv++;
 		}
 	}
 
@@ -481,10 +481,10 @@ void HighwayGraph::write_subgraphs_tmg
 		simplefile << '\n';
 	  }
 	  if (e->format & HGEdge::collapsed)
-		e->collapsed_tmg_line(collapfile, threadnum, g->systems);
+		e->collapsed_tmg_line(collapfile, fstr, threadnum, g->systems);
 	  if (e->format & HGEdge::traveled)
 	  {	for (char*n=cbycode; n<cbycode+nibbles; ++n) *n = '0';
-		e->traveled_tmg_line (travelfile, threadnum, g->systems, travnum, cbycode);
+		e->traveled_tmg_line (travelfile, fstr, threadnum, g->systems, travnum, cbycode);
 	  }
 	}
 	delete[] cbycode;

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "HighwaySystem.h"
 #include "../Args/Args.h"
 #include "../ConnectedRoute/ConnectedRoute.h"
@@ -11,6 +12,7 @@
 #include "../TravelerList/TravelerList.h"
 #include "../Waypoint/Waypoint.h"
 #include "../../functions/tmstring.h"
+#include <fmt/format.h>
 #include <fstream>
 
 TMArray<HighwaySystem> HighwaySystem::syslist;
@@ -219,24 +221,25 @@ void HighwaySystem::stats_csv()
 	sysfile << '\n';
 	for (TravelerList& t : TravelerList::allusers)
 	{	// only include entries for travelers who have any mileage in system
-		auto it = t.system_region_mileages.find(this);
-		if (it != t.system_region_mileages.end())
-		{	sprintf(fstr, ",%.2f", t.system_miles(this));
+		auto srm_it = t.system_region_mileages.find(this);
+		if (srm_it != t.system_region_mileages.end())
+		{	*fmt::format_to(fstr, ",{:.2f}", t.system_miles(this)) = 0;
 			sysfile << t.traveler_name << fstr;
 			for (Region *region : regions)
-			  try {	sprintf(fstr, ",%.2f", it->second.at(region));
-				sysfile << fstr;
-			      }
-			  catch (const std::out_of_range& oor)
-			      {	sysfile << ",0";
-			      }
+			{	auto trm_it = srm_it->second.find(region);
+				if (trm_it != srm_it->second.end())
+				{	*fmt::format_to(fstr, ",{:.2f}", trm_it->second) = 0;
+					sysfile << fstr;
+				}
+				else	sysfile << ",0";
+			}
 			sysfile << '\n';
 		}
 	}
-	sprintf(fstr, "TOTAL,%.2f", total_mileage());
+	*fmt::format_to(fstr, "TOTAL,{:.2f}", total_mileage()) = 0;
 	sysfile << fstr;
 	for (Region *region : regions)
-	{	sprintf(fstr, ",%.2f", mileage_by_region.at(region));
+	{	*fmt::format_to(fstr, ",{:.2f}", mileage_by_region.at(region)) = 0;
 		sysfile << fstr;
 	}
 	sysfile << '\n';

--- a/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactiveonly.cpp
@@ -1,7 +1,9 @@
+#define FMT_HEADER_ONLY
 #include "../classes/Args/Args.h"
 #include "../classes/Region/Region.h"
 #include "../classes/TravelerList/TravelerList.h"
 #include "../threads/threads.h"
+#include <fmt/format.h>
 #include <fstream>
 
 void allbyregionactiveonly(std::mutex* mtx, double total_mi)
@@ -19,21 +21,22 @@ void allbyregionactiveonly(std::mutex* mtx, double total_mi)
 	{	double t_total_mi = 0;
 		for (std::pair<Region* const, double>& rm : t.active_only_mileage_by_region)
 			t_total_mi += rm.second;
-		sprintf(fstr, "%.2f", t_total_mi);
+		*fmt::format_to(fstr, "{:.2f}", t_total_mi) = 0;
 		allfile << t.traveler_name << ',' << fstr;
 		for (Region *region : regions)
-		  try {	sprintf(fstr, "%.2f", t.active_only_mileage_by_region.at(region));
-			allfile << ',' << fstr;
-		      }
-		  catch (const std::out_of_range& oor)
-		      {	allfile << ",0";
-		      }
+		{	auto it = t.active_only_mileage_by_region.find(region);
+			if (it != t.active_only_mileage_by_region.end())
+			{	*fmt::format_to(fstr, "{:.2f}", it->second) = 0;
+				allfile << ',' << fstr;
+			}
+		  	else	allfile << ",0";
+		}
 		allfile << '\n';
 	}
-	sprintf(fstr, "TOTAL,%.2f", total_mi);
+	*fmt::format_to(fstr, "TOTAL,{:.2f}", total_mi) = 0;
 	allfile << fstr;
 	for (Region *region : regions)
-	{	sprintf(fstr, ",%.2f", region->active_only_mileage);
+	{	*fmt::format_to(fstr, ",{:.2f}", region->active_only_mileage) = 0;
 		allfile << fstr;
 	}
 	allfile << '\n';

--- a/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
+++ b/siteupdate/cplusplus/functions/allbyregionactivepreview.cpp
@@ -1,7 +1,9 @@
+#define FMT_HEADER_ONLY
 #include "../classes/Args/Args.h"
 #include "../classes/Region/Region.h"
 #include "../classes/TravelerList/TravelerList.h"
 #include "../threads/threads.h"
+#include <fmt/format.h>
 #include <fstream>
 
 void allbyregionactivepreview(std::mutex* mtx, double total_mi)
@@ -19,21 +21,22 @@ void allbyregionactivepreview(std::mutex* mtx, double total_mi)
 	{	double t_total_mi = 0;
 		for (std::pair<Region* const, double>& rm : t.active_preview_mileage_by_region)
 			t_total_mi += rm.second;
-		sprintf(fstr, "%.2f", t_total_mi);
+		*fmt::format_to(fstr, "{:.2f}", t_total_mi) = 0;
 		allfile << t.traveler_name << ',' << fstr;
 		for (Region *region : regions)
-		  try {	sprintf(fstr, "%.2f", t.active_preview_mileage_by_region.at(region));
-			allfile << ',' << fstr;
-		      }
-		  catch (const std::out_of_range& oor)
-		      {	allfile << ",0";
-		      }
+		{	auto it = t.active_preview_mileage_by_region.find(region);
+			if (it != t.active_preview_mileage_by_region.end())
+			{	*fmt::format_to(fstr, "{:.2f}", it->second) = 0;
+				allfile << ',' << fstr;
+			}
+			else	allfile << ",0";
+		}
 		allfile << '\n';
 	}
-	sprintf(fstr, "TOTAL,%.2f", total_mi);
+	*fmt::format_to(fstr, "TOTAL,{:.2f}", total_mi) = 0;
 	allfile << fstr;
 	for (Region *region : regions)
-	{	sprintf(fstr, ",%.2f", region->active_preview_mileage);
+	{	*fmt::format_to(fstr, ",{:.2f}", region->active_preview_mileage) = 0;
 		allfile << fstr;
 	}
 	allfile << '\n';

--- a/siteupdate/cplusplus/functions/rdstats.cpp
+++ b/siteupdate/cplusplus/functions/rdstats.cpp
@@ -1,8 +1,10 @@
+#define FMT_HEADER_ONLY
 #include "../classes/Args/Args.h"
 #include "../classes/ConnectedRoute/ConnectedRoute.h"
 #include "../classes/HighwaySystem/HighwaySystem.h"
 #include "../classes/Region/Region.h"
 #include "../classes/Route/Route.h"
+#include <fmt/format.h>
 #include <fstream>
 #include <list>
 
@@ -18,24 +20,24 @@ void rdstats(double& active_only_miles, double& active_preview_miles, time_t* ti
 		active_preview_miles += r.active_preview_mileage;
 		overall_miles += r.overall_mileage;
 	}
-	sprintf(fstr, "Active routes (active): %.2f mi\n", active_only_miles);
+	*fmt::format_to(fstr, "Active routes (active): {:.2f} mi\n", active_only_miles) = 0;
 	rdstatsfile << fstr;
-	sprintf(fstr, "Clinchable routes (active, preview): %.2f mi\n", active_preview_miles);
+	*fmt::format_to(fstr, "Clinchable routes (active, preview): {:.2f} mi\n", active_preview_miles) = 0;
 	rdstatsfile << fstr;
-	sprintf(fstr, "All routes (active, preview, devel): %.2f mi\n", overall_miles);
+	*fmt::format_to(fstr, "All routes (active, preview, devel): {:.2f} mi\n", overall_miles) = 0;
 	rdstatsfile << fstr;
 	rdstatsfile << "Breakdown by region:\n";
 	// a nice enhancement later here might break down by continent, then country,
 	// then region
 	for (Region& region : Region::allregions)
 	  if (region.overall_mileage)
-	  {	sprintf(fstr, ": %.2f (active), %.2f (active, preview) %.2f (active, preview, devel)\n",
-			region.active_only_mileage, region.active_preview_mileage, region.overall_mileage);
+	  {	*fmt::format_to(fstr, ": {:.2f} (active), {:.2f} (active, preview) {:.2f} (active, preview, devel)\n",
+				region.active_only_mileage, region.active_preview_mileage, region.overall_mileage) = 0;
 		rdstatsfile << region.code << fstr;
 	  }
 
 	for (HighwaySystem& h : HighwaySystem::syslist)
-	{	sprintf(fstr, ") total: %.2f mi\n", h.total_mileage());
+	{	*fmt::format_to(fstr, ") total: {:.2f} mi\n", h.total_mileage()) = 0;
 		rdstatsfile << "System " << h.systemname << " (" << h.level_name() << fstr;
 		if (h.mileage_by_region.size() > 1)
 		{	rdstatsfile << "System " << h.systemname << " by region:\n";
@@ -44,7 +46,7 @@ void rdstats(double& active_only_miles, double& active_preview_miles, time_t* ti
 				regions_in_system.push_back(rm.first);
 			regions_in_system.sort();
 			for (Region *r : regions_in_system)
-			{	sprintf(fstr, ": %.2f mi\n", h.mileage_by_region.at(r));
+			{	*fmt::format_to(fstr, ": {:.2f} mi\n", h.mileage_by_region.at(r)) = 0;
 				rdstatsfile << r->code << fstr;
 			}
 		}
@@ -52,11 +54,11 @@ void rdstats(double& active_only_miles, double& active_preview_miles, time_t* ti
 		for (ConnectedRoute& cr : h.con_routes)
 		{	std::string to_write = "";
 			for (Route *r : cr.roots)
-			{	sprintf(fstr, ": %.2f mi\n", r->mileage);
+			{	*fmt::format_to(fstr, ": {:.2f} mi\n", r->mileage) = 0;
 				to_write += "  " + r->readable_name() + fstr;
 				cr.mileage += r->mileage;
 			}
-			sprintf(fstr, ": %.2f mi", cr.mileage);
+			*fmt::format_to(fstr, ": {:.2f} mi", cr.mileage) = 0;
 			rdstatsfile << cr.readable_name() << fstr;
 			if (cr.roots.size() == 1)
 				rdstatsfile << " (" << cr.roots[0]->readable_name() << " only)\n";

--- a/siteupdate/cplusplus/functions/tmstring.cpp
+++ b/siteupdate/cplusplus/functions/tmstring.cpp
@@ -1,3 +1,5 @@
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
 #include "tmstring.h"
 
 bool sort_1st_csv_field(const std::string& a, const std::string& b)
@@ -63,6 +65,15 @@ const char* strdstr(const char* h, const char* n, const char d)
 		  else if (!*b) return h;
 	}
 	return 0;
+}
+
+char* format_clinched_mi(char* str, double clinched, double total)
+{	/* return a nicely-formatted string for a given number of miles
+	clinched and total miles, including percentage */
+	if (total)
+		*fmt::format_to(str, "{:.2f} of {:.2f} mi ({:.2f}%)", clinched, total, 100*clinched/total) = 0;
+	else	*fmt::format_to(str, "{:.2f} of {:.2f} mi -.--%", clinched, total) = 0;
+	return str;
 }
 
 std::string double_quotes(std::string str)

--- a/siteupdate/cplusplus/functions/tmstring.h
+++ b/siteupdate/cplusplus/functions/tmstring.h
@@ -7,4 +7,5 @@ const char* upper(const char*);
 bool valid_num_str(const char*, const char);
 int strdcmp(const char*, const char*, const char);
 const char* strdstr(const char*, const char*, const char);
+char* format_clinched_mi(char*, double, double);
 std::string double_quotes(std::string);

--- a/siteupdate/cplusplus/tasks/threaded/StatsCsv.cpp
+++ b/siteupdate/cplusplus/tasks/threaded/StatsCsv.cpp
@@ -1,28 +1,20 @@
       #ifdef threading_enabled
 	HighwaySystem::it = HighwaySystem::syslist.begin();
-	switch(Args::mtcsvfiles ? Args::numthreads : 1)
-	{   case 1:
+	if (Args::numthreads == 1 || Args::stcsvfiles)
       #endif
-		cout << et.et() << "Writing allbyregionactiveonly.csv." << endl;
+	     {	cout << et.et() << "Writing allbyregionactiveonly.csv." << endl;
 		allbyregionactiveonly(0, active_only_miles);
 		cout << et.et() << "Writing allbyregionactivepreview.csv." << endl;
 		allbyregionactivepreview(0, active_preview_miles);
 		cout << et.et() << "Writing per-system stats csv files." << endl;
 		for (HighwaySystem& h : HighwaySystem::syslist) h.stats_csv();
+	     }
       #ifdef threading_enabled
-		break;
-	   case 2:
-		thr[0] = thread(allbyregionactiveonly,    &list_mtx, active_only_miles);
+	else {	thr[0] = thread(allbyregionactiveonly,    &list_mtx, active_only_miles);
 		thr[1] = thread(allbyregionactivepreview, &list_mtx, active_preview_miles);
-		thr[0].join();
-		thr[1].join();
-		break;
-	   default:
-		thr[0] = thread(allbyregionactiveonly,    nullptr, active_only_miles);
-		thr[1] = thread(allbyregionactivepreview, nullptr, active_preview_miles);
-		thr[2] = thread(StatsCsvThread, 2, &list_mtx);
-		thr[0].join();
-		thr[1].join();
-		thr[2].join();
-	}
+		// start at t=2, because allbyregionactive* will spawn another StatsCsvThread when finished
+		for (unsigned int t = 2; t < thr.size(); t++) thr[t] = thread(StatsCsvThread, t, &list_mtx);
+		THREADLOOP thr[t].join();
+	     }
       #endif
+


### PR DESCRIPTION
Closes #626.
This reverts & re-does #623.
The slowdown is gone, replaced with the speedup it really *should* have been.

Like before, `sprintf` has been removed from user log, DB file, and graph generation routines.
(And now, routedatastats.log & stats CSVs too.)
This time, it's been replaced with calls to the [{fmt}](https://fmt.dev) library instead of using iostreams for `double` formatting.

As with #622, I recommend downloading and doing a compile & test drive before merging:
* to make sure {fmt} is working on Mac
* OK, clang is working again on noreaster. See how fast graph generation is, for real this time!
* O HAY! How fast is `--errorcheck` now? :grin:

---

As noted before, we're nearing the end of the road for big graph generation improvements.
Percentagewise, this is in line with the [first](https://github.com/TravelMapping/DataProcessing/pull/180) [big](https://github.com/TravelMapping/DataProcessing/pull/182) [five](https://github.com/TravelMapping/DataProcessing/pull/185) [pull](https://github.com/TravelMapping/DataProcessing/pull/186) [requests](https://github.com/TravelMapping/DataProcessing/pull/193) from 2019.
It's about middle-of-the-pack, doesn't beat all of them hands-down. (#623 *did*, but only in the unrealistic scenario of writing to invalid files, e.g. /dev/null.)
While I still have [a few ideas](https://github.com/yakra/DataProcessing/issues/270) left, there probably won't be anything else of this magnitude. Just smaller incremental changes, much lower impact.
Although, now that we know formatting numbers is a hotspot, we can add a couple more items to that list:
* Experiment with `fmt::format_int` and {fmt}'s `std::ofstream` support.
  FreeBSD seems especially hampered by formatting numbers (at least, with `double`s); this may help.
* [Reduce redundancy (including formatting) when writing tmg edge lines.](https://github.com/yakra/DataProcessing/issues/286)