### PR TITLE
fix siteupdate.sh exiting: failure & errorcheck

### DIFF
--- a/siteupdate/siteupdate.sh
+++ b/siteupdate/siteupdate.sh
@@ -338,8 +338,15 @@ if [[ "$nmpmdir" != "" ]]; then
     nmpmflags="-n $indir/$nmpmdir"
 fi
 echo "$0: launching $siteupdate"
-$siteupdate $errorcheck -d $dbname-$datestr $graphflag -l $indir/$logdir -c $indir/$statdir -g $indir/$graphdir $nmpmflags -w $tmbasedir/$repo -u $tmbasedir/UserData/$listdir -x .$listext | tee -a $indir/$logdir/siteupdate.log 2>&1 || exit 1
-date
+$siteupdate $errorcheck -d $dbname-$datestr $graphflag -l $indir/$logdir -c $indir/$statdir -g $indir/$graphdir $nmpmflags -w $tmbasedir/$repo -u $tmbasedir/UserData/$listdir -x .$listext | tee -a $indir/$logdir/siteupdate.log 2>&1
+if [[ ${PIPESTATUS[0]} != 0 ]]; then
+    date
+    exit 1
+fi
+
+if [[ $errorcheck == "-e" ]]; then
+    exit 0
+fi
 
 echo "$0: appending rank table creation to SQL file"
 cat addrankstables.sql >> $dbname-$datestr.sql


### PR DESCRIPTION
Tested as `./datacheck.sh` on noreaster & `/fast/tm/datacheck` on BiggaTomato.

* Closes #575
  From the bash man page:
  ```
  The return status of a pipeline is the exit status of the last command,
  unless the pipefail option is enabled.  If pipefail is enabled, the
  pipeline's return status is the value of the last (rightmost) command
  to exit with a non-zero status, or zero if all commands exit
  successfully.
  ```
  [Checking the exit status of ANY command in a pipeline](https://www.shellscript.sh/examples/pipestatus/)
  This raises the question, how did the original localupdate.sh manage to run OK back in the Python days?
  *(...Or did it?)* Ping @jteresco!
  
  Moved the `date` command to only run when `siteupdate` fails, as in a successful run it's redundant with the *Finish* time 2 lines above.
* Rank table:
  This is what originally prompted this update. After `/fast/tm/datacheck` finishes up, we see
  ```
  /fast/tm/datacheck: appending rank table creation to SQL file
  cat: addrankstables.sql: No such file or directory
  ```
  Most of the time at least, being run from a directory where `addrankstables.sql` doesn't exist.
  Then `set -e` kicks in & datacheck terminates.
  We don't want this in errorcheck mode of course. There's not even a DB file to append it to. This can result in dozens of 0-byte .sql files littering contributors' home directories.
* Closes #574
  Adding in an [`exit 0`](https://www.google.com/maps/@31.9781155,-106.5825212,3a,15y,347.37h,91.73t/data=!3m10!1e1!3m8!1sNi0TNlZCsSfdttX85ke-8w!2e0!5s20220201T000000!7i16384!8i8192!9m2!1b1!2i50?coh=205409&entry=ttu&g_ep=EgoyMDI0MTAwOS4wIKXMDSoASAFQAw%3D%3D) omits:
  * `SKIPPING file copies and DB update`
  * `./datacheck.sh: SKIPPING nmpbyregion (no ../nmpfilter/nmpbyregion executable)`
    I [wondered](https://github.com/TravelMapping/DataProcessing/issues/574#issuecomment-1492069554) if this may be useful but [it doesn't seem too important](https://github.com/TravelMapping/DataProcessing/issues/574#issuecomment-1492201818).
  Looking at how it was included in the script, it appears it's expected to be run from a location where `../nmpfilter/nmpbyregion` does exist; more likely to be a production site update than a `/fast/tm/datacheck` being run from wherever. Rather than try to locate & run an executable *(Haha, there isn't even a /fast/tm/DataProcessing/nmpfilter/nmpbyregion)* for something of questionable importance, I just decided to say heck with it.