### PR TITLE
fix 6-field error precedence for devel systems

### DIFF
--- a/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_chopped_route_segments.cpp
@@ -13,7 +13,7 @@ if (rit == Route::pri_list_hash.end())
 		  {	*c = '?';
 			invalid_char = 1;
 		  }
-		log << "Unknown region/highway combo in line: " << trim_line;
+		log << "Unknown region/route combo in line: " << trim_line;
 		if (invalid_char) log << " [contains invalid character(s)]";
 		log << '\n';
 		splist << lines[l] << endlines[l];
@@ -25,7 +25,7 @@ if (rit == Route::pri_list_hash.end())
 }
 Route* r = rit->second;
 if (r->system->devel())
-{	log << "Ignoring line matching highway in system in development: " << get_trim_line() << '\n';
+{	log << "Ignoring line matching route in system in development: " << get_trim_line() << '\n';
 	splist << lines[l] << endlines[l];
 	free(trim_line);
 	continue;

--- a/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/mark_connected_route_segments.cpp
@@ -28,8 +28,8 @@ if (rit1 == Route::alt_list_hash.end() || rit2 == Route::alt_list_hash.end())
 	for (char& c : lookup1) if (iscntrl(c)) c = '?';
 	for (char& c : lookup2) if (iscntrl(c)) c = '?';
 	if (rit1 == rit2)
-		log << "Unknown region/highway combos " << lookup1 << " and " << lookup2 << " in line: " << trim_line;
-	else {	log << "Unknown region/highway combo ";
+		log << "Unknown region/route combos " << lookup1 << " and " << lookup2 << " in line: " << trim_line;
+	else {	log << "Unknown region/route combo ";
 		log << (rit1 == Route::alt_list_hash.end() ? lookup1 : lookup2);
 		log << " in line: " << trim_line;
 	     }
@@ -41,17 +41,17 @@ if (rit1 == Route::alt_list_hash.end() || rit2 == Route::alt_list_hash.end())
 }
 Route* r1 = rit1->second;
 Route* r2 = rit2->second;
+if (r1->system->devel() || r2->system->devel())
+{	log << "Ignoring line matching route(s) in system in development: " << get_trim_line() << '\n';
+	splist << lines[l] << endlines[l];
+	free(trim_line);
+	continue;
+}
 if (r1->con_route != r2->con_route)
 {	log << lookup1 << " and " << lookup2 << " not in same connected route in line: " << get_trim_line() << '\n';
 	splist << lines[l] << endlines[l];
 	UPDATE_NOTE(r1->con_route->roots.front()) if (r1->con_route->roots.size() > 1) UPDATE_NOTE(r1->con_route->roots.back())
 	UPDATE_NOTE(r2->con_route->roots.front()) if (r2->con_route->roots.size() > 1) UPDATE_NOTE(r2->con_route->roots.back())
-	free(trim_line);
-	continue;
-}
-if (r1->system->devel())
-{	log << "Ignoring line matching highway in system in development: " << get_trim_line() << '\n';
-	splist << lines[l] << endlines[l];
 	free(trim_line);
 	continue;
 }


### PR DESCRIPTION
https://travelmapping.net/updates/2024-08-18@21:57:32/logs/users/ssoworld.log
> ...
Ignoring line matching highway in system in development: IA LinHwy US30_Whe IA LinHwy CRY44
Ignoring line matching highway in system in development: IA LinHwy US30_GM IA LinHwy US30/61
IA LINHWY and IL LINHWY not in same connected route in line: IA LinHwy US30_DW IL LinHwy US30_Ste
Ignoring line matching highway in system in development: IL LinHwy IL40 IL LinHwy US52_S
Ignoring line matching highway in system in development: IL LinHwy IL251_S IL LinHwy IL251_N
...

This changes the middle error to another `Ignoring line matching route(s) in system in development` error.
That's the more important error here; as-is, it could kinda give the impression that we'd be able to mark travels on these routes if not for the ConnectedRoute error.

---

Along the way, changes "highway" to "route" in userlog errors, as we're expanding beyond highways now.