### PR TITLE
errorcheck for 0 valid csv lines

### DIFF
--- a/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.cpp
+++ b/siteupdate/cplusplus/classes/ConnectedRoute/ConnectedRoute.cpp
@@ -9,7 +9,7 @@ ConnectedRoute::ConnectedRoute(std::string &line, HighwaySystem *sys, ErrorList 
 {	mileage = 0;
 	disconnected = 0;
 
-	// parse chopped routes csv line
+	// parse connected routes csv line
 	system = sys;
 	size_t NumFields = 5;
 	std::string sys_str, roots_str;


### PR DESCRIPTION
Came across this while using valgrind to troubleshoot something unrelated.

If there are 0 valid .csv lines, siteupdate goes on to allocate a block of 0 B for the `routes` and/or `con_routes` arrays.
Which is implementation-defined behavior. Wacky antics may ensue.

Sure, I *could* just skip the allocation, create a `HighwaySystem` object with 0 routes, and move on without complaining. But ISTM that's just bad juju. Seems that's just asking for a division by 0 error somewhere down the line. What if a 0-route system is in systems.csv as `active` or `preview`?

Making this an `ErrorList` item is The Right Thing To Do.

# Nota Bene:
This flags both inddl.csv & inddl_con.csv.
The quickest & easiest solution is to comment inddl out in systems.csv.