### PR TITLE
listfileinfo.csv robustness improvements

### DIFF
--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -12,7 +12,7 @@
 /* w */ std::string Args::datapath = "../../HighwayData";
 /* s */ std::string Args::systemsfile = "systems.csv";
 /* u */ std::string Args::userlistfilepath = "../../UserData/list_files";
-/* x */ std::string Args::userlistextension = ".list";
+/* x */ std::string Args::userlistext = ".list";
 /* d */ std::string Args::databasename = "TravelMapping";
 /* l */ std::string Args::logfilepath = ".";
 /* c */ std::string Args::csvstatfilepath = ".";
@@ -42,7 +42,7 @@ bool Args::init(int argc, char *argv[])
 		else if ARG(1, "-w", "--datapath")		{datapath	  = argv[++n];}
 		else if ARG(1, "-s", "--systemsfile")		{systemsfile      = argv[++n];}
 		else if ARG(1, "-u", "--userlistfilepath")	{userlistfilepath = argv[++n];}
-		else if ARG(1, "-x", "--userlistextension")	{userlistextension = argv[++n];}
+		else if ARG(1, "-x", "--userlistext")		{userlistext	  = argv[++n];}
 		else if ARG(1, "-d", "--databasename")		{databasename     = argv[++n];}
 		else if ARG(1, "-l", "--logfilepath")		{logfilepath      = argv[++n];}
 		else if ARG(1, "-c", "--csvstatfilepath")	{csvstatfilepath  = argv[++n];}
