### PR TITLE
MULTI_REGION_OVERLAP tweaks

### DIFF
--- a/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
+++ b/siteupdate/cplusplus/classes/HighwaySegment/HighwaySegment.cpp
@@ -42,10 +42,12 @@ void HighwaySegment::add_concurrency(std::ofstream& concurrencyfile, Waypoint* w
 			concurrencyfile << '[' << x->str() << ']';
 		concurrencyfile << " (" << concurrent->size() << ")\n";
 	     }
-	HighwaySegment* s = concurrent->front();
-	if (s->route->region != other.route->region)
-		Datacheck::add( route, s->waypoint1->label, s->waypoint2->label,
+	if (route->region != other.route->region)
+	{	Datacheck::add( other.route, other.waypoint1->label, other.waypoint2->label,
+				"", "MULTI_REGION_OVERLAP", route->root );
+		Datacheck::add( route, waypoint1->label, waypoint2->label,
 				"", "MULTI_REGION_OVERLAP", other.route->root );
+	}
 	other.concurrent = concurrent;
 }
 


### PR DESCRIPTION
`this` is guaranteed to be `concurrent->front()`, so nix `s`.

Flag an error for the 2nd region in case it's maintained by another contributor.

This means instead of just
```
ar.ar043sil;E390;OK/AR;;MULTI_REGION_OVERLAP;ok.ok020
ar.ar043sil;OK20_W;E390;;MULTI_REGION_OVERLAP;ok.ok020
```
we get
```
ar.ar043sil;E390;OK/AR;;MULTI_REGION_OVERLAP;ok.ok020
ar.ar043sil;OK20_W;E390;;MULTI_REGION_OVERLAP;ok.ok020
ok.ok020;AR43_S;E0390;;MULTI_REGION_OVERLAP;ar.ar043sil
ok.ok020;E0390;OK/AR;;MULTI_REGION_OVERLAP;ar.ar043sil
```