### PR TITLE
error check for duplicate graph names

### DIFF
--- a/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
+++ b/siteupdate/cplusplus/classes/GraphGeneration/GraphListEntry.h
@@ -1,7 +1,9 @@
+class ErrorList;
 class HighwaySystem;
 class PlaceRadius;
 class Region;
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class GraphListEntry
@@ -26,8 +28,9 @@ class GraphListEntry
 
 	static std::vector<GraphListEntry> entries;
 	static size_t num; // iterator for entries
-	std::string tag();
+	static std::unordered_map<std::string, GraphListEntry*> unique_names;
 
 	GraphListEntry(std::string, std::string, char, char, std::vector<Region*>*, std::vector<HighwaySystem*>*, PlaceRadius*);
-	static void add_group(std::string&&,  std::string&&,  char, std::vector<Region*>*, std::vector<HighwaySystem*>*, PlaceRadius*);
+	static void add_group(std::string&&,  std::string&&,  char, std::vector<Region*>*, std::vector<HighwaySystem*>*, PlaceRadius*, ErrorList&);
+	std::string tag();
 };

--- a/siteupdate/cplusplus/tasks/graph_setup.cpp
+++ b/siteupdate/cplusplus/tasks/graph_setup.cpp
@@ -3,7 +3,7 @@ vector<HighwaySystem*> *systems;
 list<array<string,3>> graph_types; // create list of graph information for the DB
 graph_types.push_back({"master", "All Travel Mapping Data",
 			"These graphs contain all routes currently plotted in the Travel Mapping project."});
-GraphListEntry::add_group("tm-master", "All Travel Mapping Data", 'M', nullptr, nullptr, nullptr);
+GraphListEntry::add_group("tm-master", "All Travel Mapping Data", 'M', nullptr, nullptr, nullptr, el);
 #include "subgraphs/continent.cpp"
 #include "subgraphs/multisystem.cpp"
 #include "subgraphs/system.cpp"

--- a/siteupdate/cplusplus/tasks/subgraphs/area.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/area.cpp
@@ -36,7 +36,7 @@ while (getline(file, line))
 	GraphListEntry::add_group(
 		string(fields[1]) + fields[4] + "-area",
 		string(fields[0]) + " (" + fields[4] + " mi radius)",
-		'a', nullptr, nullptr, a);
+		'a', nullptr, nullptr, a, el);
 	delete[] cline;
 }
 file.close();

--- a/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/continent.cpp
@@ -11,7 +11,7 @@ for (auto c = Region::continents.data(), dummy = c+Region::continents.size()-1; 
 	else {	GraphListEntry::add_group(
 			c->first + "-continent",
 			c->second + " All Routes on Continent",
-			'C', regions, nullptr, nullptr);
+			'C', regions, nullptr, nullptr, el);
 	     }
 }
 graph_types.push_back({"continent", "Routes Within a Continent", "These graphs contain the routes on a continent."});

--- a/siteupdate/cplusplus/tasks/subgraphs/country.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/country.cpp
@@ -11,7 +11,7 @@ for (auto c = Region::countries.data(), dummy = c+Region::countries.size()-1; c 
 	else {	GraphListEntry::add_group(
 			c->first + "-country",
 			c->second + " All Routes in Country",
-			'c', regions, nullptr, nullptr);
+			'c', regions, nullptr, nullptr, el);
 	     }
 }
 graph_types.push_back({"country", "Routes Within a Single Multi-Region Country",

--- a/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/fullcustom.cpp
@@ -84,7 +84,7 @@ if (file.is_open())
 			      }
 			delete[] field;
 		     }
-		if (ok)	GraphListEntry::add_group(std::move(root), std::move(descr), 'f', regions, systems, a);
+		if (ok)	GraphListEntry::add_group(std::move(root), std::move(descr), 'f', regions, systems, a, el);
 		else {	delete regions;
 			delete systems;
 			delete a;

--- a/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multiregion.cpp
@@ -29,7 +29,7 @@ while (getline(file, line))
 	  catch (const out_of_range&)
 	      {	el.add_error("unrecognized region code "+string(rg)+" in multiregion.csv line: "+line);
 	      }
-	if (regions->size()) GraphListEntry::add_group(fields[1], fields[0], 'R', regions, nullptr, nullptr);
+	if (regions->size()) GraphListEntry::add_group(fields[1], fields[0], 'R', regions, nullptr, nullptr, el);
 	else delete regions;
 	delete[] cline;
 }

--- a/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/multisystem.cpp
@@ -33,7 +33,7 @@ while (getline(file, line))
 	  catch (const std::out_of_range&)
 	      {	el.add_error("unrecognized system code "+string(s)+" in multisystem.csv line: "+line);
 	      }
-	if (systems->size()) GraphListEntry::add_group(fields[1], fields[0], 'S', nullptr, systems, nullptr);
+	if (systems->size()) GraphListEntry::add_group(fields[1], fields[0], 'S', nullptr, systems, nullptr, el);
 	else delete systems;
 	delete[] cline;
 }

--- a/siteupdate/cplusplus/tasks/subgraphs/region.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/region.cpp
@@ -4,7 +4,7 @@ for (Region& region : Region::allregions)
 	GraphListEntry::add_group(
 		region.code + "-region",
 		region.name + " (" + region.type + ")", 'r',
-		new vector<Region*>(1, &region), nullptr, nullptr);
+		new vector<Region*>(1, &region), nullptr, nullptr, el);
 		// deleted @ end of HighwayGraph::write_subgraphs_tmg
 }
 graph_types.push_back({"region", "Routes Within a Single Region", "These graphs contain all routes currently plotted within the given region."});

--- a/siteupdate/cplusplus/tasks/subgraphs/system.cpp
+++ b/siteupdate/cplusplus/tasks/subgraphs/system.cpp
@@ -8,7 +8,7 @@ while (getline(file, line))
 	{   GraphListEntry::add_group(
 		h->systemname + "-system",
 		h->systemname + " (" + h->fullname + ")",
-		's', nullptr, new vector<HighwaySystem*>(1, h), nullptr);
+		's', nullptr, new vector<HighwaySystem*>(1, h), nullptr, el);
 			      // deleted @ end of HighwayGraph::write_subgraphs_tmg
 	    h->is_subgraph_system = 1;
 	} else el.add_error("devel system "+h->systemname+" in systemgraphs.csv");


### PR DESCRIPTION
```
[17.7] ABORTING due to 1 errors:
1: Duplicate graph name Tourist in multisystem graphs
```
If a graph name is duplicated,
* single-threaded graph generation overwrites the 1st graph with the 2nd. The 1st has a DB entry, but no file.
* multithreaded graph generation attempts to write both graphs to the same file simultaneously, resulting in a corrupted file.

This prevents that from happening.
Ping @si404