### PR TITLE
bye-bye sprintf

### DIFF
--- a/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.cpp
+++ b/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.cpp
@@ -1,20 +1,15 @@
+#define FMT_HEADER_ONLY
 #include "ElapsedTime.h"
+#include <fmt/format.h>
 
 ElapsedTime::ElapsedTime(int precision)
 {	start_time = std::chrono::steady_clock::now();
-	format = "[%.1f] ";
-	format[3] = '0' + precision;
-	str = new char[15+precision];
-	      // deleted by ~ElapsedTime
+	format = "[{:.1f}] ";
+	format[4] = '0' + precision;
 }
 
 std::string ElapsedTime::et()
 {	using namespace std::chrono;
 	duration<double> elapsed = duration_cast<duration<double>>(steady_clock::now() - start_time);
-	sprintf(str, format.data(), elapsed.count());
-	return str;
-}
-
-ElapsedTime::~ElapsedTime()
-{	delete[] str;
+	return fmt::format(format.data(), elapsed.count());
 }

--- a/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.h
+++ b/siteupdate/cplusplus/classes/ElapsedTime/ElapsedTime.h
@@ -5,10 +5,8 @@ class ElapsedTime
 {	//To get a nicely-formatted elapsed time string for printing
 	std::chrono::steady_clock::time_point start_time;
 	std::string format;
-	char* str;
 
 	public:
 	ElapsedTime(int);
-	~ElapsedTime();
 	std::string et();
 };

--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.cpp
@@ -1,7 +1,9 @@
+#define FMT_HEADER_ONLY
 #include "GraphListEntry.h"
 #include "PlaceRadius.h"
 #include "../HighwaySystem/HighwaySystem.h"
 #include "../Region/Region.h"
+#include <fmt/format.h>
 
 std::vector<GraphListEntry> GraphListEntry::entries;
 size_t GraphListEntry::num; // iterator for entries
