### PR TITLE
segment name mismatch -> HIDDEN_JUNCTION

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -32,12 +32,6 @@ HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *edge1, HGEdge *
 {	// build by collapsing two existing edges around a common hidden vertex
 	c_idx = vertex - v_array;
 	format = fmt_mask;
-	// segment names should match as routes should not start or end
-	// nor should concurrencies begin or end at a hidden point
-	if (edge1->segment_name != edge2->segment_name)
-	{	std::cout << "ERROR: segment name mismatch in HGEdge collapse constructor: ";
-		std::cout << "edge1 named " << edge1->segment_name << " edge2 named " << edge2->segment_name << '\n' << std::endl;
-	}
 	segment_name = edge1->segment_name;
 	/*std::cout << "\nDEBUG: collapsing edges |";
 	if (fmt_mask & collapsed) std::cout << 'c';	else std::cout << '-';
@@ -45,9 +39,6 @@ HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *edge1, HGEdge *
 	std::cout << "| along " << segment_name << " at vertex " << *(vertex->unique_name);
 	std::cout << "\n       edge1 is " << edge1->str();
 	std::cout << "\n       edge2 is " << edge2->str() << std::endl;//*/
-	// segment and route names/systems should also match, but not
-	// doing that sanity check here, as the above check should take
-	// care of that
 	segment = edge1->segment;
 
 	// figure out and remember which endpoints are not the

--- a/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HGEdge.cpp
@@ -28,12 +28,10 @@ HGEdge::HGEdge(HighwaySegment *s)
 	segment = s;
 }
 
-HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *e1, HGEdge *e2)
+HGEdge::HGEdge(HGVertex *vertex, unsigned char fmt_mask, HGEdge *edge1, HGEdge *edge2)
 {	// build by collapsing two existing edges around a common hidden vertex
 	c_idx = vertex - v_array;
 	format = fmt_mask;
-	HGEdge *edge1 = e1;
-	HGEdge *edge2 = e2;
 	// segment names should match as routes should not start or end
 	// nor should concurrencies begin or end at a hidden point
 	if (edge1->segment_name != edge2->segment_name)

--- a/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
+++ b/siteupdate/cplusplus/classes/GraphGeneration/HighwayGraph.cpp
@@ -87,6 +87,19 @@ HighwayGraph::HighwayGraph(WaypointQuadtree &all_waypoints, ElapsedTime &et)
 			{	v.visibility = 2;
 				continue;
 			}
+			if (!v.incident_edges[0]->segment->same_ap_routes(v.incident_edges[1]->segment))
+			{ /*	std::cout << "\nWARNING: segment name mismatch in HGEdge collapse constructor: ";
+				std::cout << "edge1 named " << v.incident_edges[0]->segment->segment_name()
+					  <<" edge2 named " << v.incident_edges[1]->segment->segment_name() << std::endl;
+				std::cout << "  vertex " << *v.unique_name << " unhidden" << std::endl;
+				std::cout << "  waypoints:";
+				Waypoint* w = v.incident_edges[0]->segment->waypoint2;
+				if (w->lat != v.lat || w->lng != v.lng) w = v.incident_edges[0]->segment->waypoint1;
+				for (Waypoint* p : *w->colocated) std::cout << ' ' << p->root_at_label();
+				std::cout << std::endl; //*/
+				v.visibility = 2;
+				continue;
+			}
 			// construct from vertex this time
 			--ce; --cv;
 			// if edge clinched_by sets mismatch, set visibility to 1

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -121,3 +121,48 @@ HighwaySegment* HighwaySegment::canonical_edge_segment()
 	// Nonetheless, let's stop the compiler from complaining.
 	throw 0xBAD;
 }
