### PR TITLE
LABEL_INVALID_CHAR & MALFORMED_URL improvements

### DIFF
--- a/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
+++ b/siteupdate/cplusplus/classes/Datacheck/Datacheck.h
@@ -47,7 +47,7 @@ class Datacheck
     LOWERCASE_SUFFIX       |
     MALFORMED_LAT          | malformed "lat=" parameter from OSM url
     MALFORMED_LON          | malformed "lon=" parameter from OSM url
-    MALFORMED_URL          | always "MISSING_ARG(S)"
+    MALFORMED_URL          | fits & no bad chars ? URL : MISSING_ARG(S)
     NONTERMINAL_UNDERSCORE |
     OUT_OF_BOUNDS          | coordinate pair
     SHARP_ANGLE            | angle in degrees

--- a/siteupdate/cplusplus/classes/Route/read_wpt.cpp
+++ b/siteupdate/cplusplus/classes/Route/read_wpt.cpp
@@ -59,7 +59,7 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 		char* e = l[1]-2;		// -2 skips over the 0 inserted while splitting wptdata into lines
 		while (*e == 0) e--;		// skip back more for CRLF cases, and lines followed by blank lines
 		while (*e == ' ' || *e == '\t') *e-- = 0;
-		try {new(w) Waypoint(*l, this);}
+		try {new(w) Waypoint(*l, this, *el, wptdata);}
 		     // placement new
 		catch (const int) SKIP
 		#undef SKIP