@@ -83,7 +83,7 @@ bool Args::init(int argc, char *argv[])
 void Args::show_help()
 {	std::string indent(strlen(exec), ' ');
 	std::cout  <<  "usage: " << exec << " [-h] [-w DATAPATH] [-s SYSTEMSFILE]\n";
-	std::cout  <<  indent << "        [-u USERLISTFILEPATH] [-x USERLISTEXTENSION] [-d DATABASENAME] [-l LOGFILEPATH]\n";
+	std::cout  <<  indent << "        [-u USERLISTFILEPATH] [-x USERLISTEXT] [-d DATABASENAME] [-l LOGFILEPATH]\n";
 	std::cout  <<  indent << "        [-c CSVSTATFILEPATH] [-g GRAPHFILEPATH] [-k]\n";
 	std::cout  <<  indent << "        [-n NMPMERGEPATH] [-p SPLITREGIONPATH SPLITREGION]\n";
 	std::cout  <<  indent << "        [-U USERLIST [USERLIST ...]] [-t NUMTHREADS] [-e]\n";
@@ -101,7 +101,7 @@ void Args::show_help()
 	std::cout  <<  "		        file of highway systems to include\n";
 	std::cout  <<  "  -u USERLISTFILEPATH, --userlistfilepath USERLISTFILEPATH\n";
 	std::cout  <<  "		        path to the user list file data\n";
-	std::cout  <<  "  -x USERLISTEXTENSION, --userlistextension USERLISTEXTENSION\n";
+	std::cout  <<  "  -x USERLISTEXT, --userlistext USERLISTEXT\n";
 	std::cout  <<  "		        file extension for user list files\n";
 	std::cout  <<  "  -d DATABASENAME, --databasename DATABASENAME\n";
 	std::cout  <<  "		        Database name for .sql file name\n";

--- a/siteupdate/cplusplus/classes/Args/Args.h
+++ b/siteupdate/cplusplus/classes/Args/Args.h
@@ -6,7 +6,7 @@ class Args
 	/* w */ static std::string datapath;
 	/* s */ static std::string systemsfile;
 	/* u */ static std::string userlistfilepath;
-	/* x */ static std::string userlistextension;
+	/* x */ static std::string userlistext;
 	/* d */ static std::string databasename;
 	/* l */ static std::string logfilepath;
 	/* c */ static std::string csvstatfilepath;

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -244,7 +244,11 @@ void TravelerList::read_listinfo(ErrorList& el)
 
 	// read data lines and add entries to the listinfo map
 	while (std::getline(file, line))
-	{	std::vector<std::string> fields;
+	{	while ( !line.empty() && strchr(" \t", line.back()) )	// remove trailing whitespace
+			line.pop_back();				// (don't bother with leading)
+		if (line.empty()) continue;				// skip blank lines
+
+		std::vector<std::string> fields;
 		// read the first field, the listname, save as the map key
 		spn = strcspn(line.data(), ";");
 		std::string listname(line, 0, spn);

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -17,7 +17,7 @@ TravelerList::TravelerList(std::string& travname, ErrorList* el)
 	traveler_num = new unsigned int[Args::numthreads];
 		       // deleted by ~TravelerList
 	traveler_num[0] = this - allusers.data; // init for master traveled graph
-	traveler_name.assign(travname, 0, travname.size()-Args::userlistextension.length()); // strip ".list" or other extension from end of travname
+	traveler_name.assign(travname, 0, travname.size()-Args::userlistext.size()); // strip extension from end of travname
 	if (traveler_name.size() > DBFieldLength::traveler)
 	  el->add_error("Traveler name " + traveler_name + " > " + std::to_string(DBFieldLength::traveler) + "bytes");
 
@@ -172,14 +172,15 @@ void TravelerList::get_ids(ErrorList& el)
 		if ((dir = opendir (Args::userlistfilepath.data())) != NULL)
 		{	while ((ent = readdir (dir)) != NULL)
 			{	std::string trav(ent->d_name);
-				if (trav.size() > Args::userlistextension.length() && !trav.compare(trav.size() - Args::userlistextension.length(), Args::userlistextension.length(), Args::userlistextension))
-					ids.push_back(trav);
+				if (	trav.size() > Args::userlistext.size()
+				     && trav.data() + trav.size() - Args::userlistext.size() == Args::userlistext
+				   )	ids.push_back(trav);
 			}
 			closedir(dir);
 		}
 		else	el.add_error("Error opening user list file path \""+Args::userlistfilepath+"\". (Not found?)");
 	}
-	else for (std::string& id : ids) id += Args::userlistextension;
+	else for (std::string& id : ids) id += Args::userlistext;
 	ids.sort();
 	tl_it = allusers.alloc(ids.size());
 }

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -209,10 +209,6 @@ double TravelerList::system_miles(HighwaySystem *h)
 /* Read listfileinfo.csv file and augment TravelerList entries in allusers */
 void TravelerList::read_listinfo(ErrorList& el)
 {	std::ifstream file(Args::userlistfilepath+"/listfileinfo.csv");
-	if (!file.is_open())
-	{	el.add_error("Error opening listfileinfo.csv file.");
-		return;
-	}
 	std::string line;
 	size_t spn;
 
@@ -239,8 +235,11 @@ void TravelerList::read_listinfo(ErrorList& el)
 
 	// check that the number of defaults matches the number of fieldnames
 	if (fieldnames.size() != defaults.size())
-	{	el.add_error("Number of defaults does not match number of fieldnames in listfileinfo.csv.");
-		return;
+		el.add_error("Number of defaults does not match number of fieldnames in listfileinfo.csv.");
+	// failsafe defaults if not supplied / malformed listfileinfo.csv
+	switch (defaults.size()) // fall-thru is a Good Thing!
+	{	case 0:	defaults.emplace_back();
+		case 1:	defaults.emplace_back("1");
 	}
 
 	// read data lines and add entries to the listinfo map

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -257,7 +257,9 @@ void TravelerList::read_listinfo(ErrorList& el)
 			continue;
 		}
 		// add the fields to the map
-		TravelerList::listinfo[listname] = fields;	
+		if (!listinfo.emplace(std::move(listname), std::move(fields)).second) // C++17: use try_emplace...
+			// C++17: ...and listname won't be stolen; safe to use it instead of line.substr
+			el.add_error("Multiple entries for " + line.substr(0, line.find(';')) + " in listfileinfo.csv");
 	}
 	file.close();
 }