+
+bool HighwaySegment::same_ap_routes(HighwaySegment* other)
+{	iterator a(this);	if (a.s->route->system->level & (char)12) a.next_ap();
+	iterator b(other);	if (b.s->route->system->level & (char)12) b.next_ap();
+	// do-while is safe here. This function only gets called on segments
+	// that are or are concurrent with active/preview, so the iterators are
+	// not past the valid segments, and *a and *b are safe to dereference.
+	do {	if ((*a)->route != (*b)->route) return 0;
+		a.next_ap();
+		b.next_ap();
+	   }	while (*a && *b);
+	return *a == *b;
+}
+
+bool HighwaySegment::same_vis_routes(HighwaySegment* other)
+{	iterator a(this), b(other);
+	do {	if ((*a)->route != (*b)->route) return 0;
+		a.next_vis();
+		b.next_vis();
+	   }	while (*a && *b);
+	return *a == *b;
+}
+
+HighwaySegment::iterator::iterator(HighwaySegment* seg): concurrent(seg->concurrent)
+{	if (concurrent)
+	{	i = concurrent->begin();
+		s = *i;
+	} else	s = seg;
+}
+
+HighwaySegment* HighwaySegment::iterator::operator * () const {return s;}
+
+void HighwaySegment::iterator::next_ap()
+{	if (!concurrent) {s=0; return;}
+	do if (++i == concurrent->end()) {s=0; return;}
+	while ((*i)->route->system->level & (char)12);
+	s = *i;
+}
+
+void HighwaySegment::iterator::next_vis()
+{	if (!concurrent) {s=0; return;}
+	do if (++i == concurrent->end() /*|| (*i)->route->system->level == 'h'*/) {s=0; return;}
+	while (1);
+	s = *i;
+}

--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.h
@@ -19,6 +19,8 @@ class HighwaySegment
 	std::list<HighwaySegment*> *concurrent;
 	TMBitset<TravelerList*, uint32_t> clinched_by;
 
+	class iterator;
+
 	HighwaySegment(Waypoint*, Route*);
 	~HighwaySegment();
 
@@ -31,4 +33,21 @@ class HighwaySegment
 	const char* clinchedby_code(char*, unsigned int);
 	void write_label(std::ofstream&, std::vector<HighwaySystem*> *);
 	HighwaySegment* canonical_edge_segment();
+	bool same_ap_routes(HighwaySegment*);
+	bool same_vis_routes(HighwaySegment*);
+};
+
+class HighwaySegment::iterator
+{	HighwaySegment* s;
+	decltype(s->concurrent) concurrent;
+	decltype(s->concurrent->begin()) i;
+
+	friend bool HighwaySegment::same_ap_routes(HighwaySegment*);
+
+	public:
+	iterator(HighwaySegment*);
+
+	HighwaySegment* operator * () const;
+	void next_ap();
+	void next_vis();
 };

--- a/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
+++ b/siteupdate/cplusplus/classes/Waypoint/Waypoint.h
@@ -52,7 +52,6 @@ class Waypoint
 	Route* self_intersection();
 	bool banner_after_slash(const char*);
 	Route* coloc_banner_matches_abbrev();
-	void add_to_adjacent(std::vector<void*>&);
 
 	// Datacheck
 	void hidden_junction();


### PR DESCRIPTION
* Closes #360
  The meaning of this issue changed & its title became less accurate over time.
  Now, it's not about unhiding hidden termini in the HB, but more about unhiding graph vertices (in the `HGVertex::visibility` sense; they'll still contain `+` characters in their labels) that would cause a segment name mismatch error, thereby preventing these from happening before we even make it to the `HGEdge` constructor.
* Closes #178
  Some code was added to print out the vertex name at which the mismatch occurred, and all waypoints colocated there... then commented out. If we ever really need to take a peek, it's there.
  Instead, these cases are now also flagged as a 2-edge flavored HIDDEN_JUNCTION. Plus, cases involving devel systems are detected too.
  That being the case, datacheck.log will show one colocated point, and it should be easy enough to find the others. So I chose to quiet down siteupdate.log during the edge compression process & not have it disrupted by a big block of text for something that now just amounts to a regular datacheck error.
* Closes #91
  Segment name mismatch errors will be a thing of the past altogether.
* Eagle-eyed observers may notice that we're now able to #589 altogether, but I stopped short of actually doing that.
  There are 2 paths I could go down here --  use it or lose it -- and I have yet to find out which is more optimal. So I'll go no-build on that for now and do some more research.