### PR TITLE
process .time files for any user list extension

### DIFF
--- a/siteupdate/cplusplus/classes/Args/Args.cpp
+++ b/siteupdate/cplusplus/classes/Args/Args.cpp
@@ -75,6 +75,11 @@ bool Args::init(int argc, char *argv[])
 			splitregionapp = argv[++n];
 			splitregion = argv[++n];
 		}
+
+		if (userlistext.size() < 2)
+		{	std::cout << "Fatal error: user list file extension must be at least 2 characters.\n";
+			return 1;
+		}
 	}
 	#undef ARG
 	return 0;

--- a/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
+++ b/siteupdate/cplusplus/classes/TravelerList/TravelerList.cpp
@@ -35,7 +35,7 @@ TravelerList::TravelerList(std::string& travname, ErrorList* el)
 	log << ctime(&StartTime);
 	mtx.unlock();
 	// write last update date & time if known
-	std::ifstream file(Args::userlistfilepath+"/../time_files/"+traveler_name+".time");
+	std::ifstream file(Args::userlistfilepath+"/../time_files/"+&Args::userlistext[1]+'/'+travname+".time");
 	if (file.is_open())
 	{	getline(file, update);
 		if (update.size())

--- a/siteupdate/siteupdate.sh
+++ b/siteupdate/siteupdate.sh
@@ -31,8 +31,7 @@ compress=0
 compressflag=
 repo=HighwayData
 listdir=list_files
-listext=.list
-timedir=time_files
+listext=list
 dbname=TravelMapping
 datatype=Highways
 
@@ -145,8 +144,7 @@ for arg in "$@"; do
 	grapharchives=rgrapharchives
 	repo=RailwayData
 	listdir=rlist_files
-	listext=.rlist
-	timedir=rtime_files
+	listext=rlist
 	dbname=TravelMappingRail
     elif [[ "$arg" == --graphs ]]; then
 	graphflag=
@@ -253,7 +251,7 @@ else # C++
     if [[ "$makesiteupdate" == "1" ]]; then
 	echo "$0: compiling the latest siteupdate program"
 	cd cplusplus
-	$make
+	$make -j $numthreads
 	cd - > /dev/null
     fi
     if [[ "$numthreads" != "1" ]]; then
@@ -323,16 +321,16 @@ echo UserData '@' `(cd $tmbasedir/UserData; git show -s | head -n 1 | cut -f2 -d
 echo DataProcessing '@' `git show -s | head -n 1 | cut -f2 -d' '` | tee -a $indir/$logdir/siteupdate.log
 
 echo "$0: creating .time files"
-mkdir -p $tmbasedir/UserData/$timedir
-cd $tmbasedir/UserData/$timedir
-for t in `ls ../$listdir/*$listext | sed -r "s~../$listdir/(.*)$listext~\1.time~"`; do $make -s $t; done
+mkdir -p $tmbasedir/UserData/time_files/$listext
+cd $tmbasedir/UserData/time_files/
+$make -s -j $numthreads `ls ../$listdir/*.$listext | sed -r "s~../$listdir/(.*)~$listext/\1.time~"`
 cd - > /dev/null
   
 if [[ "$nmpmdir" != "" ]]; then
     nmpmflags="-n $indir/$nmpmdir"
 fi
 echo "$0: launching $siteupdate"
-$siteupdate $errorcheck -d $dbname-$datestr $graphflag -l $indir/$logdir -c $indir/$statdir -g $indir/$graphdir $nmpmflags -w $tmbasedir/$repo -u $tmbasedir/UserData/$listdir -x $listext | tee -a $indir/$logdir/siteupdate.log 2>&1 || exit 1
+$siteupdate $errorcheck -d $dbname-$datestr $graphflag -l $indir/$logdir -c $indir/$statdir -g $indir/$graphdir $nmpmflags -w $tmbasedir/$repo -u $tmbasedir/UserData/$listdir -x .$listext | tee -a $indir/$logdir/siteupdate.log 2>&1 || exit 1
 date
 
 echo "$0: appending rank table creation to SQL file"


### PR DESCRIPTION
Closes #646.

Most of the changes here are in siteupdate.sh.
The structure of how .time files are named & stored in the UserData repo has changed:
```
UserData/time_files/
  list/
    terescoj.list.time
    yakra.list.time
    etc.
  rlist/
    terescoj.rlist.time
    yakra.rlist.time
    etc.
```
This was the simplest to implement from both a siteupdate & siteupdate.sh perspective while keeping things consistent & also being extensible for future user list file extensions.

We're down to one Makefile now, that handles any user list extension & puts the corresponding .time file in the appropriate subdirectory. Less to maintain; won't have to make additional Makefiles in the future.
While we're at it, `$make -j $numthreads` is invoked for multi-threaded building of .time files & siteupdate itself.

There will be a UserData pull request with the new Makefile to accompany this.