### PR TITLE
class destruction when aborting per error_list

### DIFF
--- a/siteupdate/cplusplus/Makefile
+++ b/siteupdate/cplusplus/Makefile
@@ -43,6 +43,7 @@ CommonObjects = \
   classes/Waypoint/Waypoint.o \
   classes/Waypoint/canonical_waypoint_name/canonical_waypoint_name.o \
   functions/crawl_rte_data.o \
+  functions/failure_cleanup.o \
   functions/rdstats.o \
   functions/route_and_label_logs.o \
   functions/tmstring.o

--- a/siteupdate/cplusplus/functions/failure_cleanup.cpp
+++ b/siteupdate/cplusplus/functions/failure_cleanup.cpp
@@ -1,0 +1,20 @@
+#include "../classes/Args/Args.h"
+#include "../classes/GraphGeneration/GraphListEntry.h"
+#include "../classes/GraphGeneration/PlaceRadius.h"
+#include "../classes/WaypointQuadtree/WaypointQuadtree.h"
+#include <vector>
+
+void failure_cleanup
+(	WaypointQuadtree& all_waypoints, std::vector<unsigned int>& colocate_counts,
+	std::list<std::string*>& updates, std::list<std::string*>& systemupdates
+)
+{	Args::colocationlimit = 0;			// silence colocation reports
+	all_waypoints.final_report(colocate_counts);	// destroy quadtree nodes & colocation lists
+	for (auto g = GraphListEntry::entries.begin(); g < GraphListEntry::entries.end(); g += 3)
+	{	delete g->regions;			// destroy
+		delete g->systems;			// GraphListEntry
+		delete g->placeradius;			// data
+	}
+	for (std::string* u : updates)		delete[] u; // destroy updates
+	for (std::string* u : systemupdates)	delete[] u; // & systemupdates
+}

--- a/siteupdate/cplusplus/tasks/final_stats.cpp
+++ b/siteupdate/cplusplus/tasks/final_stats.cpp
@@ -1,0 +1,31 @@
+cout << et.et() << "Processed " << HighwaySystem::syslist.size << " highway systems." << endl;
+unsigned int routes = 0;
+unsigned int points = 0;
+unsigned int segments = 0;
+for (HighwaySystem& h : HighwaySystem::syslist)
+{	routes += h.routes.size;
+	for (Route& r : h.routes)
+	{	points += r.points.size;
+		segments += r.segments.size;
+	}
+}
+cout << "Processed " << routes << " routes with a total of " << points << " points and " << segments << " segments." << endl;
+if (points != all_waypoints.size())
+  cout << "MISMATCH: all_waypoints contains " << all_waypoints.size() << " waypoints!" << endl;
+cout << et.et() << "WaypointQuadtree contains " << all_waypoints.total_nodes() << " total nodes." << endl;
+
+if (!Args::errorcheck)
+{	// compute colocation of waypoints stats
+        cout << et.et() << "Computing waypoint colocation stats";
+        if (Args::colocationlimit)
+		cout << ", reporting all with " << Args::colocationlimit << " or more colocations:" << endl;
+	else	cout << "." << endl;
+	all_waypoints.final_report(colocate_counts);
+	cout << "Waypoint colocation counts:" << endl;
+	unsigned int unique_locations = 0;
+	for (unsigned int c = 1; c < colocate_counts.size(); c++)
+	{	unique_locations += colocate_counts[c];
+		printf("%6i are each occupied by %2i waypoints.\n", colocate_counts[c], c);
+	}
+	cout << "Unique locations: " << unique_locations << endl;
+} else	all_waypoints.final_report(colocate_counts);

--- a/siteupdate/cplusplus/tasks/read_updates.cpp
+++ b/siteupdate/cplusplus/tasks/read_updates.cpp
@@ -13,6 +13,7 @@ while (getline(file, line))
 	size_t NumFields = 5;
 	string* fields = new string[5];
 			 // deleted as DB table is written
+			 // or when aborting due to ErrorList errors
 	string* ptr_array[5] = {&fields[0], &fields[1], &fields[2], &fields[3], &fields[4]};
 	split(line, ptr_array, NumFields, ';');
 	if (NumFields != 5)
@@ -75,6 +76,7 @@ while (getline(file, line))
 	size_t NumFields = 5;
 	string* fields = new string[5];
 			 // deleted as DB table is written
+			 // or when aborting due to ErrorList errors
 	string* ptr_array[5] = {&fields[0], &fields[1], &fields[2], &fields[3], &fields[4]};
 	split(line, ptr_array, NumFields, ';');
 	if (NumFields != 5)

--- a/siteupdate/cplusplus/tasks/subgraphs/area.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/area.cpp
@@ -33,6 +33,7 @@ while (getline(file, line))
 	if (*endptr || r <= 0) {el.add_error("invalid radius in areagraphs.csv line: " + line); r=1;}
 	PlaceRadius *a = new PlaceRadius(fields[0], fields[1], lat, lng, r);
 			 // deleted @ end of HighwayGraph::write_subgraphs_tmg
