### PR TITLE
OUT_OF_BOUNDS bugfix

### DIFF
--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.cpp
@@ -384,7 +384,7 @@ void Waypoint::label_invalid_char()
 void Waypoint::out_of_bounds()
 {	// out-of-bounds coords
 	if (lat > 90 || lat < -90 || lng > 180 || lng < -180)
-	  Datacheck::add(route, label, "", "", "OUT_OF_BOUNDS", fmt::format("({:.15},{:.15})"));
+	  Datacheck::add(route, label, "", "", "OUT_OF_BOUNDS", fmt::format("({:.15},{:.15})", lat, lng));
 }
 
 /* checks for visible points */


### PR DESCRIPTION
an actual OUT_OF_BOUNDS instance would have
```
terminate called after throwing an instance of 'fmt::v10::format_error'
  what():  argument not found
```