@@ -74,7 +74,6 @@ void Route::read_wpt(WaypointQuadtree *all_waypoints, ErrorList *el, bool usa_fl
 
 		// single-point Datachecks, and HighwaySegment
 		w->out_of_bounds();
-		w->label_invalid_char();
 		if (w > points.data)
 		{	// add HighwaySegment, if not first point
 			new(s) HighwaySegment(w, this);

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -1,3 +1,4 @@
+class ErrorList;
 class HGVertex;
 class HighwayGraph;
 class HighwaySystem;
@@ -30,7 +31,7 @@ class Waypoint
 	std::forward_list<Waypoint*> near_miss_points;
 	bool is_hidden;
 
-	Waypoint(char *, Route *);
+	Waypoint(char *, Route *, ErrorList&, char* const);
 
 	std::string str();
 	bool same_coords(Waypoint *);
@@ -56,7 +57,6 @@ class Waypoint
 	// Datacheck
 	void hidden_junction();
 	void invalid_url(const char* const, const char* const);
-	void label_invalid_char();
 	void out_of_bounds();
 	// checks for visible points
 	void bus_with_i();

--- a/siteupdate/cplusplus/classes/Waypoint/validate_label.cpp
+++ b/siteupdate/cplusplus/classes/Waypoint/validate_label.cpp
@@ -1,0 +1,57 @@
+auto validate_label = [&](char* lbl, char* end)
+{	char* c = lbl;
+	if ([&]() // verify valid sequence of leading + or *
+	{	if (*c == '+' || *c == '*')
+		  if (*++c == '+') return 1;
+		  else if (*c == '*')
+		  {	if (c++[-1] == '*') return 1;
+		  }
+		  else if (!*c) return 1;
+		return 0;
+	}())	return Datacheck::add(rte, lbl, "", "", "LABEL_INVALID_CHAR", "");
+
+	bool flag = 0;	// once set to 1, keep going to find bad chars that can't go in DB, logfile, or terminal
+	do {	if	    (*c <= '@')	// 1/2
+		  if	    (*c <= ')') // 1/4
+		    if	    (*c <  ' '){el.add_error(fmt::format("control character(s) in label at offset {} ({:#X}) in {}/{}/{}.wpt",
+						     c-wptdata, c-wptdata, rte->region->code, rte->system->systemname, rte->root));
+					// As ErrorList error means no DB is created in order to populate the datacheck page, and putting
+					// control chars in the middle of datacheck.log is bad juju, let's skip the datacheck entry and...
+					break;}		//| up to 31 | control
+		    else if (*c <='\''){if (lbl == line)//|	     |
+					   el.add_error(fmt::format("`{}` character in label in {}/{}/{}.wpt",
+							*c, rte->region->code, rte->system->systemname, rte->root));
+					flag = 1;}	//| 32 to 39 | space !"#$%&'
+		    else		continue;	//| 40 to 41 | ()
+		  else			// 2/4		//|----------|
+		    if	    (*c <= ',')	flag = 1;	//| 42 to 44 | *+,
+		    else if (*c <= '9')	continue;	//| 45 to 57 | -./ 0-9
+		    else		flag = 1;	//| 58 to 64 | :;<=>?@
+		else			// 2/2		//|__________|
+		  if	    (*c <= '_')	// 3/4		//|	     |
+		    if	    (*c <= 'Z')	continue;	//| 65 to 90 | A-Z
+		    else if (*c <= '^'){if (*c == '\\') //|	     |
+					   el.add_error(fmt::format("backslash in label in {}/{}/{}.wpt",
+							rte->region->code, rte->system->systemname, rte->root));
+					flag = 1;}	//| 91 to 94 | [\]^
+		    else		continue;	//|    95    | _
+		  else			// 4/4		//|__________|
+		    if	    (*c <= 'z')	// 7/8		//|	     |
+		      if    (*c == '`')	flag = 1;	//|    96    | `
+		      else		continue;	//| 97 - 122 | a-z
+		    else		// 8/8		//|----------|
+		      if    (*c <= '~')	flag = 1;	//| 123..126 | {|}~
+		      else	       {el.add_error(fmt::format("ASCII DEL in label at offset {} ({:#X}) in {}/{}/{}.wpt",
+						     c-wptdata, c-wptdata, rte->region->code, rte->system->systemname, rte->root));
+					// Again, let's skip the datacheck entry and...
+					break;}		//|    127   | DEL
+	   }	while (++c < end);   /* Yes, I could rearrange the tree to process [\]^ one branch faster.
+					But those characters won't be present in clean data anyway, and it
+					disrupts the organization of the code & makes things less readable. */
+	if (flag)
+	{	std::string str = end - lbl <= DBFieldLength::label
+		? std::string(lbl, end) // or cut down to fit in DB if needed. Likely to be URL, so save the end
+		: std::string("...").append(end - DBFieldLength::label + 3, DBFieldLength::label - 3);
+		Datacheck::add(rte, str, "", "", "LABEL_INVALID_CHAR", "");
+	}
+};


### PR DESCRIPTION
https://github.com/TravelMapping/RailwayData/pull/187#issuecomment-2323107288
This does run a tiny tiny bit faster on BiggaTomato. Not making any pretty pictures this time though. :)
There will be another pull request in the Web repo to accompany this one.

---

This ended up being a bit of a rabbit hole. In a good way.

Among the invalid characters prohibited from labels are control characters.
The chances of these appearing in a .wpt are pretty low, but I decided to go the extra mile to handle them just in case.
We can't put these in an ErrorList message because attempting to print them to the terminal could make stuff go boom.
Truncating the label or skipping or replacing the offending characters sounds good at first, but that can leave us with *no* info on what the offending label is or where to find it in the file.
For a more robust solution, I opted to show the offset in .wpt file. If the :poop: hits the fan, load the file into your favorite hex editor and have fun. It works, even if it's not convenient, and was pretty simple to code.

Doing this involved moving the LABEL_INVALID_CHAR check into the Waypoint constructor, where we have the info needed to calculate the offset on hand.
**This is where things got interesting.**

Looking at the results of the 1st draft, I saw:
**`diff _37c5/logs/datacheck.log logs/datacheck.log`**
```diff
1c1
< Log file created at: Tue Sep 17 09:19:51 2024
---
> Log file created at: Tue Sep 17 09:20:17 2024
9424a9425,9426
> mexbc.mex003ens;#name;;;LABEL_INVALID_CHAR;
> mexbc.mex003ens;#sign;;;LABEL_INVALID_CHAR;
9427a9430,9431
> mexbc.mex003ens;http://www.openstreetmap.org/?lat=31.902864&lon=-116.541553;;;LABEL_INVALID_CHAR;
> mexbc.mex003ens;http://www.openstreetmap.org/?lat=31.911776&lon=-116.610442;;;LABEL_INVALID_CHAR;
```
* New datacheck errors? How did these not get flagged before?
* And what's this? With errors like these, it looks like *comments* in a .wpt file...

Let's take a look at [the file](https://github.com/TravelMapping/HighwayData/blob/0cdb6a332a7c7a79b0da85cfdb72e4f5a81268e2/hwy_data/MEX-BC/mexf/mexbc.mex003ens.wpt):
```
MEX3_S http://www.openstreetmap.org/?lat=31.878706&lon=-116.525202
AveCal http://www.openstreetmap.org/?lat=31.902864&lon=-116.541553 #name assumed from Google Maps
+X958691 http://www.openstreetmap.org/?lat=31.914285&lon=-116.551487
+X463217 http://www.openstreetmap.org/?lat=31.921661&lon=-116.581421
Ruiz http://www.openstreetmap.org/?lat=31.911776&lon=-116.610442 #sign says Entronque Ruiz AKA Ruiz Junction
+X892185 http://www.openstreetmap.org/?lat=31.898583&lon=-116.620055
+X413693 http://www.openstreetmap.org/?lat=31.891842&lon=-116.647296
+X278091 http://www.openstreetmap.org/?lat=31.898273&lon=-116.668088
MEX3_N http://www.openstreetmap.org/?lat=31.920022&lon=-116.682873
```
Of course, comments are not supported in .wpt files. So what's really happening here?
* `AveCal` is the primary label.
* `http://www.openstreetmap.org/?lat=31.902864&lon=-116.541553` looks like a URL, but is really the first AltLabel.
* `#name assumed from Google` looks like a comment, but is really 4 separate AltLabels.
* `Maps` looks like a comment, but is really a malformed URL.

...And sure enough, in datacheck.log:
`mexbc.mex003ens;AveCal;;;MALFORMED_URL;MISSING_ARG(S)`
Maybe not the most helpful `Info` text. I could see someone asking, "What the hell? It's a perfectly fine URL, nothing missing!"
So I've changed MALFORMED_URL to read like:
`mexbc.mex003ens;AveCal;;;MALFORMED_URL;Maps`
`mexbc.mex003ens;Ruiz;;;MALFORMED_URL;Junction` 
...More helpful to see what it is that siteupdate's trying to parse as the URL.
It'll only say "MISSING_ARG(S)" now if the string is too long to fit in the DB, or has characters that shouldn't go in it like backslashes, quotes or control chars.

**Why weren't the new errors flagged before?**
**Before,** there was a `Waypoint::label_invalid_char()` function, called on complete Waypoint objects.
Problem was, without a valid URL, there's no way to get valid coords, so the line gets thrown out, Waypoint never created.
**Now?** Errors get flagged as label strings get validated right from the original `wptdata` buffer, before the URL is parsed, before a Waypoint is created/thrown out.

Altogether, the new and changed error reports should give a better indication what's going on with mexbc.mex003ens.