+			 // or when aborting due to ErrorList errors
 	GraphListEntry::add_group(
 		string(fields[1]) + fields[4] + "-area",
 		string(fields[0]) + " (" + fields[4] + " mi radius)",

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -2,6 +2,7 @@
 for (auto c = Region::continents.data(), dummy = c+Region::continents.size()-1; c < dummy; c++)
 {	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		  // or when aborting due to ErrorList errors
 	for (Region& r : Region::allregions)
 	  // does it match this continent and have routes?
 	  if (c == r.continent && r.active_preview_mileage)

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -2,6 +2,7 @@
 for (auto c = Region::countries.data(), dummy = c+Region::countries.size()-1; c < dummy; c++)
 {	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		  // or when aborting due to ErrorList errors
 	for (Region& r : Region::allregions)
 	  // does it match this country and have routes?
 	  if (c == r.country && r.active_preview_mileage)

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -35,7 +35,7 @@ if (file.is_open())
 			double r = strtod(radius.data(), &endptr);
 			if (*endptr || r <= 0)	{el.add_error("invalid radius in fullcustom.csv line: " + line); ok = 0;}
 			a = new PlaceRadius(descr.data(), root.data(), lat, lng, r);
-		}	    // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		}	    // deleted @ end of HighwayGraph::write_subgraphs_tmg or when aborting due to ErrorList errors
 		else if (blanks != 3)
 		{	el.add_error("lat/lng/radius error in fullcustom.csv line: [" + line
 				   + "], either all or none must be populated");
@@ -51,6 +51,7 @@ if (file.is_open())
 		if (regionlist.empty()) regions = 0;
 		else {	regions = new vector<Region*>;
 				  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+				  // or when aborting due to ErrorList errors
 			char* field = new char[regionlist.size()+1];
 				      // deleted once region tokens are processed
 			strcpy(field, regionlist.data());
@@ -68,6 +69,7 @@ if (file.is_open())
 		if (systemlist.empty()) systems = 0;
 		else {	systems = new vector<HighwaySystem*>;
 				  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+				  // or when aborting due to ErrorList errors
 			char* field = new char[systemlist.size()+1];
 				      // deleted once system tokens are processed
 			strcpy(field, systemlist.data());

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -23,6 +23,7 @@ while (getline(file, line))
 		     + " bytes in multiregion.csv line: " + line);
 	regions = new vector<Region*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		  // or when aborting due to ErrorList errors
 	for(char* rg = strtok(fields[2], ","); rg; rg = strtok(0, ","))
 	  try {	regions->push_back(Region::code_hash.at(rg));
 	      }

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -23,6 +23,7 @@ while (getline(file, line))
 		     + " bytes in multisystem.csv line: " + line);
 	systems = new vector<HighwaySystem*>;
 		  // deleted @ end of HighwayGraph::write_subgraphs_tmg
+		  // or when aborting due to ErrorList errors
 	for(char* s = strtok(fields[2], ","); s; s = strtok(0, ","))
 	  try {	HighwaySystem* const h = HighwaySystem::sysname_hash.at(s);
 		if (h->active_or_preview())

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -6,5 +6,5 @@ for (Region& region : Region::allregions)
 		region.name + " (" + region.type + ")", 'r',
 		new vector<Region*>(1, &region), nullptr, nullptr);
 		// deleted @ end of HighwayGraph::write_subgraphs_tmg
-}
+}		// or when aborting due to ErrorList errors
 graph_types.push_back({"region", "Routes Within a Single Region", "These graphs contain all routes currently plotted within the given region."});

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -10,6 +10,7 @@ while (getline(file, line))
 		h->systemname + " (" + h->fullname + ")",
 		's', nullptr, new vector<HighwaySystem*>(1, h), nullptr);
 			      // deleted @ end of HighwayGraph::write_subgraphs_tmg
+			      // or when aborting due to ErrorList errors
 	    h->is_subgraph_system = 1;
 	} else el.add_error("devel system "+h->systemname+" in systemgraphs.csv");
       }

--- a/siteupdate/cplusplus/tasks/threaded/ReadList.cpp
+++ b/siteupdate/cplusplus/tasks/threaded/ReadList.cpp
@@ -8,7 +8,8 @@
 		// placement new
       #endif
 	if (TravelerList::file_not_found)
-	  {	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure " << Args::userlistext << " files for all specified users exist.\nAborting." << endl;
+	{	cout << "\nCheck for typos in your -U or --userlist arguments, and make sure " << Args::userlistext << " files for all specified users exist.\nAborting." << endl;
+		failure_cleanup(all_waypoints, colocate_counts, updates, systemupdates);
 		return 1;
 	}
 	TravelerList::ids.clear();


### PR DESCRIPTION
Plugs up some memory leaks.
Not the biggest deal if siteupdate is about to terminate anyway, but best practice IMO.
When using valgrind to debug, unrelated memory errors hurting the signal-to-noise ratio are a Bad Thing.