@@ -51,9 +53,7 @@ std::string GraphListEntry::category()
 
 std::string GraphListEntry::tag()
 {	switch (cat)
-	{	case 'a': char fstr[51];
-			  sprintf(fstr, "(%.15g) ", placeradius->r);
-			  return placeradius->title + fstr;
+	{	case 'a': return fmt::format("{}({:.15}) ", placeradius->title, placeradius->r);
 		case 'r': return regions->front()->code + ' ';			// must have valid pointer
 		case 's': return systems->front()->systemname + ' ';		// must have valid pointer
 		case 'S':

--- a/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySystem/HighwaySystem.cpp
@@ -123,7 +123,7 @@ void HighwaySystem::systems_csv(ErrorList& el)
 			if (line[0] == '#') continue;
 			if (strchr(line.data(), '"'))
 				el.add_error("Double quotes in systems.csv line: "+line);
-			lines.emplace_back(move(line));
+			lines.emplace_back(std::move(line));
 		}
 		it = syslist.alloc(lines.size());
 		for (std::string& l : lines)

--- a/siteupdate/cplusplus/classes/Region/read_csvs.cpp
+++ b/siteupdate/cplusplus/classes/Region/read_csvs.cpp
@@ -52,7 +52,7 @@ void Region::read_csvs(ErrorList& el)
 		std::list<std::string> lines;
 		while(getline(file, line))
 		{	if (line.size() && line.back() == 0x0D) line.pop_back();	// trim DOS newlines
-			if (line.size()) lines.emplace_back(move(line));
+			if (line.size()) lines.emplace_back(std::move(line));
 		}
 		lines.sort(sort_1st_csv_field);
 		it = allregions.alloc(lines.size()+1);

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "Route.h"
 #include "../Args/Args.h"
 #include "../ConnectedRoute/ConnectedRoute.h"
@@ -9,6 +10,7 @@
 #include "../Region/Region.h"
 #include "../Waypoint/Waypoint.h"
 #include "../../functions/tmstring.h"
+#include <fmt/format.h>
 #include <sys/stat.h>
 
 std::unordered_map<std::string, Route*> Route::root_hash, Route::pri_list_hash, Route::alt_list_hash;
@@ -180,9 +182,9 @@ void Route::write_nmp_merged()
 		for (std::string &a : w.alt_labels) wptfile << a << ' ';
 		if (w.near_miss_points.empty())
 		     {	wptfile << "http://www.openstreetmap.org/?lat=";
-			sprintf(fstr, "%.6f", w.lat);
+			*fmt::format_to(fstr, "{:.6f}", w.lat) = 0;
 			wptfile << fstr << "&lon=";
-			sprintf(fstr, "%.6f", w.lng);
+			*fmt::format_to(fstr, "{:.6f}", w.lng) = 0;
 			wptfile << fstr << '\n';
 		     }
 		else {	// for now, arbitrarily choose the northernmost
@@ -195,9 +197,9 @@ void Route::write_nmp_merged()
 				if (other_w->lng > lng)	lng = other_w->lng;
 			}
 			wptfile << "https://www.openstreetmap.org/?lat=";
-			sprintf(fstr, "%.6f", lat);
+			*fmt::format_to(fstr, "{:.6f}", lat) = 0;
 			wptfile << fstr << "&lon=";
-			sprintf(fstr, "%.6f", lng);
+			*fmt::format_to(fstr, "{:.6f}", lng) = 0;
 			wptfile << fstr << '\n';
 			w.near_miss_points.clear();
 		     }

--- a/siteupdate/cplusplus/classes/Route/Route.cpp
+++ b/siteupdate/cplusplus/classes/Route/Route.cpp
@@ -252,14 +252,14 @@ void Route::con_mismatch()
 
 void Route::mark_label_in_use(std::string& label)
 {	unused_alt_labels.erase(label);
-	labels_in_use.insert(move(label));
+	labels_in_use.insert(std::move(label));
 }
 
 void Route::mark_labels_in_use(std::string& label1, std::string& label2)
 {	unused_alt_labels.erase(label1);
 	unused_alt_labels.erase(label2);
-	labels_in_use.insert(move(label1));
-	labels_in_use.insert(move(label2));
+	labels_in_use.insert(std::move(label1));
+	labels_in_use.insert(std::move(label2));
 }
 
 // sort routes by most recent update for use at end of user logs

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -165,7 +165,7 @@ TravelerList::TravelerList(std::string& travname, ErrorList* el)
 TravelerList::~TravelerList() {delete[] traveler_num;}
 
 void TravelerList::get_ids(ErrorList& el)
-{	ids = move(Args::userlist);
+{	ids = std::move(Args::userlist);
 	if (ids.empty())
 	{	DIR *dir;
 		dirent *ent;

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "Waypoint.h"
 #include "../Datacheck/Datacheck.h"
 #include "../DBFieldLength/DBFieldLength.h"
@@ -7,6 +8,7 @@
 #include "../../templates/contains.cpp"
 #include <cmath>
 #include <cstring>
+#include <fmt/format.h>
 #define pi 3.141592653589793238
 
 bool sort_root_at_label(Waypoint *w1, Waypoint *w2)
@@ -74,11 +76,7 @@ Waypoint::Waypoint(char *line, Route *rte)
 }
 
 std::string Waypoint::str()
-{	std::string ans = route->root + " " + label + " (";
-	char s[51]; int
-	e=sprintf(s,"%.15g",lat); if (lat==int(lat)) strcpy(s+e,".0"); ans+=s; ans+=',';
-	e=sprintf(s,"%.15g",lng); if (lng==int(lng)) strcpy(s+e,".0"); ans+=s;
-	return ans + ')';
+{	return fmt::format("{} {} ({:.15},{:.15})", route->root, label, lat, lng);
 }
 
 bool Waypoint::same_coords(Waypoint *other)
@@ -200,10 +198,9 @@ void Waypoint::nmplogs(std::unordered_set<std::string> &nmpfps, std::ofstream &n
 			// both ways (other_w in w's list, w in other_w's list)
 			if (sort_root_at_label(this, other_w))
 			{	char s[51];
-				#define PYTHON_STYLE_FLOAT(F) e=sprintf(s," %.15g",F); if (F==int(F)) strcpy(s+e,".0"); nmpnmp<<s;
-				nmpnmp << root_at_label(); int
-				PYTHON_STYLE_FLOAT(lat)
-				PYTHON_STYLE_FLOAT(lng)
+				nmpnmp << root_at_label();
+				*fmt::format_to(s, " {:.15}", lat)=0; nmpnmp<<s;
+				*fmt::format_to(s, " {:.15}", lng)=0; nmpnmp<<s;
 				if (fp || li)
 				{	nmpnmp << ' ';
 					if (fp) nmpnmp << "FP";
@@ -212,15 +209,14 @@ void Waypoint::nmplogs(std::unordered_set<std::string> &nmpfps, std::ofstream &n
 				nmpnmp << '\n';
 
 				nmpnmp << other_w->root_at_label();
-				PYTHON_STYLE_FLOAT(other_w->lat)
-				PYTHON_STYLE_FLOAT(other_w->lng)
+				*fmt::format_to(s, " {:.15}", other_w->lat)=0; nmpnmp<<s;
+				*fmt::format_to(s, " {:.15}", other_w->lng)=0; nmpnmp<<s;
 				if (fp || li)
 				{	nmpnmp << ' ';
 					if (fp) nmpnmp << "FP";
 					if (li) nmpnmp << "LI";
 				}
 				nmpnmp << '\n';
-				#undef PYTHON_STYLE_FLOAT
 			}
 		}
 		// indicate if this was in the FP list or if it's off by exact amt

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -381,14 +381,10 @@ void Waypoint::label_invalid_char()
 		}
 }
 
-void Waypoint::out_of_bounds(char *s)
+void Waypoint::out_of_bounds()
 {	// out-of-bounds coords
 	if (lat > 90 || lat < -90 || lng > 180 || lng < -180)
-	{	int
-		e=sprintf(s,"(%.15g",lat); if (int(lat)==lat) strcpy(s+e, ".0"); std::string info(s);
-		e=sprintf(s,",%.15g",lng); if (int(lng)==lng) strcpy(s+e, ".0"); info += s;
-		Datacheck::add(route, label, "", "", "OUT_OF_BOUNDS", info+')');
-	}
+	  Datacheck::add(route, label, "", "", "OUT_OF_BOUNDS", fmt::format("({:.15},{:.15})"));
 }
 
 /* checks for visible points */
@@ -561,13 +557,11 @@ void Waypoint::us_letter()
 		Datacheck::add(route, label, "", "", "US_LETTER", "");
 }
 
-void Waypoint::visible_distance(char *fstr, double &vis_dist, Waypoint *&last_visible)
+void Waypoint::visible_distance(double &vis_dist, Waypoint *&last_visible)
 {	// complete visible distance check, omit report for active
 	// systems to reduce clutter
 	if (vis_dist > 10 && !route->system->active())
-	{	sprintf(fstr, "%.2f", vis_dist);
-		Datacheck::add(route, last_visible->label, label, "", "VISIBLE_DISTANCE", fstr);
-	}
+	  Datacheck::add(route, last_visible->label, label, "", "VISIBLE_DISTANCE", fmt::format("{:.2f}", vis_dist));
 	last_visible = this;
 	vis_dist = 0;
 }

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -57,7 +57,7 @@ class Waypoint
 	void hidden_junction();
 	void invalid_url(const char* const, const char* const);
 	void label_invalid_char();
-	void out_of_bounds(char *);
+	void out_of_bounds();
 	// checks for visible points
 	void bus_with_i();
 	void interstate_no_hyphen();
@@ -70,7 +70,7 @@ class Waypoint
 	void lacks_generic();
 	void underscore_datachecks(const char *);
 	void us_letter();
-	void visible_distance(char *, double &, Waypoint *&);
+	void visible_distance(double &, Waypoint *&);
 };
 
 bool sort_root_at_label(Waypoint*, Waypoint*);

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -139,8 +139,8 @@ void WaypointQuadtree::nmplogs()
 				nmpfps.emplace(line, 0, line.size()-20);
 			else if (line.size() >= 55 && !strcmp(line.data()+line.size()-24, " [SOME LOOK INTENTIONAL]"))
 				nmpfps.emplace(line, 0, line.size()-24);
-			else	nmpfps.emplace(move(line));
-		    else	nmpfps.emplace(move(line));
+			else	nmpfps.emplace(std::move(line));
+		    else	nmpfps.emplace(std::move(line));
 	}
 	file.close();
 

--- a/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
+++ b/siteupdate/cplusplus/classes/WaypointQuadtree/WaypointQuadtree.cpp
@@ -1,3 +1,4 @@
+#define FMT_HEADER_ONLY
 #include "WaypointQuadtree.h"
 #include "../Args/Args.h"
 #include "../Datacheck/Datacheck.h"
@@ -6,6 +7,7 @@
 #include "../Route/Route.h"
 #include "../Waypoint/Waypoint.h"
 #include <cstring>
+#include <fmt/format.h>
 #ifdef threading_enabled
 #include <thread>
 #endif
@@ -63,11 +65,8 @@ void WaypointQuadtree::insert(Waypoint *w, bool init)
 				// DUPLICATE_COORDS datacheck
 				for (Waypoint* p : *other_w->colocated)
 				  if (p->route == w->route)
-				  {	char s[48]; int
-					e=sprintf(s,"(%.15g",w->lat); if (int(w->lat)==w->lat) strcpy(s+e, ".0"); std::string info(s);
-					e=sprintf(s,",%.15g",w->lng); if (int(w->lng)==w->lng) strcpy(s+e, ".0"); info += s;
-					Datacheck::add(w->route, p->label, w->label, "", "DUPLICATE_COORDS", info+')');
-				  }
+				    Datacheck::add(w->route, p->label, w->label, "", "DUPLICATE_COORDS",
+						   fmt::format("({:.15},{:.15})", w->lat, w->lng));
 				other_w->colocated->push_back(w);
 				w->colocated = other_w->colocated;
 			}