--- a/siteupdate/cplusplus/tasks/threaded/ReadList.cpp
+++ b/siteupdate/cplusplus/tasks/threaded/ReadList.cpp
@@ -8,7 +8,7 @@
 		// placement new
       #endif
 	if (TravelerList::file_not_found)
-	  {	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure " << Args::userlistextension << " files for all specified users exist.\nAborting." << endl;
+	  {	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure " << Args::userlistext << " files for all specified users exist.\nAborting." << endl;
 		return 1;
 	}
 	TravelerList::ids.clear();


### PR DESCRIPTION
Earlier vesions of 178644a & c00e9c6 were ancestors of my hidden system work in progress.
I hit pause on that after discovering the crashes that c38c5bd fixes, in order to work on robustness & get this stuff sorted.
The hidden system commits have been rebased on top of these ones.

A walk through the commits...

### 178644a variable name cleanup
De minimis readability improvements.
Being anal for the sake of being anal, really. :)

### c38c5bd failsafe traveler defaults
A quality-of-life improvement for me as a developer.
When working with older UserData commits with no listfileinfo.csv, these *"default defaults"* allow me to use an empty file as a placeholder.
Without them, writing the listEntries DB table would attempt to read past the end of the `TravelerList::defaults` vector, and crash.
Now, with an empty file I can write a valid DB. A *Missing* file = an `ErrorList` error & thus skipping the DB. More on this below.

### 4b71d2a strcspn-based readfields lambda
* More robust in handling CSVs with just one column (ie, just the listnames).
  Before, the one column would get re-parsed as a phantom 2nd column, as the 1st datum. Fixed.
* Using the C-string `strscpn` function simplifies & cleans up the `for` loops.
  It returns the length of a field, whether it ends at the delimiter or null terminator, letting us remove `next_delim` entirely.
  Plus it brings the `c` and `spn` variables in line with other uses program-wide -- `c` + `spn` = `strcspn`! :)
* In addition, a lambda cuts down on boilerplate & keeps all that stuff in one place.
* Removed a few extraneous scope resolution operators.

### c00e9c6 listfileinfo.csv not found
Originally, this just added the full path to the error text when the file was missing.
Now, proceeds through the rest of the function, with the variables/lambdas/loops all doing nothing until the "default defaults" are assigned.
This may be more useful in the future if we do more with this data than just dump it into the DB. (E.G., #636?)
For now, we have all the info necessary *to* write a valid DB; we just don't because there's an ErrorList error. More on *this* below.

### 385f8e8 std::move keys/values to listinfo
Replaced a bunch of memory copies with a couple moves, though in practice it won't save enough time to notice. :)
An errorcheck for multiple entries for the same user was super easy to do at the same time, so in it goes, even if it's not the most useful thing.

### 0493474 trim trailing whitespace & skip blank lines
`terescoj;Jim's lifetime travels;1`
`terescoj;Jim's lifetime travels;1 `
See the difference? The former would put TRUE in the DB as expected; the latter FALSE.
Trying to trim *leading* whitespace messed with my existing code & lambdas, so I'm not bothering with it. It's way easier to spot in a text editor than trailing anyway.
It's common for blank lines to make their way into a file; skipping them prevents `Number of fields does not match number of fieldnames` errors.

# *The question is...*
Should a missing listfileinfo.csv still be an errorcheck error?
* **No?** [If fullcustom.csv can't be opened, siteupdate skips right over that bit and writes a valid DB, no harm no foul.](https://github.com/TravelMapping/DataProcessing/blob/d4a8716/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp#L3) Same deal here.
  I'd like to be able to freely checkout & work with older repos without having to temporarily modify the code or create a dummy file.
* **Yes?** All I can really think of here is, it lets us know if a bad commit accidentally deletes an existing file or changes permissions or whatever. But how likely is that?

@jteresco, thoughts?
I'd kinda like to make a missing file not an error.
If that's OK, then I'll do some rebasing & get all this done in one less commit.