@@ -169,11 +168,10 @@ void WaypointQuadtree::nmplogs()
 }
 
 std::string WaypointQuadtree::str()
-{	char s[139];
-	sprintf(s, "WaypointQuadtree at (%.15g,%.15g) to (%.15g,%.15g)", min_lat, min_lng, max_lat, max_lng);
+{	std::string s = fmt::format("WaypointQuadtree at ({},{}) to ({},{}", min_lat, min_lng, max_lat, max_lng);
 	if (refined())
-		return std::string(s) + " REFINED";
-	else	return std::string(s) + " contains " + std::to_string(points.size()) + " waypoints";
+		return s + " REFINED";
+	else	return s + " contains " + std::to_string(points.size()) + " waypoints";
 }
 
 unsigned int WaypointQuadtree::size()

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -84,7 +84,7 @@ if (file.is_open())
 			      }
 			delete[] field;
 		     }
-		if (ok)	GraphListEntry::add_group(move(root), move(descr), 'f', regions, systems, a);
+		if (ok)	GraphListEntry::add_group(std::move(root), std::move(descr), 'f', regions, systems, a);
 		else {	delete regions;
 			delete systems;
 			delete a;


### PR DESCRIPTION
Closes #585.
Removes `sprintf` completely.
d4a8716 silences a few warnings from the new clang version on noreaster.

It's possible that XCode may still generate warnings for other functions deprecated for similar reasons, E.G. `styrcpy` used in the subgraph CSV routines.
Feel free to open another issue if this is the case.

"Python style floats", with a `.0` at the end of integral values, are being phased out.
Cleaner simpler code, I'm not worried about keeping things diffable to siteupdate.py now that it's deprecated, and these don't affect anything in practice anyway.
* `Waypoint::str()`
  No instances in nmpfps.log, so no problem.
* tm-master.nmp
  No diffs before <-> after.
* OUT_OF_BOUNDS & DUPLICATE_COORDS datachecks
  No instances in datacheckfps.log, so no problem.

Meanwhile, the one affecting the `waypoints` sql table was phased out in #623 & phased back in in #628.
\*shrug\* Eh, it keeps the .sql files diffable?

![disk-logs](https://github.com/TravelMapping/DataProcessing/assets/13720877/5aee4530-2abb-4361-8229-c038f7775d1d)
Hm. I expected more of a difference when writing to [/dev/null](https://github.com/TravelMapping/DataProcessing/assets/13720877/9ba29993-dc19-4cf4-8d2d-67b67a93a475).
There's lots of copying, comparing & sorting strings, and checking set membership.

![disk-merge1](https://github.com/TravelMapping/DataProcessing/assets/13720877/96825310-f644-4310-b493-f972bad4b683)
What -- lab2 & lab3 are *worse* now? This looks like the [disk access bottleneck variability](https://github.com/TravelMapping/DataProcessing/pull/623#issuecomment-2119599132) that made me start writing to /dev/null. So, I deleted mountains of logs stats & graphs left over from previous runs and tried again.
![disk-merge2](https://github.com/TravelMapping/DataProcessing/assets/13720877/1c109fb2-c4ad-4008-a729-3f34feaf5ba7)
"After" mostly improves on "before" this time around, but we get there by way of stuff performing worse. Go figure.

This may be one of those rare cases when the /dev/null chart is more informative.
![null-merge_12 0](https://github.com/TravelMapping/DataProcessing/assets/13720877/f0ee1a54-8ede-4571-94cd-81f69eab5508)
FreeBSD improves tons. Disk access wasn't the bottleneck; it was `sprintf`.
Let's zoom in.
![null-merge_3 5](https://github.com/TravelMapping/DataProcessing/assets/13720877/8e18a99a-5bca-42e7-a0ae-ca9c8e3d3c70)
Everything scales up well, even if bsdlab lags behind the others.
Lab3 is the fastest on its hardware now, and lab2 is the fastest overall.